### PR TITLE
Persist new consumer state only when created

### DIFF
--- a/metro2 (copy 1)/crm/state.js
+++ b/metro2 (copy 1)/crm/state.js
@@ -30,7 +30,15 @@ function ensureConsumer(st, consumerId) {
 // ---- Public API ----
 export function listConsumerState(consumerId) {
   const st = loadState();
-  return ensureConsumer(st, consumerId);
+  if (!Object.prototype.hasOwnProperty.call(st.consumers, consumerId)) {
+    // Persist the newly created consumer so other processes can observe it
+    // immediately. Without this, a restart after the first read would lose the
+    // empty structure until an event or file was added.
+    const c = ensureConsumer(st, consumerId);
+    saveState(st);
+    return c;
+  }
+  return st.consumers[consumerId];
 }
 
 export function addEvent(consumerId, type, payload = {}) {


### PR DESCRIPTION
## Summary
- save a new consumer record to disk only when the consumer is first accessed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa56cae0d08323bcaf0411f22e1209