### PR TITLE
docs: correct letterEngine file comment

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -1,4 +1,4 @@
-// public/letterEngine.js
+// letterEngine.js
 
 const BUREAU_ADDR = {
   TransUnion: {


### PR DESCRIPTION
## Summary
- fix outdated path comment in letter engine module

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")

------
https://chatgpt.com/codex/tasks/task_e_68aa59e0d8b083239cdf3a0ce47713b8