### PR TITLE
feat: add credit audit report generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 metro2 (copy 1)/crm/node_modules/
+metro2 (copy 1)/crm/public/reports/

--- a/metro2 (copy 1)/crm/creditAuditTool.js
+++ b/metro2 (copy 1)/crm/creditAuditTool.js
@@ -1,0 +1,136 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import puppeteer from 'puppeteer';
+
+// ----- Data Source -----
+// Simulate pulling credit-report JSON from internal API/scrape
+export async function fetchCreditReport(){
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const reportPath = path.join(__dirname, 'data', 'report.json');
+  const raw = await fs.readFile(reportPath, 'utf-8');
+  return JSON.parse(raw);
+}
+
+// Normalize report into array of accounts with balances/statuses/issues
+export function normalizeReport(raw){
+  const accounts = raw.tradelines.map(tl => {
+    const bureauData = {};
+    for(const [bureau, data] of Object.entries(tl.per_bureau)){
+      bureauData[bureau] = {
+        balance: data.balance,
+        status: data.account_status || data.payment_status,
+        past_due: data.past_due,
+        dispute_reason: data.comments || ''
+      };
+    }
+    return {
+      creditor: tl.meta.creditor,
+      bureaus: bureauData,
+      issues: tl.violations.map(v => ({ title: v.title, detail: v.detail }))
+    };
+  });
+  return { generatedAt: new Date().toISOString(), accounts };
+}
+
+// ----- Consumer friendly translations -----
+const STATUS_MAP = {
+  'Collection/Chargeoff': 'Past due and sent to collections',
+  'Charge-off': 'Past due, more than 120 days',
+  'Derogatory': 'Negative status',
+  'Pays as agreed': 'Pays as agreed',
+  'Open': 'Open and active',
+  'Closed': 'Closed'
+};
+
+function friendlyStatus(status){
+  return STATUS_MAP[status] || status;
+}
+
+function recommendAction(issueTitle){
+  return `Consider disputing "${issueTitle}" with the credit bureau or contacting the creditor for correction.`;
+}
+
+// Build HTML report with plain language and recommendations
+export function renderHtml(report){
+  const rows = report.accounts.map(acc => {
+    const bureauRows = Object.entries(acc.bureaus).map(([b, info]) => `
+      <tr>
+        <td>${b}</td>
+        <td>${info.balance ?? ''}</td>
+        <td>${friendlyStatus(info.status || '')}</td>
+      </tr>`).join('\n');
+    const issues = acc.issues.map(i => `<li><strong>${i.title}:</strong> ${i.detail}<br/>Action: ${recommendAction(i.title)}</li>`).join('');
+    return `
+      <h2>${acc.creditor}</h2>
+      <table border="1" cellspacing="0" cellpadding="4">
+        <thead><tr><th>Bureau</th><th>Balance</th><th>Status</th></tr></thead>
+        <tbody>${bureauRows}</tbody>
+      </table>
+      ${issues ? `<p>Issues:</p><ul>${issues}</ul>` : '<p>No issues found.</p>'}
+    `;
+  }).join('\n');
+  const dateStr = new Date(report.generatedAt).toLocaleString();
+  return `<!DOCTYPE html>
+  <html><head><meta charset="utf-8"/><style>
+  body{font-family:Arial, sans-serif;margin:20px;}
+  h1{text-align:center;}
+  table{width:100%;margin-top:10px;border-collapse:collapse;}
+  th,td{border:1px solid #ccc;}
+  footer{margin-top:40px;font-size:0.8em;color:#555;}
+  </style></head>
+  <body>
+  <h1>Credit Audit Report</h1>
+  <p>Generated: ${dateStr}</p>
+  ${rows}
+  <footer>
+    <hr/>
+    <p>This report is for informational purposes only and is not legal advice.</p>
+  </footer>
+  </body></html>`;
+}
+
+// Save HTML as PDF under public/reports and return shareable link
+export async function savePdf(html){
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const outDir = path.join(__dirname, 'public', 'reports');
+  await fs.mkdir(outDir, { recursive: true });
+  const filename = `audit-${Date.now()}.pdf`;
+  const outPath = path.join(outDir, filename);
+
+  try{
+    const execPath = await detectChromium();
+    const browser = await puppeteer.launch({
+      headless:true,
+      args:["--no-sandbox","--disable-setuid-sandbox","--disable-dev-shm-usage"],
+      executablePath: execPath || undefined
+    });
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'load' });
+    await page.pdf({ path: outPath, format:'Letter', printBackground:true, margin:{top:'1in',bottom:'1in',left:'1in',right:'1in'} });
+    await browser.close();
+    return { path: outPath, url: `/reports/${filename}` };
+  }catch(err){
+    const htmlPath = outPath.replace(/\.pdf$/, '.html');
+    await fs.writeFile(htmlPath, html, 'utf-8');
+    return { path: htmlPath, url: `/reports/${path.basename(htmlPath)}`, warning: err.message };
+  }
+}
+
+async function detectChromium(){
+  if(process.env.PUPPETEER_EXECUTABLE_PATH) return process.env.PUPPETEER_EXECUTABLE_PATH;
+  for(const p of ['/usr/bin/chromium','/usr/bin/chromium-browser','/snap/bin/chromium','/usr/bin/google-chrome','/usr/bin/google-chrome-stable']){
+    try{ await fs.access(p); return p; }catch{}
+  }
+  return null;
+}
+
+// CLI usage
+if(fileURLToPath(import.meta.url) === path.resolve(process.argv[1])){
+  const raw = await fetchCreditReport();
+  const normalized = normalizeReport(raw);
+  const html = renderHtml(normalized);
+  const result = await savePdf(html);
+  console.log('PDF saved to', result.path);
+  console.log('Shareable link (when served):', result.url);
+}

--- a/metro2 (copy 1)/crm/package.json
+++ b/metro2 (copy 1)/crm/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "node server.js"
+    "dev": "node server.js",
+    "audit": "node creditAuditTool.js"
   },
   "dependencies": {
     "cheerio": "^1.1.2",


### PR DESCRIPTION
## Summary
- add credit audit tool that normalizes report data and creates consumer friendly explanations
- generate shareable audit report and expose via `npm run audit`

## Testing
- `npm run audit`

------
https://chatgpt.com/codex/tasks/task_e_68aa5edbc4bc8323b78e758e4e7cc861