### PR TITLE
feat: add color theme selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+metro2 (copy 1)/crm/node_modules/

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <title>Metro 2 CRM</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="theme-color" content="#007AFF" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     :root{
@@ -12,6 +13,8 @@
       --muted:#6b7280;
       --green:#22c55e;
       --green-bg:rgba(34,197,94,.12);
+      --accent:#007AFF;
+      --accent-bg:rgba(0,122,255,.12);
     }
     body{
       background:
@@ -25,16 +28,18 @@
     .glass{ background:var(--glass-bg); border:1px solid var(--glass-brd); border-radius:18px; backdrop-filter:blur(12px); box-shadow:0 8px 24px rgba(0,0,0,.1) }
     .card{ border-radius:18px; padding:16px }
     .chip{ border:1px solid var(--glass-brd); padding:4px 10px; border-radius:999px; font-size:12px; background:rgba(255,255,255,.7); cursor:pointer; user-select:none }
-    .chip.active{ background:#ecfeff; border-color:#67e8f9 }
+    .chip.active{ background:var(--accent-bg); border-color:var(--accent) }
     .muted{ color:var(--muted) }
-    .btn{ border:1px solid var(--glass-brd); border-radius:10px; padding:6px 12px; background:white/80; position:relative; }
+    .btn{ border:1px solid var(--accent); border-radius:10px; padding:6px 12px; background:white/80; position:relative; }
     .btn:hover{ background:#f9fafb }
-    .tl-card{ transition:transform .2s ease, box-shadow .15s ease, background .15s ease; cursor:pointer }
+    .tl-card{ transition:transform .2s ease, box-shadow .15s ease, background .15s ease; }
     .tl-card:hover{ transform: translateY(-1px) scale(1.01) }
     .tl-card.selected{ box-shadow:0 0 0 2px var(--green) inset; background:var(--green-bg) }
     .wrap-anywhere{ overflow-wrap:anywhere; word-break:break-word }
     .hidden{ display:none }
     .focus-ring{ outline: 2px dashed #6366f1; outline-offset: 4px; }
+
+    .color-bubble{ width:32px; height:32px; border-radius:9999px; cursor:pointer; border:2px solid white; box-shadow:0 0 0 2px rgba(0,0,0,.1); }
 
     /* Modes */
     .tl-card.mode-identity{ box-shadow:0 0 0 2px #d4af37 inset, 0 8px 24px rgba(0,0,0,.1); background: rgba(212,175,55,.12); }
@@ -65,6 +70,16 @@
   </style>
 </head>
 <body>
+<div id="colorPanel" class="fixed right-4 top-1/2 -translate-y-1/2 flex flex-col items-center gap-2">
+  <button id="colorToggle" class="color-bubble flex items-center justify-center text-white text-sm" style="background:var(--accent)">×</button>
+  <div id="colorBubbles" class="flex flex-col gap-2">
+    <button class="color-bubble" data-color="#007AFF" style="background:#007AFF"></button>
+    <button class="color-bubble" data-color="#34C759" style="background:#34C759"></button>
+    <button class="color-bubble" data-color="#FF9500" style="background:#FF9500"></button>
+    <button class="color-bubble" data-color="#FF3B30" style="background:#FF3B30"></button>
+    <button class="color-bubble" data-color="#AF52DE" style="background:#AF52DE"></button>
+  </div>
+</div>
 <header class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -254,11 +254,15 @@ function renderTradelines(tradelines){
       renderTradelines(tradelines);
     });
 
-    // OPEN ZOOM on click (outside controls)
-    card.addEventListener("click",(e)=>{
-      if (e.target.closest("input,label,button,a")) return; // ignore controls
-      openZoomModal(tl, idx);
-    });
+    // Open zoom only when clicking creditor name
+    const nameEl = node.querySelector(".tl-creditor");
+    if (nameEl) {
+      nameEl.classList.add("cursor-pointer");
+      nameEl.addEventListener("click", (e) => {
+        e.stopPropagation();
+        openZoomModal(tl, idx);
+      });
+    }
 
     // keep selected class synced when user flips any checkbox
     card.querySelectorAll('input.bureau').forEach(cb=>{
@@ -670,3 +674,28 @@ $("#helpModal").addEventListener("click", (e)=>{ if(e.target.id==="helpModal"){ 
 
 // ===================== Init =====================
 loadConsumers();
+
+// ----- Color theme selector -----
+function hexToRgba(hex, alpha){
+  const h = hex.replace('#','');
+  const r = parseInt(h.substring(0,2),16);
+  const g = parseInt(h.substring(2,4),16);
+  const b = parseInt(h.substring(4,6),16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+const colorToggle = $("#colorToggle");
+const colorBubbles = $("#colorBubbles");
+const metaTheme = document.querySelector('meta[name="theme-color"]');
+colorToggle?.addEventListener("click", ()=>{
+  colorBubbles.classList.toggle("hidden");
+  colorToggle.textContent = colorBubbles.classList.contains("hidden") ? "🎨" : "×";
+});
+document.querySelectorAll(".color-bubble[data-color]").forEach(b=>{
+  b.addEventListener("click", ()=>{
+    const color = b.dataset.color;
+    document.documentElement.style.setProperty("--accent", color);
+    document.documentElement.style.setProperty("--accent-bg", hexToRgba(color,0.12));
+    if(colorToggle) colorToggle.style.background = color;
+    metaTheme?.setAttribute('content', color);
+  });
+});


### PR DESCRIPTION
## Summary
- add theme-color meta tag and sync it with selected accent color
- open tradeline detail modal only when clicking creditor name

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b45fa248323b5a41068ad17b9e3