### PR TITLE
Add audit button with backend endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 metro2 (copy 1)/crm/node_modules/
+metro2 (copy 1)/crm/public/reports/

--- a/metro2 (copy 1)/crm/creditAuditTool.js
+++ b/metro2 (copy 1)/crm/creditAuditTool.js
@@ -1,0 +1,136 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import puppeteer from 'puppeteer';
+
+// ----- Data Source -----
+// Simulate pulling credit-report JSON from internal API/scrape
+export async function fetchCreditReport(){
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const reportPath = path.join(__dirname, 'data', 'report.json');
+  const raw = await fs.readFile(reportPath, 'utf-8');
+  return JSON.parse(raw);
+}
+
+// Normalize report into array of accounts with balances/statuses/issues
+export function normalizeReport(raw){
+  const accounts = raw.tradelines.map(tl => {
+    const bureauData = {};
+    for(const [bureau, data] of Object.entries(tl.per_bureau)){
+      bureauData[bureau] = {
+        balance: data.balance,
+        status: data.account_status || data.payment_status,
+        past_due: data.past_due,
+        dispute_reason: data.comments || ''
+      };
+    }
+    return {
+      creditor: tl.meta.creditor,
+      bureaus: bureauData,
+      issues: tl.violations.map(v => ({ title: v.title, detail: v.detail }))
+    };
+  });
+  return { generatedAt: new Date().toISOString(), accounts };
+}
+
+// ----- Consumer friendly translations -----
+const STATUS_MAP = {
+  'Collection/Chargeoff': 'Past due and sent to collections',
+  'Charge-off': 'Past due, more than 120 days',
+  'Derogatory': 'Negative status',
+  'Pays as agreed': 'Pays as agreed',
+  'Open': 'Open and active',
+  'Closed': 'Closed'
+};
+
+function friendlyStatus(status){
+  return STATUS_MAP[status] || status;
+}
+
+function recommendAction(issueTitle){
+  return `Consider disputing "${issueTitle}" with the credit bureau or contacting the creditor for correction.`;
+}
+
+// Build HTML report with plain language and recommendations
+export function renderHtml(report){
+  const rows = report.accounts.map(acc => {
+    const bureauRows = Object.entries(acc.bureaus).map(([b, info]) => `
+      <tr>
+        <td>${b}</td>
+        <td>${info.balance ?? ''}</td>
+        <td>${friendlyStatus(info.status || '')}</td>
+      </tr>`).join('\n');
+    const issues = acc.issues.map(i => `<li><strong>${i.title}:</strong> ${i.detail}<br/>Action: ${recommendAction(i.title)}</li>`).join('');
+    return `
+      <h2>${acc.creditor}</h2>
+      <table border="1" cellspacing="0" cellpadding="4">
+        <thead><tr><th>Bureau</th><th>Balance</th><th>Status</th></tr></thead>
+        <tbody>${bureauRows}</tbody>
+      </table>
+      ${issues ? `<p>Issues:</p><ul>${issues}</ul>` : '<p>No issues found.</p>'}
+    `;
+  }).join('\n');
+  const dateStr = new Date(report.generatedAt).toLocaleString();
+  return `<!DOCTYPE html>
+  <html><head><meta charset="utf-8"/><style>
+  body{font-family:Arial, sans-serif;margin:20px;}
+  h1{text-align:center;}
+  table{width:100%;margin-top:10px;border-collapse:collapse;}
+  th,td{border:1px solid #ccc;}
+  footer{margin-top:40px;font-size:0.8em;color:#555;}
+  </style></head>
+  <body>
+  <h1>Credit Audit Report</h1>
+  <p>Generated: ${dateStr}</p>
+  ${rows}
+  <footer>
+    <hr/>
+    <p>This report is for informational purposes only and is not legal advice.</p>
+  </footer>
+  </body></html>`;
+}
+
+// Save HTML as PDF under public/reports and return shareable link
+export async function savePdf(html){
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const outDir = path.join(__dirname, 'public', 'reports');
+  await fs.mkdir(outDir, { recursive: true });
+  const filename = `audit-${Date.now()}.pdf`;
+  const outPath = path.join(outDir, filename);
+
+  try{
+    const execPath = await detectChromium();
+    const browser = await puppeteer.launch({
+      headless:true,
+      args:["--no-sandbox","--disable-setuid-sandbox","--disable-dev-shm-usage"],
+      executablePath: execPath || undefined
+    });
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'load' });
+    await page.pdf({ path: outPath, format:'Letter', printBackground:true, margin:{top:'1in',bottom:'1in',left:'1in',right:'1in'} });
+    await browser.close();
+    return { path: outPath, url: `/reports/${filename}` };
+  }catch(err){
+    const htmlPath = outPath.replace(/\.pdf$/, '.html');
+    await fs.writeFile(htmlPath, html, 'utf-8');
+    return { path: htmlPath, url: `/reports/${path.basename(htmlPath)}`, warning: err.message };
+  }
+}
+
+async function detectChromium(){
+  if(process.env.PUPPETEER_EXECUTABLE_PATH) return process.env.PUPPETEER_EXECUTABLE_PATH;
+  for(const p of ['/usr/bin/chromium','/usr/bin/chromium-browser','/snap/bin/chromium','/usr/bin/google-chrome','/usr/bin/google-chrome-stable']){
+    try{ await fs.access(p); return p; }catch{}
+  }
+  return null;
+}
+
+// CLI usage
+if(fileURLToPath(import.meta.url) === path.resolve(process.argv[1])){
+  const raw = await fetchCreditReport();
+  const normalized = normalizeReport(raw);
+  const html = renderHtml(normalized);
+  const result = await savePdf(html);
+  console.log('PDF saved to', result.path);
+  console.log('Shareable link (when served):', result.url);
+}

--- a/metro2 (copy 1)/crm/package.json
+++ b/metro2 (copy 1)/crm/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "node server.js"
+    "dev": "node server.js",
+    "audit": "node creditAuditTool.js"
   },
   "dependencies": {
     "cheerio": "^1.1.2",

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -128,6 +128,7 @@
             <div class="text-sm muted">Report: <select id="reportPicker" class="border rounded px-2 py-1 text-sm"></select></div>
           </div>
           <div class="flex gap-2">
+            <button id="btnAuditReport" class="btn" data-tip="Run audit on current report">Audit</button>
             <button id="btnDeleteReport" class="btn" data-tip="Delete current report (click)">Delete Report</button>
           </div>
         </div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -475,6 +475,26 @@ $("#fileInput").addEventListener("change", async (e)=>{
   }
 });
 
+// Audit report
+$("#btnAuditReport").addEventListener("click", async ()=>{
+  if(!currentConsumerId || !currentReportId) return showErr("Select a report first.");
+  const btn = $("#btnAuditReport");
+  const old = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = "Auditing...";
+  try{
+    const res = await api(`/api/consumers/${currentConsumerId}/report/${currentReportId}/audit`, { method:"POST" });
+    if(!res?.ok) return showErr(res?.error || "Failed to run audit.");
+    if(res.url) window.open(res.url, "_blank");
+    if(res.warning) showErr(res.warning);
+  }catch(err){
+    showErr(String(err));
+  }finally{
+    btn.textContent = old;
+    btn.disabled = false;
+  }
+});
+
 // Delete report
 $("#btnDeleteReport").addEventListener("click", async ()=>{
   if(!currentConsumerId || !currentReportId) return showErr("Select a report first.");

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -10,6 +10,7 @@ import puppeteer from "puppeteer";
 import crypto from "crypto";
 import os from "os";
 import { generateLetters } from "./letterEngine.js";
+import { normalizeReport, renderHtml, savePdf } from "./creditAuditTool.js";
 import {
   listConsumerState,
   addEvent,
@@ -180,6 +181,23 @@ app.delete("/api/consumers/:id/report/:rid", (req,res)=>{
   saveDB(db);
   addEvent(c.id, "report_deleted", { reportId: removed?.id, filename: removed?.filename });
   res.json({ ok:true });
+});
+
+app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
+  const db=loadDB();
+  const c=db.consumers.find(x=>x.id===req.params.id);
+  if(!c) return res.status(404).json({ ok:false, error:"Consumer not found" });
+  const r=c.reports.find(x=>x.id===req.params.rid);
+  if(!r) return res.status(404).json({ ok:false, error:"Report not found" });
+  try{
+    const normalized = normalizeReport(r.data);
+    const html = renderHtml(normalized);
+    const result = await savePdf(html);
+    addEvent(c.id, "audit_generated", { reportId: r.id, file: result.path });
+    res.json({ ok:true, url: result.url, warning: result.warning });
+  }catch(e){
+    res.status(500).json({ ok:false, error: String(e) });
+  }
 });
 
 // =================== Letters & PDFs ===================


### PR DESCRIPTION
## Summary
- Add Audit button next to Delete Report in UI to trigger report auditing
- Implement frontend handler opening generated audit report
- Create backend endpoint leveraging existing audit utilities to produce downloadable report

## Testing
- ⚠️ `npm test` (missing script: "test")
- ✅ `npm run audit`

------
https://chatgpt.com/codex/tasks/task_e_68aa5edbc4bc8323b78e758e4e7cc861