### PR TITLE
Add glassmorphic cards and personalize audit reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/node_modules/
+**/public/reports/

--- a/metro2 (copy 1)/crm/creditAuditTool.js
+++ b/metro2 (copy 1)/crm/creditAuditTool.js
@@ -52,15 +52,18 @@ function recommendAction(issueTitle){
 }
 
 // Build HTML report with plain language and recommendations
-export function renderHtml(report){
+export function renderHtml(report, consumerName = "Consumer"){
   const rows = report.accounts.map(acc => {
-    const bureauRows = Object.entries(acc.bureaus).map(([b, info]) => `
-      <tr>
+    const bureauRows = Object.entries(acc.bureaus).map(([b, info]) => {
+      const statusText = friendlyStatus(info.status || '');
+      const neg = statusText !== 'Open and active' && statusText !== 'Pays as agreed';
+      return `
+      <tr${neg ? ' class="neg"' : ''}>
         <td>${b}</td>
         <td>${info.balance ?? ''}</td>
-        <td>${friendlyStatus(info.status || '')}</td>
-      </tr>`).join('\n');
-    const issues = acc.issues.map(i => `<li><strong>${i.title}:</strong> ${i.detail}<br/>Action: ${recommendAction(i.title)}</li>`).join('');
+        <td>${statusText}</td>
+      </tr>`;}).join('\n');
+    const issues = acc.issues.map(i => `<li class="neg"><strong>${i.title}:</strong> ${i.detail}<br/>Action: ${recommendAction(i.title)}</li>`).join('');
     return `
       <h2>${acc.creditor}</h2>
       <table border="1" cellspacing="0" cellpadding="4">
@@ -77,10 +80,11 @@ export function renderHtml(report){
   h1{text-align:center;}
   table{width:100%;margin-top:10px;border-collapse:collapse;}
   th,td{border:1px solid #ccc;}
+  .neg{color:#b91c1c;}
   footer{margin-top:40px;font-size:0.8em;color:#555;}
   </style></head>
   <body>
-  <h1>Credit Audit Report</h1>
+  <h1>Credit Audit Report for ${consumerName}</h1>
   <p>Generated: ${dateStr}</p>
   ${rows}
   <footer>

--- a/metro2 (copy 1)/crm/public/app.js
+++ b/metro2 (copy 1)/crm/public/app.js
@@ -251,6 +251,9 @@ function renderTradelines(tradelines){
     const card = node.querySelector(".tl-card");
     card.dataset.index = idx;
 
+    const negativeTags = ["Collections","Late Payments","Charge-Off"];
+    if (tags.some(t=>negativeTags.includes(t))) card.classList.add("negative");
+
     node.querySelector(".tl-creditor").textContent = tl.meta?.creditor || "Unknown Creditor";
     node.querySelector(".tl-idx").textContent = idx;
 

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -8,8 +8,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     :root{
-      --glass-bg: rgba(255,255,255,0.65);
-      --glass-brd: rgba(255,255,255,0.35);
+      --glass-bg: rgba(255,255,255,0.4);
+      --glass-brd: rgba(255,255,255,0.25);
       --muted:#6b7280;
       --green:#22c55e;
       --green-bg:rgba(34,197,94,.12);
@@ -25,7 +25,7 @@
       color:#0f172a;
       font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial;
     }
-    .glass{ background:var(--glass-bg); border:1px solid var(--glass-brd); border-radius:18px; backdrop-filter:blur(12px); box-shadow:0 8px 24px rgba(0,0,0,.1) }
+    .glass{ background:var(--glass-bg); border:1px solid var(--glass-brd); border-radius:18px; backdrop-filter:blur(12px) saturate(180%); box-shadow:0 8px 24px rgba(0,0,0,.1) }
     .card{ border-radius:18px; padding:16px }
     .chip{ border:1px solid var(--glass-brd); padding:4px 10px; border-radius:999px; font-size:12px; background:rgba(255,255,255,.7); cursor:pointer; user-select:none }
     .chip.active{ background:var(--accent-bg); border-color:var(--accent) }
@@ -35,6 +35,7 @@
     .tl-card{ transition:transform .2s ease, box-shadow .15s ease, background .15s ease; }
     .tl-card:hover{ transform: translateY(-1px) scale(1.01) }
     .tl-card.selected{ box-shadow:0 0 0 2px var(--green) inset; background:var(--green-bg) }
+    .tl-card.negative{ box-shadow:0 0 0 2px #ef4444 inset, 0 8px 24px rgba(0,0,0,.1); background:rgba(239,68,68,.12); }
     .wrap-anywhere{ overflow-wrap:anywhere; word-break:break-word }
     .hidden{ display:none }
     .focus-ring{ outline: 2px dashed #6366f1; outline-offset: 4px; }

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -217,6 +217,9 @@ function renderTradelines(tradelines){
     const card = node.querySelector(".tl-card");
     card.dataset.index = idx;
 
+    const negativeTags = ["Collections","Late Payments","Charge-Off"];
+    if (tags.some(t=>negativeTags.includes(t))) card.classList.add("negative");
+
     node.querySelector(".tl-creditor").textContent = tl.meta?.creditor || "Unknown Creditor";
     node.querySelector(".tl-idx").textContent = idx;
 
@@ -226,7 +229,7 @@ function renderTradelines(tradelines){
 
     const tagWrap = node.querySelector(".tl-tags");
     tagWrap.innerHTML = "";
-    deriveTags(tl).forEach(t=>{
+    tags.forEach(t=>{
       const chip = document.createElement("span");
       chip.className = "chip";
       chip.textContent = t;
@@ -575,9 +578,9 @@ $("#activityFile").addEventListener("change", async (e)=>{
 // ===================== Modes + Global Hotkeys =====================
 // Minimal re-implementation here so we don't rely on inline scripts
 const MODES = [
-  { key: "identity", hotkey: "i", cardClass: "mode-identity" },
-  { key: "breach",   hotkey: "d", cardClass: "mode-breach"   },
-  { key: "assault",  hotkey: "s", cardClass: "mode-assault"  },
+  { key: "identity", hotkey: "i", cardClass: "mode-identity", chip: "ID Theft" },
+  { key: "breach",   hotkey: "d", cardClass: "mode-breach",   chip: "Breach"   },
+  { key: "assault",  hotkey: "s", cardClass: "mode-assault",  chip: "Assault"  },
 ];
 let activeMode = null;
 function setMode(key){ activeMode = (activeMode===key)? null : key; updateModeButtons(); }
@@ -606,6 +609,16 @@ function attachCardHandlers(root=document){
     // focus ring for hotkeys R/A
     card.addEventListener("pointerdown", ()=> focusCard(card));
 
+    // main click behavior: toggle selection or special mode
+    card.addEventListener("click", (e)=>{
+      if (e.target.closest("input, label, button")) return;
+      if (activeMode){
+        toggleCardMode(card, activeMode);
+      } else {
+        toggleWholeCardSelection(card);
+      }
+    });
+
     // badge container safety
     if (!card.querySelector(".special-badges")) {
       const head = card.querySelector(".tl-head") || card.firstElementChild;
@@ -613,6 +626,9 @@ function attachCardHandlers(root=document){
       holder.className = "special-badges flex gap-1";
       head.appendChild(holder);
     }
+
+    // ensure badges match current classes
+    updateCardBadges(card);
   });
 }
 let lastFocusedCard = null;
@@ -624,6 +640,28 @@ function focusCard(card){
 function toggleWholeCardSelection(card){
   const any = Array.from(card.querySelectorAll('input.bureau')).some(cb=>cb.checked);
   setCardSelected(card, !any);
+}
+
+function toggleCardMode(card, modeKey){
+  const info = MODES.find(m => m.key === modeKey);
+  if (!info) return;
+  // remove other mode classes before toggling desired one
+  MODES.forEach(m => { if (m.cardClass !== info.cardClass) card.classList.remove(m.cardClass); });
+  card.classList.toggle(info.cardClass);
+  updateCardBadges(card);
+}
+
+function updateCardBadges(card){
+  const wrap = card.querySelector(".special-badges");
+  if (!wrap) return;
+  wrap.innerHTML = "";
+  const mode = MODES.find(m => card.classList.contains(m.cardClass));
+  if (mode){
+    const s = document.createElement("span");
+    s.className = `chip chip-mini chip-${mode.key}`;
+    s.textContent = mode.chip;
+    wrap.appendChild(s);
+  }
 }
 window.__crm_helpers = {
   attachCardHandlers,

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -7,8 +7,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     :root {
-      --glass-bg: rgba(255,255,255,0.65);
-      --glass-brd: rgba(255,255,255,0.35);
+      --glass-bg: rgba(255,255,255,0.4);
+      --glass-brd: rgba(255,255,255,0.25);
       --muted:#6b7280;
       --green:#22c55e;
       --green-bg: rgba(34,197,94,.12);
@@ -18,13 +18,14 @@
       color:#0f172a;
       font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial;
     }
-    .glass{ background:var(--glass-bg); border:1px solid var(--glass-brd); border-radius:18px; backdrop-filter:blur(12px); box-shadow:0 8px 24px rgba(0,0,0,.1); }
+    .glass{ background:var(--glass-bg); border:1px solid var(--glass-brd); border-radius:18px; backdrop-filter:blur(12px) saturate(180%); box-shadow:0 8px 24px rgba(0,0,0,.1); }
     .card{ border-radius:18px; padding:16px }
     .btn{ border:1px solid var(--glass-brd); border-radius:10px; padding:6px 12px; background:white/80; }
     .btn:hover{ background:#f9fafb }
     .muted{ color:var(--muted) }
     .tl-card{ transition:transform .15s ease, box-shadow .15s ease, background .15s ease; cursor:pointer; }
     .tl-card:hover{ transform:translateY(-1px); }
+    .tl-card.negative{ box-shadow:0 0 0 2px #ef4444 inset, 0 8px 24px rgba(0,0,0,.1); background:rgba(239,68,68,.12); }
     .hidden{ display:none }
     .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:none;align-items:center;justify-content:center;z-index:50}
     .modal{width:min(1100px,96vw);height:min(90vh,900px);border-radius:18px;box-shadow:0 20px 60px rgba(0,0,0,.25);background:white;display:flex;flex-direction:column;overflow:hidden}

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -191,7 +191,7 @@ app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
   if(!r) return res.status(404).json({ ok:false, error:"Report not found" });
   try{
     const normalized = normalizeReport(r.data);
-    const html = renderHtml(normalized);
+    const html = renderHtml(normalized, c.name);
     const result = await savePdf(html);
     addEvent(c.id, "audit_generated", { reportId: r.id, file: result.path });
     res.json({ ok:true, url: result.url, warning: result.warning });


### PR DESCRIPTION
## Summary
- Refine UI card styling with glassmorphism and red highlights for negative tradelines
- Personalize generated audit PDFs with consumer name and red flags on negative statuses
- Ignore build artifacts and reports in version control

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa7cbe5a2c8323b1ac57e5c1e9a221