### PR TITLE
Add single-bureau negative item logic and playbook

### DIFF
--- a/metro2 (copy 1)/crm/playbook.js
+++ b/metro2 (copy 1)/crm/playbook.js
@@ -1,0 +1,15 @@
+// playbook.js
+// Defines dispute letter sequences ("sequence attacks")
+
+export const PLAYBOOKS = {
+  metro2ComplianceSequence: {
+    name: 'Metro 2 compliance sequence',
+    letters: [
+      'Metro 2 inconsistency dispute',
+      'Factual errors layer',
+      'Deletion demand failure to fix under Metro 2 and FCRA 607(b)'
+    ]
+  }
+};
+
+export default PLAYBOOKS;


### PR DESCRIPTION
## Summary
- Flag negative tradelines present on only one bureau as "Incomplete file and misleading" when generating letters
- Introduce `playbook` module defining Metro 2 compliance sequence

## Testing
- `node -e "import('./playbook.js').then(m=>console.log('loaded playbook', m.PLAYBOOKS.metro2ComplianceSequence.letters.length))"`
- `node -e "import('./letterEngine.js').then(m=>console.log('letters fn', typeof m.generateLetters))"`
- `npm run audit`

------
https://chatgpt.com/codex/tasks/task_e_68aaac2bc3948323b272e325ea27d50a