### PR TITLE
fix: remove leftover code from letter engine

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -510,29 +510,4 @@ function generateLetters({ report, selections, consumer, requestType = "correct"
   return letters;
 }
 
-
-    for (const bureau of sel.bureaus || []) {
-      if (!ALL_BUREAUS.includes(bureau)) continue;
-
-      const letter = buildLetterHTML({
-        consumer,
-        bureau,
-        tl,
-        selectedViolationIdxs: sel.violationIdxs || [],
-        requestType,
-        comparisonBureaus,
-        modeKey: sel.specialMode || null,
-      });
-      letters.push({
-        bureau,
-        tradelineIndex: sel.tradelineIndex,
-        creditor: tl.meta.creditor,
-        ...letter,
-      });
-    }
-  }
-
-  return letters;
-}
-
 export { generateLetters };


### PR DESCRIPTION
## Summary
- remove duplicated leftover block from `generateLetters`
- ensure letter engine loads without syntax errors

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68aab20757c4832381effff8ff2f6136