### PR TITLE
Add basic logging and robust PDF fallback

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -29,6 +29,16 @@ const __dirname = path.dirname(__filename);
 const app = express();
 app.use(express.json({ limit: "10mb" }));
 
+// Basic request logging for debugging
+app.use((req, res, next) => {
+  const start = Date.now();
+  res.on("finish", () => {
+    const ms = Date.now() - start;
+    console.log(`${new Date().toISOString()} ${req.method} ${req.originalUrl} -> ${res.statusCode} ${ms}ms`);
+  });
+  next();
+});
+
 // periodically surface due letter reminders
 processAllReminders();
 setInterval(() => {


### PR DESCRIPTION
## Summary
- log each HTTP request with method, path and status code
- add detailed messages for PDF generation and fallback to HTML
- clarify CLI output when PDF rendering fails

## Testing
- `node creditAuditTool.js`
- `curl -s http://localhost:3000/api/consumers | jq '.consumers | length'`


------
https://chatgpt.com/codex/tasks/task_e_68abf4ab6ef8832382751902c9e33aa8