### PR TITLE
Add navigation routes and consumer card controls

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Billing</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-8">
+  <h1 class="text-2xl font-bold mb-4">Billing</h1>
+  <p>This is a placeholder for the Billing page.</p>
+</body>
+</html>
+

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-8">
+  <h1 class="text-2xl font-bold mb-4">Dashboard</h1>
+  <p>This is a placeholder for the Dashboard page.</p>
+</body>
+</html>
+

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -74,11 +74,16 @@
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">
       <button id="btnMarketing" class="btn" data-tip="Marketing">+ Marketing</button>
-      <button id="btnNewConsumer" class="btn" data-tip="New Consumer (N)">New Consumer</button>
-      <button id="btnEditConsumer" class="btn" data-tip="Edit Consumer (E)">Edit Consumer</button>
+      <a href="/dashboard" class="btn">Dashboard</a>
+      <a href="/clients" class="btn">Clients</a>
+      <a href="/schedule" class="btn">Schedule</a>
+      <a id="navCompany" href="/my-company" class="btn">My Company</a>
+      <a href="/billing" class="btn">Billing</a>
+      <a href="/letters" class="btn">Letter</a>
+      <a href="/library" class="btn">Library</a>
+      <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
       <button id="btnUpload" class="btn" data-tip="Upload HTML (U)">Upload HTML</button>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-      <button id="btnLibrary" class="btn" data-tip="Creditor Library">Library</button>
       <input id="fileInput" type="file" accept=".html,.htm,text/html" class="hidden" />
     </div>
   </div>
@@ -101,7 +106,13 @@
   <section class="grid md:grid-cols-[320px,1fr] gap-4">
     <!-- Consumers -->
     <aside class="glass card space-y-2">
-      <div class="font-semibold">Consumers</div>
+      <div class="flex items-center justify-between">
+        <div class="font-semibold">Consumers</div>
+        <div class="flex gap-2">
+          <button id="btnNewConsumer" class="btn text-sm" data-tip="New Consumer (N)">New Consumer</button>
+          <button id="btnEditConsumer" class="btn text-sm" data-tip="Edit Consumer (E)">Edit Consumer</button>
+        </div>
+      </div>
       <input id="consumerSearch" placeholder="Search consumers..." class="w-full border rounded px-2 py-1 text-sm" />
       <div id="consumerList" class="space-y-2"></div>
       <div class="flex items-center justify-between pt-2">

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -978,7 +978,7 @@ async function openLibrary(){
   modal.classList.remove("hidden"); modal.classList.add("flex");
   document.body.style.overflow = "hidden";
 }
-$("#btnLibrary").addEventListener("click", openLibrary);
+$("#btnCreditors").addEventListener("click", openLibrary);
 $("#libraryClose").addEventListener("click", ()=>{
   const modal = $("#libraryModal");
   modal.classList.add("hidden"); modal.classList.remove("flex");
@@ -988,4 +988,9 @@ $("#libraryModal").addEventListener("click", (e)=>{ if(e.target.id==="libraryMod
 
 // ===================== Init =====================
 loadConsumers();
+
+const companyName = localStorage.getItem("companyName");
+if (companyName) {
+  $("#navCompany").textContent = companyName;
+}
 

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Library</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-8">
+  <h1 class="text-2xl font-bold mb-4">Library</h1>
+  <p>This is a placeholder for the Library page.</p>
+</body>
+</html>
+

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>My Company</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-8">
+  <h1 class="text-2xl font-bold mb-4">My Company</h1>
+  <form id="companyForm" class="space-y-4">
+    <label class="block">
+      <span class="text-sm">Company Name</span>
+      <input id="companyName" class="border rounded px-2 py-1 w-full" />
+    </label>
+    <button class="btn border px-4 py-2 rounded" type="submit">Save</button>
+  </form>
+  <script>
+    document.getElementById('companyForm').addEventListener('submit', function(e){
+      e.preventDefault();
+      const name = document.getElementById('companyName').value.trim();
+      if(name){
+        localStorage.setItem('companyName', name);
+        window.location.href = '/';
+      }
+    });
+  </script>
+</body>
+</html>
+

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Schedule</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-8">
+  <h1 class="text-2xl font-bold mb-4">Schedule</h1>
+  <p>This is a placeholder for the Schedule page.</p>
+</body>
+</html>
+

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -50,6 +50,13 @@ setInterval(() => {
 const PUBLIC_DIR = path.join(__dirname, "public");
 app.use(express.static(PUBLIC_DIR));
 app.get("/", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "index.html")));
+app.get("/dashboard", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "dashboard.html")));
+app.get("/clients", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "index.html")));
+app.get("/schedule", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "schedule.html")));
+app.get("/my-company", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "my-company.html")));
+app.get("/billing", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "billing.html")));
+app.get("/library", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "library.html")));
+app.get("/letter", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "letters.html")));
 app.get("/letters", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "letters.html")));
 app.get("/letters/:jobId", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "letters.html")));
 


### PR DESCRIPTION
## Summary
- Move "New Consumer" and "Edit Consumer" buttons into the Consumers card
- Add header navigation links for Dashboard, Clients, Schedule, My Company, Billing, Letter, Library, and Creditors
- Create placeholder pages and express routes for new navigation links

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac6cd65cd483239bb75db715e481ac