### PR TITLE
Move Upload HTML button to selected consumer card

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -73,7 +73,6 @@
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">
-      <button id="btnMarketing" class="btn" data-tip="Marketing">+ Marketing</button>
       <a href="/dashboard" class="btn">Dashboard</a>
       <a href="/clients" class="btn">Clients</a>
       <a href="/schedule" class="btn">Schedule</a>
@@ -82,9 +81,7 @@
       <a href="/letters" class="btn">Letter</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
-      <button id="btnUpload" class="btn" data-tip="Upload HTML (U)">Upload HTML</button>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-      <input id="fileInput" type="file" accept=".html,.htm,text/html" class="hidden" />
     </div>
   </div>
 </header>
@@ -131,8 +128,10 @@
             <div class="text-sm muted">Report: <select id="reportPicker" class="border rounded px-2 py-1 text-sm"></select></div>
           </div>
           <div class="flex gap-2">
+            <button id="btnUpload" class="btn" data-tip="Upload HTML (U)">Upload HTML</button>
             <button id="btnAuditReport" class="btn" data-tip="Run audit on current report">Audit</button>
             <button id="btnDeleteReport" class="btn" data-tip="Delete current report (click)">Delete Report</button>
+            <input id="fileInput" type="file" accept=".html,.htm,text/html" class="hidden" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Remove unused Marketing button from header navigation
- Place Upload HTML button inside Selected Consumer card for contextual uploads

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac6fd3655c8323b3fe8a0609481a04