### PR TITLE
Unify CRM pages with shared header, client portal and letter editing

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -4,10 +4,30 @@
   <meta charset="utf-8">
   <title>Billing</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
 </head>
-<body class="p-8">
+<body>
+<header class="p-4">
+  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
+    <div class="text-xl font-semibold">Metro 2 CRM</div>
+    <div class="flex items-center gap-2">
+      <a href="/dashboard" class="btn">Dashboard</a>
+      <a href="/clients" class="btn">Clients</a>
+      <a href="/leads" class="btn">Leads</a>
+      <a href="/schedule" class="btn">Schedule</a>
+      <a id="navCompany" href="/my-company" class="btn">My Company</a>
+      <a href="/billing" class="btn">Billing</a>
+      <a href="/letters" class="btn">Letter</a>
+      <a href="/library" class="btn">Library</a>
+      <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
+      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+    </div>
+  </div>
+</header>
+<main class="max-w-7xl mx-auto p-4">
   <h1 class="text-2xl font-bold mb-4">Billing</h1>
   <p>This is a placeholder for the Billing page.</p>
+</main>
+<script src="/common.js"></script>
 </body>
 </html>
-

--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Dashboard</title>
+  <title>Client Portal - {{name}}</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
 </head>
@@ -24,9 +24,9 @@
     </div>
   </div>
 </header>
-<main class="max-w-7xl mx-auto p-4">
-  <h1 class="text-2xl font-bold mb-4">Dashboard</h1>
-  <p>This is a placeholder for the Dashboard page.</p>
+<main class="max-w-3xl mx-auto p-4">
+  <h1 class="text-2xl font-bold mb-4">Welcome, {{name}}</h1>
+  <p>This is your client access portal.</p>
 </main>
 <script src="/common.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -1,0 +1,115 @@
+/* public/common.js */
+const THEMES = {
+  blue:   { accent: '#007AFF', hover: '#005bb5', glassBg: 'rgba(0,122,255,0.15)', glassBrd: 'rgba(0,122,255,0.3)' },
+  green:  { accent: '#34C759', hover: '#248a3d', glassBg: 'rgba(52,199,89,0.15)', glassBrd: 'rgba(52,199,89,0.3)' },
+  orange: { accent: '#FF9500', hover: '#cc7600', glassBg: 'rgba(255,149,0,0.15)', glassBrd: 'rgba(255,149,0,0.3)' },
+  red:    { accent: '#FF3B30', hover: '#c82d24', glassBg: 'rgba(255,59,48,0.15)', glassBrd: 'rgba(255,59,48,0.3)' },
+  purple: { accent: '#AF52DE', hover: '#893dba', glassBg: 'rgba(175,82,222,0.15)', glassBrd: 'rgba(175,82,222,0.3)' }
+};
+
+function applyTheme(name){
+  const t = THEMES[name] || THEMES.blue;
+  const root = document.documentElement.style;
+  root.setProperty('--accent', t.accent);
+  root.setProperty('--accent-hover', t.hover);
+  root.setProperty('--glass-bg', t.glassBg);
+  root.setProperty('--glass-brd', t.glassBrd);
+  localStorage.setItem('theme', name);
+}
+
+function initPalette(){
+  if(document.getElementById('themePalette')) return;
+  const wrap = document.createElement('div');
+  wrap.id = 'themePalette';
+  wrap.className = 'collapsed';
+  wrap.innerHTML = `
+    <button class="toggle">▶</button>
+    <div class="palette-bubbles">
+      <div class="bubble" data-theme="blue" style="background:#007AFF"></div>
+      <div class="bubble" data-theme="green" style="background:#34C759"></div>
+      <div class="bubble" data-theme="orange" style="background:#FF9500"></div>
+      <div class="bubble" data-theme="red" style="background:#FF3B30"></div>
+      <div class="bubble" data-theme="purple" style="background:#AF52DE"></div>
+    </div>`;
+  document.body.appendChild(wrap);
+  const toggle = wrap.querySelector('.toggle');
+  toggle.addEventListener('click', ()=>{
+    wrap.classList.toggle('collapsed');
+    toggle.textContent = wrap.classList.contains('collapsed') ? '▶' : '◀';
+  });
+  wrap.addEventListener('click', (e)=>{
+    const b = e.target.closest('.bubble');
+    if(!b) return;
+    applyTheme(b.dataset.theme);
+  });
+  const saved = localStorage.getItem('theme') || 'blue';
+  applyTheme(saved);
+}
+
+function ensureHelpModal(){
+  if(document.getElementById('helpModal')) return;
+  const div = document.createElement('div');
+  div.id = 'helpModal';
+  div.className = 'fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)] z-50';
+  div.innerHTML = `
+    <div class="glass card w-[min(720px,92vw)]">
+      <div class="flex items-center justify-between mb-2">
+        <div class="font-semibold">Hotkeys & Tips</div>
+        <button id="helpClose" class="btn">×</button>
+      </div>
+      <div class="text-sm space-y-2">
+        <div class="grid grid-cols-2 gap-3">
+          <div class="glass card p-2">
+            <div class="font-medium mb-1">Global</div>
+            <ul class="list-disc list-inside">
+              <li><b>N</b> – New consumer</li>
+              <li><b>U</b> – Upload HTML</li>
+              <li><b>E</b> – Edit consumer</li>
+              <li><b>G</b> – Generate letters</li>
+              <li><b>C</b> – Clear (context-aware)</li>
+              <li><b>H</b> – Help overlay</li>
+              <li><b>R</b> – Remove focused tradeline card</li>
+            </ul>
+          </div>
+          <div class="glass card p-2">
+            <div class="font-medium mb-1">Modes / Cards</div>
+            <ul class="list-disc list-inside">
+              <li>Modes: <b>I</b>=Identity Theft, <b>D</b>=Data Breach, <b>S</b>=Sexual Assault</li>
+              <li>Click a card to zoom; press <b>A</b> to toggle all bureaus on that card.</li>
+              <li>Press <b>Esc</b> to exit a mode.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>`;
+  document.body.appendChild(div);
+}
+
+function openHelp(){
+  ensureHelpModal();
+  const modal = document.getElementById('helpModal');
+  modal.classList.remove('hidden');
+  modal.classList.add('flex');
+  document.body.style.overflow = 'hidden';
+  bindHelp();
+}
+function closeHelp(){
+  const modal = document.getElementById('helpModal');
+  modal.classList.add('hidden');
+  modal.classList.remove('flex');
+  document.body.style.overflow = '';
+}
+
+function bindHelp(){
+  document.getElementById('btnHelp')?.addEventListener('click', openHelp);
+  document.getElementById('helpClose')?.addEventListener('click', closeHelp);
+  document.getElementById('helpModal')?.addEventListener('click', (e)=>{ if(e.target.id==='helpModal') closeHelp(); });
+}
+
+document.addEventListener('DOMContentLoaded', ()=>{
+  ensureHelpModal();
+  bindHelp();
+  initPalette();
+});
+
+window.openHelp = openHelp;

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="theme-color" content="#007AFF" />
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
   <style>
     :root{
       --glass-bg: rgba(255,255,255,0.4);
@@ -30,8 +31,6 @@
     .chip{ border:1px solid var(--glass-brd); padding:4px 10px; border-radius:999px; font-size:12px; background:rgba(255,255,255,.7); cursor:pointer; user-select:none }
     .chip.active{ background:var(--accent-bg); border-color:var(--accent) }
     .muted{ color:var(--muted) }
-    .btn{ border:1px solid var(--accent); border-radius:10px; padding:6px 12px; background:white/80; position:relative; }
-    .btn:hover{ background:#f9fafb }
     .tl-card{ transition:transform .2s ease, box-shadow .15s ease, background .15s ease; }
     .tl-card:hover{ transform: translateY(-1px) scale(1.01) }
     .tl-card.selected{ box-shadow:0 0 0 2px var(--green) inset; background:var(--green-bg) }
@@ -73,29 +72,36 @@
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">
-      <button id="btnMarketing" class="btn" data-tip="Marketing">+ Marketing</button>
       <a href="/dashboard" class="btn">Dashboard</a>
       <a href="/clients" class="btn">Clients</a>
+      <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
       <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
-      <button id="btnUpload" class="btn" data-tip="Upload HTML (U)">Upload HTML</button>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-      <input id="fileInput" type="file" accept=".html,.htm,text/html" class="hidden" />
     </div>
   </div>
 </header>
 
 <!-- Quick Actions -->
 <div class="max-w-7xl mx-auto">
-  <div class="glass card">
-    <div class="font-medium mb-2">Quick Actions</div>
-    <div id="modeBar" class="flex gap-2 flex-wrap"></div>
-    <div class="text-sm muted mt-1">
-      Click a mode, then click tradeline cards to tag them. Click the mode again to exit.
+  <div class="glass card space-y-4">
+    <div>
+      <div class="font-medium mb-1">Client Tracker</div>
+      <div id="trackerSteps" class="flex gap-4 text-sm">
+        <label class="flex items-center gap-2"><input type="checkbox" id="step1" /> Step 1</label>
+        <label class="flex items-center gap-2"><input type="checkbox" id="step2" /> Step 2</label>
+      </div>
+    </div>
+    <div>
+      <div class="font-medium mb-2">Quick Actions</div>
+      <div id="modeBar" class="flex gap-2 flex-wrap"></div>
+      <div class="text-sm muted mt-1">
+        Click a mode, then click tradeline cards to tag them. Click the mode again to exit.
+      </div>
     </div>
   </div>
 </div>
@@ -131,8 +137,11 @@
             <div class="text-sm muted">Report: <select id="reportPicker" class="border rounded px-2 py-1 text-sm"></select></div>
           </div>
           <div class="flex gap-2">
+            <button id="btnUpload" class="btn" data-tip="Upload HTML (U)">Upload HTML</button>
+            <button id="btnDataBreach" class="btn" data-tip="Databreach options">Databreach</button>
             <button id="btnAuditReport" class="btn" data-tip="Run audit on current report">Audit</button>
             <button id="btnDeleteReport" class="btn" data-tip="Delete current report (click)">Delete Report</button>
+            <input id="fileInput" type="file" accept=".html,.htm,text/html" class="hidden" />
           </div>
         </div>
       </div>
@@ -203,16 +212,13 @@
 
 <!-- Consumer list item template -->
 <template id="consumerItem">
-  <div class="glass card">
+  <div class="glass card consumer-card cursor-pointer">
     <div class="flex items-start justify-between">
       <div>
         <div class="name font-medium"></div>
         <div class="email text-sm muted"></div>
       </div>
-      <div class="flex gap-2">
-        <button class="select btn" data-tip="Open Consumer (click)">Open</button>
-        <button class="delete btn" data-tip="Delete Consumer (click)">×</button>
-      </div>
+      <button class="delete btn" data-tip="Delete Consumer (click)">×</button>
     </div>
   </div>
 </template>
@@ -358,6 +364,7 @@
   </div>
 </div>
 
+<script src="common.js"></script>
 <!-- Special modes + global hotkeys are initialized inside index.js -->
 <script type="module" src="index.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/leads.html
+++ b/metro2 (copy 1)/crm/public/leads.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Dashboard</title>
+  <title>Leads</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
 </head>
@@ -25,8 +25,8 @@
   </div>
 </header>
 <main class="max-w-7xl mx-auto p-4">
-  <h1 class="text-2xl font-bold mb-4">Dashboard</h1>
-  <p>This is a placeholder for the Dashboard page.</p>
+  <h1 class="text-2xl font-bold mb-4">Leads</h1>
+  <p>This is a placeholder for the Leads page.</p>
 </main>
 <script src="/common.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -5,24 +5,12 @@
   <title>Generated Letters</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
   <style>
     :root {
-      --glass-bg: rgba(255,255,255,0.4);
-      --glass-brd: rgba(255,255,255,0.25);
-      --muted:#6b7280;
       --green:#22c55e;
       --green-bg: rgba(34,197,94,.12);
     }
-    body{
-      background:#f7fafc;
-      color:#0f172a;
-      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial;
-    }
-    .glass{ background:var(--glass-bg); border:1px solid var(--glass-brd); border-radius:18px; backdrop-filter:blur(12px) saturate(180%); box-shadow:0 8px 24px rgba(0,0,0,.1); }
-    .card{ border-radius:18px; padding:16px }
-    .btn{ border:1px solid var(--glass-brd); border-radius:10px; padding:6px 12px; background:white/80; }
-    .btn:hover{ background:#f9fafb }
-    .muted{ color:var(--muted) }
     .tl-card{ transition:transform .15s ease, box-shadow .15s ease, background .15s ease; cursor:pointer; }
     .tl-card:hover{ transform:translateY(-1px); }
     .tl-card.negative{ box-shadow:0 0 0 2px #ef4444 inset, 0 8px 24px rgba(0,0,0,.1); background:rgba(239,68,68,.12); }
@@ -35,13 +23,25 @@
 </head>
 <body>
 <header class="p-4">
-  <div class="max-w-7xl mx-auto flex items-center justify-between glass card">
-    <h1 class="text-xl font-semibold">Generated Letters</h1>
-    <div class="text-sm muted">Job: <span id="jobId">—</span></div>
+  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
+    <div class="text-xl font-semibold">Metro 2 CRM</div>
+    <div class="flex items-center gap-2">
+      <a href="/dashboard" class="btn">Dashboard</a>
+      <a href="/clients" class="btn">Clients</a>
+      <a href="/leads" class="btn">Leads</a>
+      <a href="/schedule" class="btn">Schedule</a>
+      <a id="navCompany" href="/my-company" class="btn">My Company</a>
+      <a href="/billing" class="btn">Billing</a>
+      <a href="/letters" class="btn">Letter</a>
+      <a href="/library" class="btn">Library</a>
+      <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
+      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+    </div>
   </div>
 </header>
 
 <main class="max-w-7xl mx-auto p-4 space-y-4">
+  <div class="text-sm muted">Job: <span id="jobId">—</span></div>
   <div id="err" class="hidden p-3 bg-red-50 border border-red-200 text-red-700 rounded-lg"></div>
 
   <div class="glass card">
@@ -75,13 +75,17 @@
       <div class="flex items-center gap-2">
         <a id="pvOpen" target="_blank" class="btn">Open HTML</a>
         <button id="pvPrint" class="btn">Print</button>
+        <button id="pvEdit" class="btn">Edit</button>
+        <button id="pvSave" class="btn hidden">Save</button>
         <button id="pvClose" class="btn">Close</button>
       </div>
     </header>
     <iframe id="pvFrame" src="about:blank"></iframe>
+    <textarea id="pvEditor" class="hidden w-full h-full p-2 font-mono text-sm"></textarea>
   </div>
 </div>
 
+<script src="/common.js"></script>
 <script src="letters.js" type="module"></script>
 </body>
 </html>

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -4,10 +4,30 @@
   <meta charset="utf-8">
   <title>Library</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
 </head>
-<body class="p-8">
+<body>
+<header class="p-4">
+  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
+    <div class="text-xl font-semibold">Metro 2 CRM</div>
+    <div class="flex items-center gap-2">
+      <a href="/dashboard" class="btn">Dashboard</a>
+      <a href="/clients" class="btn">Clients</a>
+      <a href="/leads" class="btn">Leads</a>
+      <a href="/schedule" class="btn">Schedule</a>
+      <a id="navCompany" href="/my-company" class="btn">My Company</a>
+      <a href="/billing" class="btn">Billing</a>
+      <a href="/letters" class="btn">Letter</a>
+      <a href="/library" class="btn">Library</a>
+      <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
+      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+    </div>
+  </div>
+</header>
+<main class="max-w-7xl mx-auto p-4">
   <h1 class="text-2xl font-bold mb-4">Library</h1>
   <p>This is a placeholder for the Library page.</p>
+</main>
+<script src="/common.js"></script>
 </body>
 </html>
-

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -4,26 +4,30 @@
   <meta charset="utf-8">
   <title>My Company</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
 </head>
-<body class="p-8">
+<body>
+<header class="p-4">
+  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
+    <div class="text-xl font-semibold">Metro 2 CRM</div>
+    <div class="flex items-center gap-2">
+      <a href="/dashboard" class="btn">Dashboard</a>
+      <a href="/clients" class="btn">Clients</a>
+      <a href="/leads" class="btn">Leads</a>
+      <a href="/schedule" class="btn">Schedule</a>
+      <a id="navCompany" href="/my-company" class="btn">My Company</a>
+      <a href="/billing" class="btn">Billing</a>
+      <a href="/letters" class="btn">Letter</a>
+      <a href="/library" class="btn">Library</a>
+      <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
+      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+    </div>
+  </div>
+</header>
+<main class="max-w-7xl mx-auto p-4">
   <h1 class="text-2xl font-bold mb-4">My Company</h1>
-  <form id="companyForm" class="space-y-4">
-    <label class="block">
-      <span class="text-sm">Company Name</span>
-      <input id="companyName" class="border rounded px-2 py-1 w-full" />
-    </label>
-    <button class="btn border px-4 py-2 rounded" type="submit">Save</button>
-  </form>
-  <script>
-    document.getElementById('companyForm').addEventListener('submit', function(e){
-      e.preventDefault();
-      const name = document.getElementById('companyName').value.trim();
-      if(name){
-        localStorage.setItem('companyName', name);
-        window.location.href = '/';
-      }
-    });
-  </script>
+  <p>This is a placeholder for the My Company page.</p>
+</main>
+<script src="/common.js"></script>
 </body>
 </html>
-

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -5,8 +5,26 @@
   <title>Hotkey Quiz</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body class="bg-slate-50 text-slate-900">
+  <header class="p-4">
+    <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <div class="flex items-center gap-2">
+        <a href="/dashboard" class="btn">Dashboard</a>
+        <a href="/clients" class="btn">Clients</a>
+        <a href="/leads" class="btn">Leads</a>
+        <a href="/schedule" class="btn">Schedule</a>
+        <a id="navCompany" href="/my-company" class="btn">My Company</a>
+        <a href="/billing" class="btn">Billing</a>
+        <a href="/letters" class="btn">Letter</a>
+        <a href="/library" class="btn">Library</a>
+        <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
+        <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      </div>
+    </div>
+  </header>
   <main class="max-w-3xl mx-auto p-6">
     <div class="bg-white rounded-2xl shadow p-6">
       <div class="flex items-center justify-between">
@@ -15,7 +33,7 @@
       </div>
       <p class="text-sm text-slate-600 mt-1">Quick 6-question multiple-choice to learn the keyboard shortcuts.</p>
 
-      <div id="quiz" class="mt-4 space-y-4"></div>
+  <div id="quiz" class="mt-4 space-y-4"></div>
 
       <div class="mt-4 flex items-center gap-3">
         <button id="btnSubmit" class="border rounded px-4 py-2">Submit</button>
@@ -26,5 +44,6 @@
   </main>
 
   <script type="module" src="quiz.js"></script>
+  <script src="/common.js"></script>
 </body>
 </html>

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -4,10 +4,30 @@
   <meta charset="utf-8">
   <title>Schedule</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
 </head>
-<body class="p-8">
+<body>
+<header class="p-4">
+  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
+    <div class="text-xl font-semibold">Metro 2 CRM</div>
+    <div class="flex items-center gap-2">
+      <a href="/dashboard" class="btn">Dashboard</a>
+      <a href="/clients" class="btn">Clients</a>
+      <a href="/leads" class="btn">Leads</a>
+      <a href="/schedule" class="btn">Schedule</a>
+      <a id="navCompany" href="/my-company" class="btn">My Company</a>
+      <a href="/billing" class="btn">Billing</a>
+      <a href="/letters" class="btn">Letter</a>
+      <a href="/library" class="btn">Library</a>
+      <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
+      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+    </div>
+  </div>
+</header>
+<main class="max-w-7xl mx-auto p-4">
   <h1 class="text-2xl font-bold mb-4">Schedule</h1>
   <p>This is a placeholder for the Schedule page.</p>
+</main>
+<script src="/common.js"></script>
 </body>
 </html>
-

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -1,0 +1,69 @@
+:root {
+  --glass-bg: rgba(255,255,255,0.4);
+  --glass-brd: rgba(255,255,255,0.25);
+  --muted: #6b7280;
+  --accent: #007AFF;
+  --accent-hover: #005bb5;
+}
+body {
+  background:
+    radial-gradient(1200px 800px at -10% -10%, #e0f2fe 0%, transparent 50%),
+    radial-gradient(900px 700px at 110% 0%, #fef3c7 0%, transparent 55%),
+    radial-gradient(1000px 900px at 50% 120%, #fce7f3 0%, transparent 55%),
+    #f7fafc;
+  color:#0f172a;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial;
+}
+.glass {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-brd);
+  border-radius: 18px;
+  backdrop-filter: blur(12px) saturate(180%);
+  box-shadow: 0 8px 24px rgba(0,0,0,.1);
+}
+.card { border-radius:18px; padding:16px }
+.btn {
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 10px;
+  padding: 6px 12px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.05);
+  transition: background .2s;
+}
+.btn:hover { background: var(--accent-hover); }
+.muted { color: var(--muted); }
+
+#themePalette {
+  position: fixed;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  z-index: 40;
+}
+#themePalette .toggle {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+}
+#themePalette.collapsed .palette-bubbles { display: none; }
+#themePalette .palette-bubbles {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+#themePalette .bubble {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Apply shared navigation header and new blue button styling across CRM pages, including new Leads page
- Track workflow steps per consumer with client tracker checkboxes
- Generate a dedicated client portal HTML page whenever a new client is created
- Allow editing and saving letters directly from the preview modal
- Move client tracker above quick actions and make entire consumer cards clickable
- Introduce theme palette and reusable help modal across pages

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac6fd3655c8323b3fe8a0609481a04