### PR TITLE
Revamp dashboard layout and letters editor

### DIFF
--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -24,10 +24,68 @@
     </div>
   </div>
 </header>
-<main class="max-w-7xl mx-auto p-4">
-  <h1 class="text-2xl font-bold mb-4">Dashboard</h1>
-  <p>This is a placeholder for the Dashboard page.</p>
+<main class="max-w-7xl mx-auto p-4 space-y-4">
+  <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div class="glass card">
+      <div class="flex items-start justify-between">
+        <div>
+          <div class="text-sm muted">Total Leads</div>
+          <div id="dashLeads" class="text-2xl font-semibold">0</div>
+        </div>
+        <a href="#" class="btn text-xs">Details</a>
+      </div>
+    </div>
+
+    <div class="glass card">
+      <div class="flex items-start justify-between">
+        <div>
+          <div class="text-sm muted">Total Clients</div>
+          <div id="dashClients" class="text-2xl font-semibold">0</div>
+        </div>
+        <a href="#" class="btn text-xs">Details</a>
+      </div>
+    </div>
+
+    <div class="glass card">
+      <div class="flex items-start justify-between">
+        <div>
+          <div class="text-sm muted">Sales</div>
+          <div id="dashSales" class="text-2xl font-semibold">$0.00</div>
+        </div>
+        <a href="#" class="btn text-xs">Details</a>
+      </div>
+    </div>
+
+    <div class="glass card">
+      <div class="flex items-start justify-between">
+        <div>
+          <div class="text-sm muted">Payments</div>
+          <div id="dashPayments" class="text-2xl font-semibold">$0.00</div>
+        </div>
+        <a href="#" class="btn text-xs">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+    <div class="glass card lg:col-span-2">
+      <div class="flex items-center justify-between mb-2">
+        <div class="font-medium">Notepad</div>
+        <button id="dashSaveNote" class="btn text-sm">Save</button>
+      </div>
+      <textarea id="dashNote" class="w-full h-40 border rounded p-2 text-sm"></textarea>
+    </div>
+
+    <div class="glass card">
+      <div class="font-medium mb-2">Retention Rate</div>
+      <div id="dashRetention" class="text-2xl font-semibold">0.0%</div>
+    </div>
+
+    <div class="glass card">
+      <div class="font-medium mb-2">Company Deletion Statistics</div>
+      <div id="dashDeletion" class="text-sm muted">No data</div>
+    </div>
+  </div>
 </main>
-=======
 </body>
 </html>

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -52,12 +52,14 @@
     .mode-btn.active{ box-shadow:0 0 0 2px #1f2937 inset; background:#eef2ff; }
 
     /* Tooltip bubble */
-    .btn[data-tip]:hover::after{
+    .btn[data-tip]:hover::after,
+    .chip[data-tip]:hover::after{
       content: attr(data-tip);
       position:absolute; left:50%; transform:translateX(-50%); bottom: calc(100% + 8px);
       background: rgba(17,24,39,.95); color:white; font-size:12px; padding:6px 8px; border-radius:8px; white-space:nowrap; box-shadow:0 6px 18px rgba(0,0,0,.2); z-index:40;
     }
-    .btn[data-tip]:hover::before{
+    .btn[data-tip]:hover::before,
+    .chip[data-tip]:hover::before{
       content:""; position:absolute; left:50%; transform:translateX(-50%); bottom: 100%;
       border:6px solid transparent; border-top-color: rgba(17,24,39,.95); z-index:39;
     }
@@ -122,8 +124,8 @@
       <div class="flex items-center justify-between">
         <div class="font-semibold">Consumers</div>
         <div class="flex gap-2">
-          <button id="btnNewConsumer" class="btn text-sm" data-tip="New Consumer (N)">New Consumer</button>
-          <button id="btnEditConsumer" class="btn text-sm" data-tip="Edit Consumer (E)">Edit Consumer</button>
+          <button id="btnNewConsumer" class="btn text-sm" data-tip="New Consumer (N)">New</button>
+          <button id="btnEditConsumer" class="btn text-sm" data-tip="Edit Consumer (E)">Edit</button>
         </div>
       </div>
       <input id="consumerSearch" placeholder="Search consumers..." class="w-full border rounded px-2 py-1 text-sm" />
@@ -144,10 +146,10 @@
             <div class="text-sm muted">Report: <select id="reportPicker" class="border rounded px-2 py-1 text-sm"></select></div>
           </div>
           <div class="flex gap-2">
-            <button id="btnUpload" class="btn" data-tip="Upload HTML (U)">Upload HTML</button>
-            <button id="btnDataBreach" class="btn" data-tip="Databreach options">Databreach</button>
-            <button id="btnAuditReport" class="btn" data-tip="Run audit on current report">Audit</button>
-            <button id="btnDeleteReport" class="btn" data-tip="Delete current report (click)">Delete Report</button>
+            <button id="btnUpload" class="chip" data-tip="Upload HTML (U)">Upload HTML</button>
+            <button id="btnDataBreach" class="chip" data-tip="Databreach options">Databreach</button>
+            <button id="btnAuditReport" class="chip" data-tip="Run audit on current report">Audit</button>
+            <button id="btnDeleteReport" class="chip" data-tip="Delete current report (click)">Delete Report</button>
             <input id="fileInput" type="file" accept=".html,.htm,text/html" class="hidden" />
           </div>
         </div>

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -80,8 +80,10 @@
         <button id="pvClose" class="btn">Close</button>
       </div>
     </header>
-    <iframe id="pvFrame" src="about:blank"></iframe>
-    <textarea id="pvEditor" class="hidden w-full h-full p-2 font-mono text-sm"></textarea>
+    <div id="pvBody" class="flex flex-1">
+      <iframe id="pvFrame" class="flex-1 h-full" src="about:blank"></iframe>
+      <textarea id="pvEditor" class="hidden flex-1 h-full p-2 text-sm"></textarea>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Restyle consumer action buttons and update tooltips
- Introduce card-based dashboard with metrics and notepad widgets
- Add side-by-side letter editor showing live preview

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac7d9e8e788323b7ad7666cecbdfd0