### PR TITLE
Add HaveIBeenPwned data breach lookup

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -745,6 +745,35 @@ $("#fileInput").addEventListener("change", async (e)=>{
   }
 });
 
+// Data breach lookup
+$("#btnDataBreach").addEventListener("click", async ()=>{
+  if(!currentConsumerId) return showErr("Select a consumer first.");
+  const c = DB.consumers.find(x=>x.id===currentConsumerId);
+  if(!c?.email) return showErr("Selected consumer has no email.");
+  const btn = $("#btnDataBreach");
+  const old = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = "Checking...";
+  try{
+    const res = await api(`/api/databreach`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: c.email })
+    });
+    if(!res?.ok) return showErr(res?.error || "Breach check failed.");
+    const list = res.breaches || [];
+    const msg = list.length
+      ? `${c.email} found in:\n\n${list.map(b=>b.Name || b.name || "unknown").join("\n")}`
+      : `${c.email} not found in known breaches.`;
+    alert(msg);
+  }catch(err){
+    showErr(String(err));
+  }finally{
+    btn.textContent = old;
+    btn.disabled = false;
+  }
+});
+
 // Audit report
 $("#btnAuditReport").addEventListener("click", async ()=>{
   if(!currentConsumerId || !currentReportId) return showErr("Select a report first.");

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -254,6 +254,40 @@ app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
   }
 });
 
+// Check consumer email against Have I Been Pwned
+// Use POST so email isn't logged in query string
+app.post("/api/databreach", async (req, res) => {
+  const email = String(req.body.email || "").trim();
+  if (!email) return res.status(400).json({ ok: false, error: "Email required" });
+  const apiKey = process.env.HIBP_API_KEY;
+  if (!apiKey) return res.status(500).json({ ok: false, error: "HIBP API key not configured" });
+  try {
+    const hibpRes = await fetch(
+      `https://haveibeenpwned.com/api/v3/breachedaccount/${encodeURIComponent(email)}?truncateResponse=false`,
+      {
+        headers: {
+          "hibp-api-key": apiKey,
+          "user-agent": "crm-app"
+        }
+      }
+    );
+    if (hibpRes.status === 404) {
+      return res.json({ ok: true, breaches: [] });
+    }
+    if (!hibpRes.ok) {
+      const text = await hibpRes.text().catch(() => "");
+      return res
+        .status(hibpRes.status)
+        .json({ ok: false, error: text || `HIBP request failed (status ${hibpRes.status})` });
+    }
+    const data = await hibpRes.json();
+    res.json({ ok: true, breaches: data });
+  } catch (e) {
+    console.error("HIBP check failed", e);
+    res.status(500).json({ ok: false, error: "HIBP request failed" });
+  }
+});
+
 // =================== Letters & PDFs ===================
 const LETTERS_DIR = path.resolve("./letters");
 const JOBS_INDEX_PATH = path.join(LETTERS_DIR, "_jobs.json");


### PR DESCRIPTION
## Summary
- Add `/api/databreach` endpoint that checks consumer email against Have I Been Pwned
- Wire up Databreach button in the UI to query endpoint and display breaches
- Switch endpoint to POST so consumer email isn't logged in query strings

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acb66717d48323b803c84c277bf61d