### PR TITLE
Add Have I Been Pwned lookup for Data Breach button

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -240,8 +240,9 @@ app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
   const r=c.reports.find(x=>x.id===req.params.rid);
   if(!r) return res.status(404).json({ ok:false, error:"Report not found" });
 
-  const selections = Array.isArray(req.body?.selections) ? req.body.selections : [];
-  if(!selections.length) return res.status(400).json({ ok:false, error:"No selections provided" });
+  const selections = Array.isArray(req.body?.selections) && req.body.selections.length
+    ? req.body.selections
+    : null;
 
   try{
     const normalized = normalizeReport(r.data, selections);
@@ -251,6 +252,40 @@ app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
     res.json({ ok:true, url: result.url, warning: result.warning });
   }catch(e){
     res.status(500).json({ ok:false, error: String(e) });
+  }
+});
+
+// Check consumer email against Have I Been Pwned
+// Use POST so email isn't logged in query string
+app.post("/api/databreach", async (req, res) => {
+  const email = String(req.body.email || "").trim();
+  if (!email) return res.status(400).json({ ok: false, error: "Email required" });
+  const apiKey = process.env.HIBP_API_KEY;
+  if (!apiKey) return res.status(500).json({ ok: false, error: "HIBP API key not configured" });
+  try {
+    const hibpRes = await fetch(
+      `https://haveibeenpwned.com/api/v3/breachedaccount/${encodeURIComponent(email)}?truncateResponse=false`,
+      {
+        headers: {
+          "hibp-api-key": apiKey,
+          "user-agent": "crm-app"
+        }
+      }
+    );
+    if (hibpRes.status === 404) {
+      return res.json({ ok: true, breaches: [] });
+    }
+    if (!hibpRes.ok) {
+      const text = await hibpRes.text().catch(() => "");
+      return res
+        .status(hibpRes.status)
+        .json({ ok: false, error: text || `HIBP request failed (status ${hibpRes.status})` });
+    }
+    const data = await hibpRes.json();
+    res.json({ ok: true, breaches: data });
+  } catch (e) {
+    console.error("HIBP check failed", e);
+    res.status(500).json({ ok: false, error: "HIBP request failed" });
   }
 });
 


### PR DESCRIPTION
## Summary
- Query Have I Been Pwned for the selected consumer email via new `/api/databreach` route
- Hook up the front-end "Data Breach" button to display results
- Allow audit to run the entire report when no tradelines are specified and preserve selections across pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acb66717d48323b803c84c277bf61d