### PR TITLE
Fix data breach lookup and remove duplicate server routes

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -770,11 +770,6 @@ $("#btnDataBreach").addEventListener("click", async ()=>{
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: c.email })
     });
-
-
-
-
-    const res = await api(`/api/databreach?email=${encodeURIComponent(c.email)}`);
     if(!res?.ok) return showErr(res?.error || "Breach check failed.");
     const list = res.breaches || [];
     const msg = list.length

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -57,9 +57,9 @@ app.get("/schedule", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "schedule
 app.get("/my-company", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "my-company.html")));
 app.get("/billing", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "billing.html")));
 app.get("/library", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "library.html")));
-app.get("/letter", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "letters.html")));
-app.get("/letters", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "letters.html")));
-app.get("/letters/:jobId", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "letters.html")));
+app.get(["/letters", "/letters/:jobId"], (_req, res) =>
+  res.sendFile(path.join(PUBLIC_DIR, "letters.html"))
+);
 app.get("/quiz", (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "quiz.html")));
 app.get("/portal/:id", (req, res) => {
   const f = path.join(PUBLIC_DIR, `portal-${req.params.id}.html`);
@@ -257,289 +257,54 @@ app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
 
 // Check consumer email against Have I Been Pwned
 // Use POST so email isn't logged in query string
-app.post("/api/databreach", async (req, res) => {
-  const email = String(req.body.email || "").trim();
-  if (!email) return res.status(400).json({ ok: false, error: "Email required" });
+async function hibpLookup(email) {
   const apiKey = process.env.HIBP_API_KEY;
-  if (!apiKey) return res.status(500).json({ ok: false, error: "HIBP API key not configured" });
+  if (!apiKey) return { ok: false, status: 500, error: "HIBP API key not configured" };
   try {
     const hibpRes = await fetch(
       `https://haveibeenpwned.com/api/v3/breachedaccount/${encodeURIComponent(email)}?truncateResponse=false`,
       {
         headers: {
           "hibp-api-key": apiKey,
-          "user-agent": "crm-app"
-        }
+          "user-agent": "crm-app",
+        },
       }
     );
     if (hibpRes.status === 404) {
-      return res.json({ ok: true, breaches: [] });
+      return { ok: true, breaches: [] };
     }
     if (!hibpRes.ok) {
       const text = await hibpRes.text().catch(() => "");
-      return res
-        .status(hibpRes.status)
-        .json({ ok: false, error: text || `HIBP request failed (status ${hibpRes.status})` });
+      return {
+        ok: false,
+        status: hibpRes.status,
+        error: text || `HIBP request failed (status ${hibpRes.status})`,
+      };
     }
     const data = await hibpRes.json();
-    res.json({ ok: true, breaches: data });
+    return { ok: true, breaches: data };
   } catch (e) {
     console.error("HIBP check failed", e);
-    res.status(500).json({ ok: false, error: "HIBP request failed" });
+    return { ok: false, status: 500, error: "HIBP request failed" };
   }
-});
+}
 
-// =================== Letters & PDFs ===================
-const LETTERS_DIR = path.resolve("./letters");
-const JOBS_INDEX_PATH = path.join(LETTERS_DIR, "_jobs.json");
+async function handleDataBreach(email, res) {
+  const result = await hibpLookup(email);
+  if (result.ok) return res.json(result);
+  res.status(result.status || 500).json({ ok: false, error: result.error });
+}
 
-app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
-  const db=loadDB();
-  const c=db.consumers.find(x=>x.id===req.params.id);
-  if(!c) return res.status(404).json({ ok:false, error:"Consumer not found" });
-  const r=c.reports.find(x=>x.id===req.params.rid);
-  if(!r) return res.status(404).json({ ok:false, error:"Report not found" });
-
-  const selections = Array.isArray(req.body?.selections) && req.body.selections.length
-    ? req.body.selections
-    : null;
-
-  try{
-    const normalized = normalizeReport(r.data, selections);
-    const html = renderHtml(normalized, c.name);
-    const result = await savePdf(html);
-    addEvent(c.id, "audit_generated", { reportId: r.id, file: result.path });
-    res.json({ ok:true, url: result.url, warning: result.warning });
-  }catch(e){
-    res.status(500).json({ ok:false, error: String(e) });
-  }
-});
-
-// Check consumer email against Have I Been Pwned
-// Use POST so email isn't logged in query string
 app.post("/api/databreach", async (req, res) => {
   const email = String(req.body.email || "").trim();
   if (!email) return res.status(400).json({ ok: false, error: "Email required" });
-  const apiKey = process.env.HIBP_API_KEY;
-  if (!apiKey) return res.status(500).json({ ok: false, error: "HIBP API key not configured" });
-  try {
-    const hibpRes = await fetch(
-      `https://haveibeenpwned.com/api/v3/breachedaccount/${encodeURIComponent(email)}?truncateResponse=false`,
-      {
-        headers: {
-          "hibp-api-key": apiKey,
-          "user-agent": "crm-app"
-        }
-      }
-    );
-    if (hibpRes.status === 404) {
-      return res.json({ ok: true, breaches: [] });
-    }
-    if (!hibpRes.ok) {
-      const text = await hibpRes.text().catch(() => "");
-      return res
-        .status(hibpRes.status)
-        .json({ ok: false, error: text || `HIBP request failed (status ${hibpRes.status})` });
-    }
-    const data = await hibpRes.json();
-    res.json({ ok: true, breaches: data });
-  } catch (e) {
-    console.error("HIBP check failed", e);
-    res.status(500).json({ ok: false, error: "HIBP request failed" });
-  }
+  await handleDataBreach(email, res);
 });
 
-// =================== Letters & PDFs ===================
-const LETTERS_DIR = path.resolve("./letters");
-const JOBS_INDEX_PATH = path.join(LETTERS_DIR, "_jobs.json");
-
-app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
-  const db=loadDB();
-  const c=db.consumers.find(x=>x.id===req.params.id);
-  if(!c) return res.status(404).json({ ok:false, error:"Consumer not found" });
-  const r=c.reports.find(x=>x.id===req.params.rid);
-  if(!r) return res.status(404).json({ ok:false, error:"Report not found" });
-
-  const selections = Array.isArray(req.body?.selections) && req.body.selections.length
-    ? req.body.selections
-    : null;
-
-  try{
-    const normalized = normalizeReport(r.data, selections);
-    const html = renderHtml(normalized, c.name);
-    const result = await savePdf(html);
-    addEvent(c.id, "audit_generated", { reportId: r.id, file: result.path });
-    res.json({ ok:true, url: result.url, warning: result.warning });
-  }catch(e){
-    res.status(500).json({ ok:false, error: String(e) });
-  }
-});
-
-// Check consumer email against Have I Been Pwned
-// Use POST so email isn't logged in query string
-app.post("/api/databreach", async (req, res) => {
-  const email = String(req.body.email || "").trim();
-  if (!email) return res.status(400).json({ ok: false, error: "Email required" });
-  const apiKey = process.env.HIBP_API_KEY;
-  if (!apiKey) return res.status(500).json({ ok: false, error: "HIBP API key not configured" });
-  try {
-    const hibpRes = await fetch(
-      `https://haveibeenpwned.com/api/v3/breachedaccount/${encodeURIComponent(email)}?truncateResponse=false`,
-      {
-        headers: {
-          "hibp-api-key": apiKey,
-          "user-agent": "crm-app"
-        }
-      }
-    );
-    if (hibpRes.status === 404) {
-      return res.json({ ok: true, breaches: [] });
-    }
-    if (!hibpRes.ok) {
-      const text = await hibpRes.text().catch(() => "");
-      return res
-        .status(hibpRes.status)
-        .json({ ok: false, error: text || `HIBP request failed (status ${hibpRes.status})` });
-    }
-    const data = await hibpRes.json();
-    res.json({ ok: true, breaches: data });
-  } catch (e) {
-    console.error("HIBP check failed", e);
-    res.status(500).json({ ok: false, error: "HIBP request failed" });
-  }
-});
-
-// =================== Letters & PDFs ===================
-const LETTERS_DIR = path.resolve("./letters");
-const JOBS_INDEX_PATH = path.join(LETTERS_DIR, "_jobs.json");
-
-app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
-  const db=loadDB();
-  const c=db.consumers.find(x=>x.id===req.params.id);
-  if(!c) return res.status(404).json({ ok:false, error:"Consumer not found" });
-  const r=c.reports.find(x=>x.id===req.params.rid);
-  if(!r) return res.status(404).json({ ok:false, error:"Report not found" });
-
-  const selections = Array.isArray(req.body?.selections) && req.body.selections.length
-    ? req.body.selections
-    : null;
-
-  try{
-    const normalized = normalizeReport(r.data, selections);
-    const html = renderHtml(normalized, c.name);
-    const result = await savePdf(html);
-    addEvent(c.id, "audit_generated", { reportId: r.id, file: result.path });
-    res.json({ ok:true, url: result.url, warning: result.warning });
-  }catch(e){
-    res.status(500).json({ ok:false, error: String(e) });
-  }
-});
-
-// Check consumer email against Have I Been Pwned
-// Use POST so email isn't logged in query string
-app.post("/api/databreach", async (req, res) => {
-  const email = String(req.body.email || "").trim();
-  if (!email) return res.status(400).json({ ok: false, error: "Email required" });
-  const apiKey = process.env.HIBP_API_KEY;
-  if (!apiKey) return res.status(500).json({ ok: false, error: "HIBP API key not configured" });
-  try {
-    const hibpRes = await fetch(
-      `https://haveibeenpwned.com/api/v3/breachedaccount/${encodeURIComponent(email)}?truncateResponse=false`,
-      {
-        headers: {
-          "hibp-api-key": apiKey,
-          "user-agent": "crm-app"
-        }
-      }
-    );
-    if (hibpRes.status === 404) {
-      return res.json({ ok: true, breaches: [] });
-    }
-    if (!hibpRes.ok) {
-      const text = await hibpRes.text().catch(() => "");
-      return res
-        .status(hibpRes.status)
-        .json({ ok: false, error: text || `HIBP request failed (status ${hibpRes.status})` });
-    }
-    const data = await hibpRes.json();
-    res.json({ ok: true, breaches: data });
-  } catch (e) {
-    console.error("HIBP check failed", e);
-    res.status(500).json({ ok: false, error: "HIBP request failed" });
-  }
-});
-
-// =================== Letters & PDFs ===================
-const LETTERS_DIR = path.resolve("./letters");
-const JOBS_INDEX_PATH = path.join(LETTERS_DIR, "_jobs.json");
-
-app.post("/api/consumers/:id/report/:rid/audit", async (req,res)=>{
-  const db=loadDB();
-  const c=db.consumers.find(x=>x.id===req.params.id);
-  if(!c) return res.status(404).json({ ok:false, error:"Consumer not found" });
-  const r=c.reports.find(x=>x.id===req.params.rid);
-  if(!r) return res.status(404).json({ ok:false, error:"Report not found" });
-
-  const selections = Array.isArray(req.body?.selections) && req.body.selections.length
-    ? req.body.selections
-    : null;
-
-  try{
-    const normalized = normalizeReport(r.data, selections);
-    const html = renderHtml(normalized, c.name);
-    const result = await savePdf(html);
-    addEvent(c.id, "audit_generated", { reportId: r.id, file: result.path });
-    res.json({ ok:true, url: result.url, warning: result.warning });
-  }catch(e){
-
-  const selections = Array.isArray(req.body?.selections) ? req.body.selections : [];
-  if(!selections.length) return res.status(400).json({ ok:false, error:"No selections provided" });
-
-  try{
-    const normalized = normalizeReport(r.data, selections);
-    const html = renderHtml(normalized, c.name);
-    const result = await savePdf(html);
-    addEvent(c.id, "audit_generated", { reportId: r.id, file: result.path });
-    res.json({ ok:true, url: result.url, warning: result.warning });
-  }catch(e){
-    res.status(500).json({ ok:false, error: String(e) });
-  }
-});
-
-// Check consumer email against Have I Been Pwned
-// Use POST so email isn't logged in query string
-app.post("/api/databreach", async (req, res) => {
-  const email = String(req.body.email || "").trim();
 app.get("/api/databreach", async (req, res) => {
   const email = String(req.query.email || "").trim();
   if (!email) return res.status(400).json({ ok: false, error: "Email required" });
-  const apiKey = process.env.HIBP_API_KEY;
-  if (!apiKey) return res.status(500).json({ ok: false, error: "HIBP API key not configured" });
-  try {
-    const hibpRes = await fetch(
-      `https://haveibeenpwned.com/api/v3/breachedaccount/${encodeURIComponent(email)}?truncateResponse=false`,
-      {
-        headers: {
-          "hibp-api-key": apiKey,
-          "user-agent": "crm-app"
-        }
-      }
-    );
-    if (hibpRes.status === 404) {
-      return res.json({ ok: true, breaches: [] });
-    }
-    if (!hibpRes.ok) {
-      const text = await hibpRes.text().catch(() => "");
-      return res
-        .status(hibpRes.status)
-        .json({ ok: false, error: text || `HIBP request failed (status ${hibpRes.status})` });
-    }
-    const data = await hibpRes.json();
-    res.json({ ok: true, breaches: data });
-  } catch (e) {
-    console.error("HIBP check failed", e);
-    res.status(500).json({ ok: false, error: "HIBP request failed" });
-  }
+  await handleDataBreach(email, res);
 });
 
 // =================== Letters & PDFs ===================


### PR DESCRIPTION
## Summary
- remove repeated server routes and deduplicate Letters & PDFs section
- add GET /api/databreach endpoint and clean POST handler
- fix client-side data breach check by removing duplicate fetch
- consolidate HIBP lookup into shared handler to avoid duplicated logic
- streamline letters endpoint by collapsing duplicate routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`
- `node --check public/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68ace8d215d48323b1ea4160c1c4cfbf