### PR TITLE
Handle spawn errors in Python analyzer

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -97,6 +97,10 @@ async function runPythonAnalyzer(htmlContent){
   py.stderr.on("data",d=>stderr+=d.toString());
 
   return new Promise((resolve,reject)=>{
+    py.on("error", async(err) => {
+      try { await fs.promises.rm(tmpDir,{recursive:true,force:true}); }catch{}
+      reject(err);
+    });
     py.on("close", async(code)=>{
       try{
         if(code!==0) throw new Error(`Analyzer exit ${code}\n${stderr}\n${stdout}`);


### PR DESCRIPTION
## Summary
- ensure the Python analyzer promise rejects on spawn failures by attaching an `error` listener

## Testing
- `npm test` *(fails: Missing script: "test")*
- Start server without Python in PATH and POST an upload -> receives 500 error


------
https://chatgpt.com/codex/tasks/task_e_68ad0068c7bc8323a4f577ec12727f89