### PR TITLE
feat: move tracker controls inline and add portal link

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -83,11 +83,14 @@
 <div class="max-w-7xl mx-auto">
   <div class="glass card space-y-4">
     <div>
-      <div class="font-medium mb-1">Client Tracker</div>
-      <div id="trackerSteps" class="flex flex-wrap gap-4 text-sm"></div>
-      <div id="stepControls" class="flex items-center gap-2 mt-2 text-sm">
-        <button id="addStep" class="btn text-sm" title="Add step">+</button>
+      <div class="flex items-center justify-between mb-1">
+        <div class="font-medium">Client Tracker</div>
+        <div id="stepControls" class="flex items-center gap-2 text-sm">
+          <a id="clientPortalLink" class="btn text-sm hidden" href="#" target="_blank">Client Portal</a>
+          <button id="addStep" class="btn text-sm" title="Add step">+</button>
+        </div>
       </div>
+      <div id="trackerSteps" class="flex flex-wrap gap-4 text-sm"></div>
     </div>
     <div>
         <div class="font-medium mb-2">Quick Actions</div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -17,6 +17,18 @@ const collectorSelection = {};
 const trackerData = JSON.parse(localStorage.getItem("trackerData")||"{}");
 const trackerSteps = JSON.parse(localStorage.getItem("trackerSteps") || '["Step 1","Step 2"]');
 
+function updatePortalLink(){
+  const a = $("#clientPortalLink");
+  if(!a) return;
+  if(currentConsumerId){
+    a.href = `/portal-${currentConsumerId}.html`;
+    a.classList.remove("hidden");
+  } else {
+    a.href = "#";
+    a.classList.add("hidden");
+  }
+}
+
 // ----- UI helpers -----
 function showErr(msg){
   const e = $("#err");
@@ -142,6 +154,7 @@ function renderConsumers(){
         $("#tlList").innerHTML = "";
         $("#selConsumer").textContent = "—";
         $("#activityList").innerHTML = "";
+        updatePortalLink();
       }
       loadConsumers();
     });
@@ -179,6 +192,7 @@ async function selectConsumer(id){
   currentConsumerId = id;
   const c = DB.consumers.find(x=>x.id===id);
   $("#selConsumer").textContent = c ? c.name : "—";
+  updatePortalLink();
   await refreshReports();
   await loadConsumerState();
   loadTracker();
@@ -1041,6 +1055,7 @@ $("#libraryModal").addEventListener("click", (e)=>{ if(e.target.id==="libraryMod
 // ===================== Init =====================
 loadConsumers();
 loadTracker();
+updatePortalLink();
 
 const companyName = localStorage.getItem("companyName");
 if (companyName) {


### PR DESCRIPTION
## Summary
- align tracker add button with header and include client portal link
- wire portal link to selected consumer

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adf425b220832392f823078e266fc8