### PR TITLE
feat: expand client portal and company management

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -8,28 +8,32 @@
 </head>
 <body>
 <header class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
-      <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/library" class="btn">Library</a>
-      <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+  <div class="max-w-3xl mx-auto flex items-center justify-between">
+    <div id="companyName" class="text-xl font-semibold">Client Portal</div>
+    <nav class="flex items-center gap-2">
+      <a id="navDashboard" href="#" class="btn">Dashboard</a>
+      <a href="#uploads" class="btn">My Uploads</a>
+    </nav>
   </div>
 </header>
-<main class="max-w-3xl mx-auto p-4">
-  <h1 class="text-2xl font-bold mb-4">Welcome, {{name}}</h1>
-  <p>This is your client access portal.</p>
-</main>
-<script src="/common.js"></script>
-  <script src="/hotkeys.js"></script>
+<main class="max-w-3xl mx-auto p-4 space-y-4">
+  <h1 class="text-2xl font-bold">Welcome, {{name}}</h1>
 
+  <div class="glass card">
+    <div class="font-medium mb-2">Current Step</div>
+    <div id="currentStep" class="text-lg">Loading...</div>
+  </div>
+
+  <div class="glass card">
+    <div class="font-medium mb-2">Our Team</div>
+    <div id="teamList" class="space-y-2 text-sm">Loading...</div>
+  </div>
+
+  <div class="glass card">
+    <div class="font-medium mb-2">News</div>
+    <div id="newsFeed" class="text-sm space-y-1">Loading...</div>
+  </div>
+</main>
+<script src="/client-portal.js"></script>
 </body>
 </html>

--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -1,0 +1,59 @@
+/* public/client-portal.js */
+document.addEventListener('DOMContentLoaded', () => {
+  const idMatch = location.pathname.match(/portal-(.+)\.html$/);
+  const consumerId = idMatch ? idMatch[1] : null;
+
+  const dash = document.getElementById('navDashboard');
+  if (dash) dash.href = location.pathname;
+
+  const company = JSON.parse(localStorage.getItem('companyInfo') || '{}');
+  if (company.name) {
+    const cn = document.getElementById('companyName');
+    if (cn) cn.textContent = company.name;
+  }
+
+  const teamList = document.getElementById('teamList');
+  const team = JSON.parse(localStorage.getItem('teamMembers') || '[]');
+  if (teamList) {
+    if (!team.length) {
+      teamList.textContent = 'No team members added.';
+    } else {
+      teamList.innerHTML = team.map(m => {
+        const role = m.role ? `<div class="text-xs muted">${m.role}${m.email? ' - ' + m.email : ''}</div>` : (m.email ? `<div class="text-xs muted">${m.email}</div>` : '');
+        return `<div class="news-item"><div class="font-medium">${m.name}</div>${role}</div>`;
+      }).join('');
+    }
+  }
+
+  const stepEl = document.getElementById('currentStep');
+  if (consumerId && stepEl) {
+    const steps = JSON.parse(localStorage.getItem('trackerSteps') || '[]');
+    const data = JSON.parse(localStorage.getItem('trackerData') || '{}')[consumerId] || {};
+    const idx = steps.findIndex(s => !data[s]);
+    let current = 'Completed';
+    if (idx !== -1) current = steps[idx];
+    stepEl.textContent = current;
+  }
+
+  const feedEl = document.getElementById('newsFeed');
+  if (feedEl) {
+    const rssUrl = 'https://hnrss.org/frontpage';
+    const apiUrl = 'https://api.rss2json.com/v1/api.json?rss_url=' + encodeURIComponent(rssUrl);
+    fetch(apiUrl)
+      .then(r => r.json())
+      .then(data => {
+        const items = data.items || [];
+        if (!items.length) {
+          feedEl.textContent = 'No news available.';
+          return;
+        }
+        feedEl.innerHTML = items.slice(0,5).map(item => `
+          <div class="news-item"><a href="${item.link}" target="_blank">${item.title}</a></div>
+        `).join('');
+      })
+      .catch(err => {
+        console.error('Failed to load news feed', err);
+        feedEl.textContent = 'Failed to load news.';
+      });
+  }
+});

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -4,7 +4,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (feedEl) {
     const rssUrl = 'https://hnrss.org/frontpage';
     const apiUrl = 'https://api.rss2json.com/v1/api.json?rss_url=' + encodeURIComponent(rssUrl);
-
     fetch(apiUrl)
       .then(r => r.json())
       .then(data => {
@@ -14,9 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
         feedEl.innerHTML = items.slice(0,5).map(item => {
-          const title = item.title;
-          const link = item.link;
-          return `<div><a href="${link}" target="_blank" class="text-blue-600 underline">${title}</a></div>`;
+          return `<div class="news-item"><a href="${item.link}" target="_blank" class="text-blue-600 underline">${item.title}</a></div>`;
         }).join('');
       })
       .catch(err => {
@@ -33,31 +30,4 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('dashNote', noteEl.value);
     });
   }
-
-
-
-
-  if (!feedEl) return;
-
-  const rssUrl = 'https://hnrss.org/frontpage';
-  const apiUrl = 'https://api.rss2json.com/v1/api.json?rss_url=' + encodeURIComponent(rssUrl);
-
-  fetch(apiUrl)
-    .then(r => r.json())
-    .then(data => {
-      const items = data.items || [];
-      if (!items.length) {
-        feedEl.textContent = 'No news available.';
-        return;
-      }
-      feedEl.innerHTML = items.slice(0,5).map(item => {
-        const title = item.title;
-        const link = item.link;
-        return `<div><a href="${link}" target="_blank" class="text-blue-600 underline">${title}</a></div>`;
-      }).join('');
-    })
-    .catch(err => {
-      console.error('Failed to load news feed', err);
-      feedEl.textContent = 'Failed to load news.';
-    });
 });

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -83,11 +83,14 @@
 <div class="max-w-7xl mx-auto">
   <div class="glass card space-y-4">
     <div>
-      <div class="font-medium mb-1">Client Tracker</div>
-      <div id="trackerSteps" class="flex flex-wrap gap-4 text-sm"></div>
-      <div id="stepControls" class="flex items-center gap-2 mt-2 text-sm">
-        <button id="addStep" class="btn text-sm" title="Add step">+</button>
+      <div class="flex items-center justify-between mb-1">
+        <div class="font-medium">Client Tracker</div>
+        <div id="stepControls" class="flex items-center gap-2 text-sm">
+          <a id="clientPortalLink" class="btn text-sm hidden" href="#" target="_blank">Client Portal</a>
+          <button id="addStep" class="btn text-sm" title="Add step">+</button>
+        </div>
       </div>
+      <div id="trackerSteps" class="flex flex-wrap gap-4 text-sm"></div>
     </div>
     <div>
         <div class="font-medium mb-2">Quick Actions</div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -17,6 +17,18 @@ const collectorSelection = {};
 const trackerData = JSON.parse(localStorage.getItem("trackerData")||"{}");
 const trackerSteps = JSON.parse(localStorage.getItem("trackerSteps") || '["Step 1","Step 2"]');
 
+function updatePortalLink(){
+  const a = $("#clientPortalLink");
+  if(!a) return;
+  if(currentConsumerId){
+    a.href = `/portal-${currentConsumerId}.html`;
+    a.classList.remove("hidden");
+  } else {
+    a.href = "#";
+    a.classList.add("hidden");
+  }
+}
+
 // ----- UI helpers -----
 function showErr(msg){
   const e = $("#err");
@@ -142,6 +154,7 @@ function renderConsumers(){
         $("#tlList").innerHTML = "";
         $("#selConsumer").textContent = "—";
         $("#activityList").innerHTML = "";
+        updatePortalLink();
       }
       loadConsumers();
     });
@@ -179,6 +192,7 @@ async function selectConsumer(id){
   currentConsumerId = id;
   const c = DB.consumers.find(x=>x.id===id);
   $("#selConsumer").textContent = c ? c.name : "—";
+  updatePortalLink();
   await refreshReports();
   await loadConsumerState();
   loadTracker();
@@ -1041,6 +1055,7 @@ $("#libraryModal").addEventListener("click", (e)=>{ if(e.target.id==="libraryMod
 // ===================== Init =====================
 loadConsumers();
 loadTracker();
+updatePortalLink();
 
 const companyName = localStorage.getItem("companyName");
 if (companyName) {

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -24,11 +24,31 @@
     </div>
   </div>
 </header>
-<main class="max-w-7xl mx-auto p-4">
-  <h1 class="text-2xl font-bold mb-4">My Company</h1>
-  <p>This is a placeholder for the My Company page.</p>
+<main class="max-w-3xl mx-auto p-4 space-y-4">
+  <h1 class="text-2xl font-bold">My Company</h1>
+
+  <div class="glass card space-y-2">
+    <div class="font-medium">Company Information</div>
+    <input id="companyName" class="w-full border rounded px-2 py-1 text-sm" placeholder="Company Name" />
+    <input id="companyPhone" class="w-full border rounded px-2 py-1 text-sm" placeholder="Phone" />
+    <input id="companyEmail" class="w-full border rounded px-2 py-1 text-sm" placeholder="Email" />
+    <textarea id="companyAddress" class="w-full border rounded px-2 py-1 text-sm" placeholder="Address"></textarea>
+    <button id="saveCompany" class="btn text-sm">Save</button>
+  </div>
+
+  <div class="glass card space-y-2">
+    <div class="font-medium">Team Members</div>
+    <div id="teamMemberList" class="space-y-2 text-sm"></div>
+    <div class="flex flex-col sm:flex-row gap-2">
+      <input id="tmName" class="flex-1 border rounded px-2 py-1 text-sm" placeholder="Name" />
+      <input id="tmRole" class="flex-1 border rounded px-2 py-1 text-sm" placeholder="Role" />
+      <input id="tmEmail" class="flex-1 border rounded px-2 py-1 text-sm" placeholder="Email" />
+      <button id="addTeamMember" class="btn text-sm">Add</button>
+    </div>
+  </div>
 </main>
 <script src="/common.js"></script>
-  <script src="/hotkeys.js"></script>
+<script src="/hotkeys.js"></script>
+<script src="/my-company.js"></script>
 </body>
 </html>

--- a/metro2 (copy 1)/crm/public/my-company.js
+++ b/metro2 (copy 1)/crm/public/my-company.js
@@ -1,0 +1,70 @@
+/* public/my-company.js */
+document.addEventListener('DOMContentLoaded', () => {
+  const nameEl = document.getElementById('companyName');
+  const phoneEl = document.getElementById('companyPhone');
+  const emailEl = document.getElementById('companyEmail');
+  const addrEl = document.getElementById('companyAddress');
+  const saveBtn = document.getElementById('saveCompany');
+
+  const company = JSON.parse(localStorage.getItem('companyInfo') || '{}');
+  if (nameEl) nameEl.value = company.name || '';
+  if (phoneEl) phoneEl.value = company.phone || '';
+  if (emailEl) emailEl.value = company.email || '';
+  if (addrEl) addrEl.value = company.address || '';
+
+  if (saveBtn) {
+    saveBtn.addEventListener('click', () => {
+      const data = {
+        name: nameEl.value.trim(),
+        phone: phoneEl.value.trim(),
+        email: emailEl.value.trim(),
+        address: addrEl.value.trim(),
+      };
+      localStorage.setItem('companyInfo', JSON.stringify(data));
+    });
+  }
+
+  let members = JSON.parse(localStorage.getItem('teamMembers') || '[]');
+  const listEl = document.getElementById('teamMemberList');
+  function renderMembers() {
+    if (!listEl) return;
+    if (!members.length) {
+      listEl.innerHTML = '<div class="muted text-sm">No team members.</div>';
+      return;
+    }
+    listEl.innerHTML = members.map((m,i) => `
+      <div class="flex items-center justify-between border rounded px-2 py-1">
+        <div>
+          <div class="font-medium">${m.name}</div>
+          <div class="text-xs muted">${m.role || ''}${m.email ? ' - ' + m.email : ''}</div>
+        </div>
+        <button data-index="${i}" class="text-red-500 text-xs remove-member">Remove</button>
+      </div>
+    `).join('');
+    listEl.querySelectorAll('.remove-member').forEach(btn => {
+      btn.addEventListener('click', e => {
+        const idx = parseInt(e.target.dataset.index, 10);
+        members.splice(idx,1);
+        localStorage.setItem('teamMembers', JSON.stringify(members));
+        renderMembers();
+      });
+    });
+  }
+  renderMembers();
+
+  const addBtn = document.getElementById('addTeamMember');
+  if (addBtn) {
+    addBtn.addEventListener('click', () => {
+      const n = document.getElementById('tmName');
+      const r = document.getElementById('tmRole');
+      const e = document.getElementById('tmEmail');
+      if (!n.value.trim()) return;
+      members.push({ name: n.value.trim(), role: r.value.trim(), email: e.value.trim() });
+      localStorage.setItem('teamMembers', JSON.stringify(members));
+      n.value = '';
+      r.value = '';
+      e.value = '';
+      renderMembers();
+    });
+  }
+});

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -75,3 +75,15 @@ body {
   cursor: pointer;
 }
 
+.news-item {
+  padding: 4px 0;
+  border-bottom: 1px solid var(--glass-brd);
+}
+.news-item a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.news-item:last-child {
+  border-bottom: none;
+}
+


### PR DESCRIPTION
## Summary
- add client-facing dashboard with progress, team, and news sections
- allow storing company info and team members
- style RSS news items across dashboard and portal

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68adf425b220832392f823078e266fc8