### PR TITLE
Add PDF download option to letter cards

### DIFF
--- a/metro2 (copy 1)/crm/public/letters.js
+++ b/metro2 (copy 1)/crm/public/letters.js
@@ -54,6 +54,7 @@ function renderCards(){
         </div>
         <div class="flex gap-2">
           <a class="btn text-sm open-html" href="${L.htmlUrl}" target="_blank" data-tip="Open HTML (H)">Open HTML</a>
+          <a class="btn text-sm" href="/api/letters/${encodeURIComponent(JOB_ID)}/${L.index}.pdf" data-tip="Download PDF">Download PDF</a>
           <button class="btn text-sm do-print" data-tip="Print (P)">Print</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a Download PDF link beside each letter card

## Testing
- `npm test` *(fails: Missing script "test")*
- `curl -I http://localhost:3000/api/letters/a324b12de401120c/0.pdf` *(404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae60c0fdbc8323ab2bc9b6497db03f