### PR TITLE
fix letters directory path resolution

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -541,7 +541,7 @@ app.get("/api/databreach", async (req, res) => {
 
 
 // =================== Letters & PDFs ===================
-const LETTERS_DIR = path.resolve("./letters");
+const LETTERS_DIR = path.join(__dirname, "letters");
 fs.mkdirSync(LETTERS_DIR,{ recursive:true });
 const JOBS_INDEX_PATH = path.join(LETTERS_DIR, "_jobs.json");
 


### PR DESCRIPTION
## Summary
- ensure letters directory resolves relative to server file using `__dirname`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js` followed by `curl -X POST /api/generate` and `curl /api/letters`


------
https://chatgpt.com/codex/tasks/task_e_68ae8c969c048323bd1f5a651db738b1