### PR TITLE
Improve notes saving, add client portal link, and fix billing client selection

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -107,13 +107,13 @@ function bindHelp(){
   document.getElementById('helpModal')?.addEventListener('click', (e)=>{ if(e.target.id==='helpModal') closeHelp(); });
 }
 
+window.selectedConsumerId = localStorage.getItem('selectedConsumerId') || null;
+
 document.addEventListener('DOMContentLoaded', ()=>{
   ensureHelpModal();
   bindHelp();
   initPalette();
   initVoiceNotes();
-  window.selectedConsumerId = localStorage.getItem('selectedConsumerId') || null;
-
 });
 
 window.openHelp = openHelp;

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -149,6 +149,7 @@
           <div class="flex items-center gap-2">
             <input id="activityFile" type="file" class="hidden" />
             <button id="btnAddFile" class="btn" data-tip="Upload file to this consumer">+ Add File</button>
+            <a id="activityPortalLink" class="btn hidden" href="#" target="_blank">Client Portal</a>
           </div>
         </div>
         <div id="activityList" class="space-y-2 text-sm max-h-48 overflow-y-auto"></div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -18,16 +18,17 @@ const trackerData = JSON.parse(localStorage.getItem("trackerData")||"{}");
 const trackerSteps = JSON.parse(localStorage.getItem("trackerSteps") || '["Step 1","Step 2"]');
 
 function updatePortalLink(){
-  const a = $("#clientPortalLink");
-  if(!a) return;
-  if(currentConsumerId){
-    a.href = `/portal/${currentConsumerId}`;
-
-    a.classList.remove("hidden");
-  } else {
-    a.href = "#";
-    a.classList.add("hidden");
-  }
+  const links = ["#clientPortalLink", "#activityPortalLink"].map(sel => $(sel));
+  links.forEach(a => {
+    if(!a) return;
+    if(currentConsumerId){
+      a.href = `/portal/${currentConsumerId}`;
+      a.classList.remove("hidden");
+    } else {
+      a.href = "#";
+      a.classList.add("hidden");
+    }
+  });
 }
 
 // ----- UI helpers -----


### PR DESCRIPTION
## Summary
- Avoid duplicate dashboard notepad entries by updating existing note when saving
- Added auto-save for dashboard notes
- Added client portal shortcut next to Add File in Files & Activity
- Ensure Billing page loads when a client is already selected

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af084419e883239fa635afdbb75ed7