### PR TITLE
Separate education and documents into their own sections

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -46,20 +46,9 @@
     <div id="reportSnapshot" class="text-sm space-y-1">No data.</div>
   </div>
 
-  <div id="educationSection" class="glass card">
-    <div class="font-medium mb-2">Education</div>
-    <div id="education" class="text-sm space-y-1">No educational items.</div>
-  </div>
-
   <div class="glass card">
-
     <div class="font-medium mb-2">Milestones</div>
     <div id="milestones" class="text-sm space-y-1">No milestones yet.</div>
-  </div>
-
-  <div id="documentSection" class="glass card">
-    <div class="font-medium mb-2">Document Center</div>
-    <div id="docList" class="text-sm space-y-1">No documents uploaded.</div>
   </div>
 
   <div class="glass card">
@@ -105,6 +94,18 @@
     <input id="messageInput" class="input flex-1" placeholder="Type message..." />
     <button class="btn" type="submit">Send</button>
   </form>
+</div>
+<div id="educationSection" class="max-w-3xl mx-auto p-4 hidden">
+  <div class="glass card">
+    <div class="font-medium mb-2">Education</div>
+    <div id="education" class="text-sm space-y-1">No educational items.</div>
+  </div>
+</div>
+<div id="documentSection" class="max-w-3xl mx-auto p-4 hidden">
+  <div class="glass card">
+    <div class="font-medium mb-2">Document Center</div>
+    <div id="docList" class="text-sm space-y-1">No documents uploaded.</div>
+  </div>
 </div>
 <script src="/client-portal.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -167,22 +167,30 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // Handle uploads view
+  // Handle section navigation
   const portalMain = document.getElementById('portalMain');
   const uploadSection = document.getElementById('uploadSection');
+  const educationSection = document.getElementById('educationSection');
+  const documentSection = document.getElementById('documentSection');
   function showSection(hash){
-    if (hash === '#uploads') {
-      portalMain.classList.add('hidden');
+    if (portalMain) portalMain.classList.add('hidden');
+    if (uploadSection) uploadSection.classList.add('hidden');
+    if (messageSection) messageSection.classList.add('hidden');
+    if (educationSection) educationSection.classList.add('hidden');
+    if (documentSection) documentSection.classList.add('hidden');
+
+    if (hash === '#uploads' && uploadSection) {
       uploadSection.classList.remove('hidden');
-      if(messageSection) messageSection.classList.add('hidden');
-    } else if (hash === '#messages') {
-      portalMain.classList.add('hidden');
-      uploadSection.classList.add('hidden');
-      if(messageSection) { messageSection.classList.remove('hidden'); loadMessages(); }
-    } else {
+    } else if (hash === '#messages' && messageSection) {
+      messageSection.classList.remove('hidden');
+      loadMessages();
+    } else if (hash === '#educationSection' && educationSection) {
+      educationSection.classList.remove('hidden');
+    } else if (hash === '#documentSection' && documentSection) {
+      documentSection.classList.remove('hidden');
+      loadDocs();
+    } else if (portalMain) {
       portalMain.classList.remove('hidden');
-      uploadSection.classList.add('hidden');
-      if(messageSection) messageSection.classList.add('hidden');
     }
   }
   showSection(location.hash);


### PR DESCRIPTION
## Summary
- Move education content from the dashboard to a dedicated education section
- Relocate document center to a dedicated documents section
- Update section navigation logic to show/hide new pages and refresh documents when opened

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af329961d88323beb7a20495f455b2