### PR TITLE
Add client location map and lively dashboard elements

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -46,20 +46,9 @@
     <div id="reportSnapshot" class="text-sm space-y-1">No data.</div>
   </div>
 
-  <div id="educationSection" class="glass card">
-    <div class="font-medium mb-2">Education</div>
-    <div id="education" class="text-sm space-y-1">No educational items.</div>
-  </div>
-
   <div class="glass card">
-
     <div class="font-medium mb-2">Milestones</div>
     <div id="milestones" class="text-sm space-y-1">No milestones yet.</div>
-  </div>
-
-  <div id="documentSection" class="glass card">
-    <div class="font-medium mb-2">Document Center</div>
-    <div id="docList" class="text-sm space-y-1">No documents uploaded.</div>
   </div>
 
   <div class="glass card">
@@ -105,6 +94,18 @@
     <input id="messageInput" class="input flex-1" placeholder="Type message..." />
     <button class="btn" type="submit">Send</button>
   </form>
+</div>
+<div id="educationSection" class="max-w-3xl mx-auto p-4 hidden">
+  <div class="glass card">
+    <div class="font-medium mb-2">Education</div>
+    <div id="education" class="text-sm space-y-1">No educational items.</div>
+  </div>
+</div>
+<div id="documentSection" class="max-w-3xl mx-auto p-4 hidden">
+  <div class="glass card">
+    <div class="font-medium mb-2">Document Center</div>
+    <div id="docList" class="text-sm space-y-1">No documents uploaded.</div>
+  </div>
 </div>
 <script src="/client-portal.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -167,22 +167,30 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // Handle uploads view
+  // Handle section navigation
   const portalMain = document.getElementById('portalMain');
   const uploadSection = document.getElementById('uploadSection');
+  const educationSection = document.getElementById('educationSection');
+  const documentSection = document.getElementById('documentSection');
   function showSection(hash){
-    if (hash === '#uploads') {
-      portalMain.classList.add('hidden');
+    if (portalMain) portalMain.classList.add('hidden');
+    if (uploadSection) uploadSection.classList.add('hidden');
+    if (messageSection) messageSection.classList.add('hidden');
+    if (educationSection) educationSection.classList.add('hidden');
+    if (documentSection) documentSection.classList.add('hidden');
+
+    if (hash === '#uploads' && uploadSection) {
       uploadSection.classList.remove('hidden');
-      if(messageSection) messageSection.classList.add('hidden');
-    } else if (hash === '#messages') {
-      portalMain.classList.add('hidden');
-      uploadSection.classList.add('hidden');
-      if(messageSection) { messageSection.classList.remove('hidden'); loadMessages(); }
-    } else {
+    } else if (hash === '#messages' && messageSection) {
+      messageSection.classList.remove('hidden');
+      loadMessages();
+    } else if (hash === '#educationSection' && educationSection) {
+      educationSection.classList.remove('hidden');
+    } else if (hash === '#documentSection' && documentSection) {
+      documentSection.classList.remove('hidden');
+      loadDocs();
+    } else if (portalMain) {
       portalMain.classList.remove('hidden');
-      uploadSection.classList.add('hidden');
-      if(messageSection) messageSection.classList.add('hidden');
     }
   }
   showSection(location.hash);

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -5,6 +5,16 @@
   <title>Dashboard</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1j7k8fBRT1Q9ir3R8A4bMHt0gXu6p0UmmE8Zy+3E=" crossorigin="" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-oEnJPhGf6QjaxzX2LeLYI0m0CMvYZRyGmA4KQ1uYf3s=" crossorigin=""></script>
+  <style>
+    @keyframes blob{0%,100%{transform:translate(0,0);}33%{transform:translate(15px,-10px);}66%{transform:translate(-10px,10px);}}
+    .animate-blob{animation:blob 10s ease-in-out infinite;}
+    @keyframes fadeInUp{from{opacity:0;transform:translateY(10px);}to{opacity:1;transform:translateY(0);}}
+    .animate-fadeInUp{animation:fadeInUp .6s ease-out both;}
+    .confetti-piece{position:absolute;width:6px;height:6px;border-radius:1px;animation:confetti 1.2s ease-out forwards;}
+    @keyframes confetti{to{transform:translate(var(--tx),var(--ty)) rotate(720deg);opacity:0;}}
+  </style>
 </head>
 <body>
 <header class="p-4">
@@ -21,10 +31,22 @@
       <a href="/library" class="btn">Library</a>
       <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <div id="streakPill" class="hidden sm:flex items-center gap-2 rounded-full bg-orange-100 px-4 py-2 text-orange-700 shadow-sm animate-fadeInUp">
+        <span class="animate-pulse text-xl">🔥</span>
+        <span class="font-semibold text-sm">7-day streak</span>
+      </div>
     </div>
   </div>
 </header>
 <main class="max-w-7xl mx-auto p-4 space-y-4">
+  <div class="glass card relative overflow-hidden">
+    <div class="pointer-events-none absolute -top-16 -right-16 h-56 w-56 rounded-full bg-gradient-to-tr from-emerald-400 to-cyan-400 opacity-20 blur-3xl animate-blob"></div>
+    <h2 class="mb-2 text-2xl font-bold">Welcome back!</h2>
+    <p class="text-sm text-gray-600">Let’s knock out today’s tasks.</p>
+    <button id="btnGoal" class="mt-4 rounded-full bg-emerald-500 px-5 py-2.5 font-semibold text-white shadow hover:brightness-110 active:scale-95">Mark Today’s Goal Done</button>
+    <div id="confetti" class="pointer-events-none absolute inset-0"></div>
+  </div>
+
   <div class="glass card">
     <div class="font-medium mb-2">News</div>
     <div id="newsFeed" class="text-sm space-y-1">Loading...</div>
@@ -98,6 +120,11 @@
     <div class="glass card">
       <div class="font-medium mb-2">Company Deletion Statistics</div>
       <div id="dashDeletion" class="text-sm muted">No data</div>
+    </div>
+
+    <div class="glass card md:col-span-2 lg:col-span-3">
+      <div class="font-medium mb-2">Client Locations</div>
+      <div id="clientMap" class="w-full h-64 rounded-lg"></div>
     </div>
 
   </div>

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -1,5 +1,55 @@
 /* public/dashboard.js */
 function escapeHtml(s){ return String(s||"").replace(/[&<>"']/g, c=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;' }[c])); }
+
+const stateCenters = {
+  AL:[32.806671,-86.79113], AK:[61.370716,-152.404419], AZ:[33.729759,-111.431221], AR:[34.969704,-92.373123],
+  CA:[36.116203,-119.681564], CO:[39.059811,-105.311104], CT:[41.597782,-72.755371], DE:[39.318523,-75.507141],
+  FL:[27.766279,-81.686783], GA:[33.040619,-83.643074], HI:[21.094318,-157.498337], ID:[44.240459,-114.478828],
+  IL:[40.349457,-88.986137], IN:[39.849426,-86.258278], IA:[42.011539,-93.210526], KS:[38.5266,-96.726486],
+  KY:[37.66814,-84.670067], LA:[31.169546,-91.867805], ME:[44.693947,-69.381927], MD:[39.063946,-76.802101],
+  MA:[42.230171,-71.530106], MI:[43.326618,-84.536095], MN:[45.694454,-93.900192], MS:[32.741646,-89.678696],
+  MO:[38.456085,-92.288368], MT:[46.921925,-110.454353], NE:[41.12537,-98.268082], NV:[38.313515,-117.055374],
+  NH:[43.452492,-71.563896], NJ:[40.298904,-74.521011], NM:[34.840515,-106.248482], NY:[42.165726,-74.948051],
+  NC:[35.630066,-79.806419], ND:[47.528912,-99.784012], OH:[40.388783,-82.764915], OK:[35.565342,-96.928917],
+  OR:[44.572021,-122.070938], PA:[40.590752,-77.209755], RI:[41.680893,-71.51178], SC:[33.856892,-80.945007],
+  SD:[44.299782,-99.438828], TN:[35.747845,-86.692345], TX:[31.054487,-97.563461], UT:[40.150032,-111.862434],
+  VT:[44.045876,-72.710686], VA:[37.769337,-78.169968], WA:[47.400902,-121.490494], WV:[38.491226,-80.954453],
+  WI:[44.268543,-89.616508], WY:[42.755966,-107.30249], DC:[38.897438,-77.026817]
+};
+const stateNames = {
+  AL:"Alabama", AK:"Alaska", AZ:"Arizona", AR:"Arkansas", CA:"California", CO:"Colorado", CT:"Connecticut",
+  DE:"Delaware", FL:"Florida", GA:"Georgia", HI:"Hawaii", ID:"Idaho", IL:"Illinois", IN:"Indiana", IA:"Iowa",
+  KS:"Kansas", KY:"Kentucky", LA:"Louisiana", ME:"Maine", MD:"Maryland", MA:"Massachusetts", MI:"Michigan",
+  MN:"Minnesota", MS:"Mississippi", MO:"Missouri", MT:"Montana", NE:"Nebraska", NV:"Nevada", NH:"New Hampshire",
+  NJ:"New Jersey", NM:"New Mexico", NY:"New York", NC:"North Carolina", ND:"North Dakota", OH:"Ohio",
+  OK:"Oklahoma", OR:"Oregon", PA:"Pennsylvania", RI:"Rhode Island", SC:"South Carolina", SD:"South Dakota",
+  TN:"Tennessee", TX:"Texas", UT:"Utah", VT:"Vermont", VA:"Virginia", WA:"Washington", WV:"West Virginia",
+  WI:"Wisconsin", WY:"Wyoming", DC:"District of Columbia"
+};
+Object.entries(stateNames).forEach(([abbr,name])=>{ stateCenters[name.toUpperCase()] = stateCenters[abbr]; });
+function getStateCode(st){
+  if(!st) return null;
+  st = st.trim().toUpperCase();
+  if(stateCenters[st]) return st;
+  const entry = Object.entries(stateNames).find(([,name]) => name.toUpperCase() === st);
+  return entry ? entry[0] : null;
+}
+function renderClientMap(consumers){
+  const mapEl = document.getElementById('clientMap');
+  if(!mapEl) return;
+  const map = L.map(mapEl).setView([37.8,-96],4);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{ attribution:'© OpenStreetMap contributors'}).addTo(map);
+  consumers.forEach(c=>{
+    const code = getStateCode(c.state);
+    const coords = stateCenters[code];
+    if(coords){
+      L.circleMarker(coords,{ radius:6, color:'#059669', fillColor:'#10b981', fillOpacity:0.7 })
+        .addTo(map)
+        .bindPopup(c.name || '');
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const feedEl = document.getElementById('newsFeed');
   if (feedEl) {
@@ -71,6 +121,25 @@ document.addEventListener('DOMContentLoaded', () => {
     titleEl.addEventListener('input', scheduleAutoSave);
   }
 
+  const goalBtn = document.getElementById('btnGoal');
+  if(goalBtn){
+    const confettiEl = document.getElementById('confetti');
+    goalBtn.addEventListener('click', () => {
+      if(!confettiEl) return;
+      for(let i=0;i<20;i++){
+        const s=document.createElement('span');
+        s.className='confetti-piece';
+        const tx=(Math.random()-0.5)*200;
+        const ty=(-Math.random()*150-50);
+        s.style.setProperty('--tx', tx+'px');
+        s.style.setProperty('--ty', ty+'px');
+        s.style.backgroundColor=`hsl(${Math.random()*360},80%,60%)`;
+        confettiEl.appendChild(s);
+        setTimeout(()=>s.remove(),1200);
+      }
+    });
+  }
+
   Promise.all([
     fetch('/api/consumers').then(r => r.json()),
     fetch('/api/leads').then(r => r.json())
@@ -98,7 +167,7 @@ document.addEventListener('DOMContentLoaded', () => {
       set('dashRetention', retention.toFixed(1)+"%");
       const convEl = document.getElementById('dashConversion');
       if(convEl) convEl.textContent = conversion.toFixed(1)+"%";
-
+      renderClientMap(consumers);
     })
     .catch(err=> console.error('Failed to load dashboard stats', err));
 });


### PR DESCRIPTION
## Summary
- Move education content from the dashboard to a dedicated education section
- Relocate document center to a dedicated documents section
- Introduce welcoming streak UI and confetti micro-interaction on the dashboard
- Visualize client distribution across the US with a Leaflet-based map

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af329961d88323beb7a20495f455b2