### PR TITLE
Remove letter editing functionality

### DIFF
--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -84,14 +84,11 @@
       <div class="flex items-center gap-2">
         <a id="pvOpen" target="_blank" class="btn">Open HTML</a>
         <button id="pvPrint" class="btn">Print</button>
-        <button id="pvEdit" class="btn">Edit</button>
-        <button id="pvSave" class="btn hidden">Save</button>
         <button id="pvClose" class="btn">Close</button>
       </div>
     </header>
     <div id="pvBody" class="flex flex-1">
       <iframe id="pvFrame" class="flex-1 h-full" src="about:blank"></iframe>
-      <textarea id="pvEditor" class="hidden flex-1 h-full p-2 text-sm"></textarea>
     </div>
   </div>
 </div>

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -829,31 +829,6 @@ app.get("/api/letters/:jobId/:idx.html", (req,res)=>{
   res.send(L.html);
 });
 
-app.put("/api/letters/:jobId/:idx", async (req,res)=>{
-  const { jobId, idx } = req.params;
-  const html = req.body?.html;
-  if(typeof html !== "string") return res.status(400).json({ ok:false, error:"Missing html" });
-  console.log(`Updating letter ${idx} for job ${jobId}`);
-  let job = getJobMem(jobId);
-  if(job){
-    const L = job.letters[Number(idx)];
-    if(!L) return res.status(404).json({ ok:false, error:"Letter not found" });
-    L.html = html;
-    try{ fs.writeFileSync(path.join(LETTERS_DIR, L.filename), html); }
-    catch(e){ return res.status(500).json({ ok:false, error:String(e) }); }
-    console.log(`Letter ${L.filename} updated on disk`);
-    return res.json({ ok:true });
-  }
-  const disk = loadJobFromDisk(jobId);
-  if(!disk) return res.status(404).json({ ok:false, error:"Job not found" });
-  const Lm = disk.letters[Number(idx)];
-  if(!Lm) return res.status(404).json({ ok:false, error:"Letter not found" });
-  try{ fs.writeFileSync(Lm.htmlPath, html); }
-  catch(e){ return res.status(500).json({ ok:false, error:String(e) }); }
-  console.log(`Letter ${Lm.htmlPath} updated on disk`);
-  res.json({ ok:true });
-});
-
 // Render letter PDF on-the-fly
 app.get("/api/letters/:jobId/:idx.pdf", async (req,res)=>{
   const { jobId, idx } = req.params;


### PR DESCRIPTION
## Summary
- remove Edit and Save controls from letter preview UI
- drop API endpoint for updating letter HTML

## Testing
- `node --check 'metro2 (copy 1)/crm/public/letters.js'`
- `node --check 'metro2 (copy 1)/crm/server.js'`
- `cd 'metro2 (copy 1)/crm' && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af4b6faa208323af7a183eac174a83