### PR TITLE
feat: show deletion and product tiers on dashboards

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -11,6 +11,8 @@
       .animate-blob{animation:blob 10s ease-in-out infinite;}
       .confetti-piece{position:absolute;width:6px;height:6px;border-radius:1px;animation:confetti 1.2s ease-out forwards;}
       @keyframes confetti{to{transform:translate(var(--tx),var(--ty)) rotate(720deg);opacity:0;}}
+    @keyframes fadeInUp{from{opacity:0;transform:translateY(10px);}to{opacity:1;transform:translateY(0);}}
+    .animate-fadeInUp{animation:fadeInUp .6s ease-out both;}
     .btn{position:relative;overflow:hidden;}
     .btn span.ripple{position:absolute;border-radius:50%;transform:scale(0);animation:ripple 700ms ease-out;background:rgba(255,255,255,0.6);}
     @keyframes ripple{to{transform:scale(3);opacity:0;}}
@@ -35,9 +37,9 @@
       <a href="#educationSection" class="btn">Education</a>
       
     </nav>
-    <div id="streakPill" class="hidden sm:flex items-center gap-2 rounded-full bg-orange-100 px-4 py-2 text-orange-700 shadow-sm">
-      <span class="animate-pulse text-xl">🔥</span>
-      <span class="font-semibold text-sm">7-day streak</span>
+    <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You’ve planted the seed — secured cards are your first step to building credit.">
+      <span class="text-xl">🔒</span>
+      <span class="font-semibold text-sm">Secured Start</span>
     </div>
   </div>
 </header>
@@ -83,6 +85,7 @@
       <div id="timelineEmpty" class="w-32 h-32"></div>
       <div id="timelineText" class="mt-2">No disputes yet.</div>
     </div>
+    <div id="disputeSummary" class="text-sm mt-2"></div>
   </div>
 
   <div class="glass card">

--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -1,8 +1,43 @@
 /* public/client-portal.js */
+const productTiers = [
+  { deletions:150, score:780, name:'Wealth Builder', icon:'👑', class:'bg-gradient-to-r from-purple-400 to-pink-500 text-white', message:'Legendary status — mortgages, lines, and cards all bend in your favor. You’ve built true financial freedom.' },
+  { deletions:125, score:760, name:'Elite Borrower', icon:'🦸', class:'bg-red-100 text-red-700', message:'You’ve achieved elite borrower status — lenders see you as top-tier.' },
+  { deletions:100, score:750, name:'Funding Power', icon:'🏆', class:'bg-yellow-200 text-yellow-800', message:'You’ve become a funding champion — major approvals are within reach.' },
+  { deletions:75, score:740, name:'Travel & Rewards', icon:'✈️', class:'bg-indigo-100 text-indigo-700', message:'You now qualify for premium travel rewards and lifestyle cards.' },
+  { deletions:50, score:720, name:'Credit Line Access', icon:'💼', class:'bg-blue-100 text-blue-700', message:'Business and personal credit lines are opening up.' },
+  { deletions:40, score:700, name:'Mortgage Ready', icon:'🏡', class:'bg-green-100 text-green-700', message:'You’re building toward homeownership — mortgage approvals are now within reach.' },
+  { deletions:30, score:680, name:'Loan Lever', icon:'🏦', class:'bg-lime-100 text-lime-700', message:'Personal loan doors are opening — leverage your clean report.' },
+  { deletions:20, score:650, name:'Prime Plastic', icon:'💳', class:'bg-cyan-100 text-cyan-700', message:'You’re climbing into prime cards with real rewards.' },
+  { deletions:10, score:0, name:'Auto Access', icon:'🚗', class:'bg-orange-100 text-orange-700', message:'Now you’re positioned for auto financing approvals.' },
+  { deletions:5, score:0, name:'Retail Ready', icon:'🛍️', class:'bg-emerald-100 text-emerald-700', message:'You’re ready for retail cards — momentum is building.' },
+  { deletions:1, score:0, name:'Approval Spark', icon:'✅', class:'bg-emerald-100 text-emerald-700', message:'Your first approval spark — you’re clearing the way for credit opportunities.' },
+  { deletions:0, score:0, name:'Secured Start', icon:'🔒', class:'bg-emerald-100 text-emerald-700', message:'You’ve planted the seed — secured cards are your first step to building credit.' },
+];
+
+function getProductTier(deletions, score){
+  for(const tier of productTiers){
+    if(deletions >= tier.deletions && (!tier.score || score >= tier.score)) return tier;
+  }
+  return productTiers[productTiers.length-1];
+}
+
+function renderProductTier(){
+  const el = document.getElementById('tierBadge');
+  if(!el) return;
+  const deletions = Number(localStorage.getItem('deletions') || 0);
+  const scoreData = JSON.parse(localStorage.getItem('creditScore') || '{"current":0}');
+  const score = Number(scoreData.current || 0);
+  const tier = getProductTier(deletions, score);
+  el.className = `hidden sm:flex items-center gap-2 rounded-full px-4 py-2 shadow-sm animate-fadeInUp ${tier.class}`;
+  el.innerHTML = `<span class="text-xl">${tier.icon}</span><span class="font-semibold text-sm">${tier.name}</span>`;
+  el.title = tier.message;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const idMatch = location.pathname.match(/\/portal\/(.+)$/);
 
   const consumerId = idMatch ? idMatch[1] : null;
+  renderProductTier();
 
   const dash = document.getElementById('navDashboard');
   if (dash) dash.href = location.pathname;
@@ -106,9 +141,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  const timeline = JSON.parse(localStorage.getItem('disputeTimeline') || '[]');
   const timelineEl = document.getElementById('timeline');
   if (timelineEl) {
-    const timeline = JSON.parse(localStorage.getItem('disputeTimeline') || '[]');
     if (!timeline.length) {
       const empty = document.getElementById('timelineEmpty');
       if (empty && window.lottie) {
@@ -126,6 +161,17 @@ document.addEventListener('DOMContentLoaded', () => {
       const te = document.getElementById('timelineEmpty');
       if (te) te.remove();
       timelineEl.innerHTML = timeline.map(t => `<div class="timeline-item"><span class="font-medium">${t.account}</span> - ${t.stage}</div>`).join('');
+    }
+  }
+
+  const summaryEl = document.getElementById('disputeSummary');
+  if(summaryEl){
+    const perRound = 10;
+    if(timeline.length){
+      const rounds = Math.ceil(timeline.length / perRound);
+      summaryEl.textContent = `${timeline.length} items across ${rounds} round${rounds===1?'':'s'} (${perRound} per round)`;
+    } else {
+      summaryEl.textContent = 'No disputes yet.';
     }
   }
 

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -31,9 +31,9 @@
       <a href="/library" class="btn">Library</a>
       <button id="btnCreditors" class="btn" data-tip="Creditor Library">Creditors</button>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-      <div id="streakPill" class="hidden sm:flex items-center gap-2 rounded-full bg-orange-100 px-4 py-2 text-orange-700 shadow-sm animate-fadeInUp">
-        <span class="animate-pulse text-xl">🔥</span>
-        <span class="font-semibold text-sm">7-day streak</span>
+      <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You've started your journey.">
+        <span class="text-xl">📄</span>
+        <span class="font-semibold text-sm">Rookie</span>
       </div>
     </div>
   </div>

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -1,6 +1,39 @@
 /* public/dashboard.js */
 function escapeHtml(s){ return String(s||"").replace(/[&<>"']/g, c=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;' }[c])); }
 
+const deletionTiers = [
+  { threshold: 150, name: 'Credit Legend', icon: '👑', class: 'bg-gradient-to-r from-purple-400 to-pink-500 text-white', message: 'The ultimate, rare achievement.' },
+  { threshold: 125, name: 'Credit Hero', icon: '🦸', class: 'bg-red-100 text-red-700', message: 'You’re now the hero of your credit story.' },
+  { threshold: 100, name: 'Credit Champion', icon: '🏆', class: 'bg-yellow-200 text-yellow-800', message: 'Championing your credit victory.' },
+  { threshold: 75, name: 'Credit Warrior', icon: '🛡️', class: 'bg-indigo-100 text-indigo-700', message: 'Battle-ready credit repair fighter.' },
+  { threshold: 60, name: 'Credit Surgeon', icon: '🩺', class: 'bg-cyan-100 text-cyan-700', message: 'Precision deletions.' },
+  { threshold: 50, name: 'Dispute Master', icon: '🥋', class: 'bg-purple-100 text-purple-700', message: 'Mastering the dispute process.' },
+  { threshold: 40, name: 'Debt Slayer', icon: '⚔️', class: 'bg-gray-100 text-gray-700', message: 'Slaying negative accounts.' },
+  { threshold: 30, name: 'Report Scrubber', icon: '🧼', class: 'bg-blue-100 text-blue-700', message: 'Deep cleaning your credit.' },
+  { threshold: 20, name: 'Score Shifter', icon: '📊', class: 'bg-green-100 text-green-700', message: 'Scores are improving.' },
+  { threshold: 15, name: 'Credit Cleaner', icon: '🧽', class: 'bg-yellow-100 text-yellow-700', message: 'Your report is shining.' },
+  { threshold: 10, name: 'Balance Buster', icon: '💥', class: 'bg-orange-100 text-orange-700', message: 'Breaking negative balances.' },
+  { threshold: 5, name: 'Debt Duster', icon: '🧹', class: 'bg-emerald-100 text-emerald-700', message: 'Cleaning up the dust.' },
+  { threshold: 0, name: 'Rookie', icon: '📄', class: 'bg-emerald-100 text-emerald-700', message: 'You’ve started your journey.' }
+];
+
+function getDeletionTier(count){
+  for(const tier of deletionTiers){
+    if(count >= tier.threshold) return tier;
+  }
+  return deletionTiers[deletionTiers.length-1];
+}
+
+function renderDeletionTier(){
+  const el = document.getElementById('tierBadge');
+  if(!el) return;
+  const deletions = Number(localStorage.getItem('deletions') || 0);
+  const tier = getDeletionTier(deletions);
+  el.className = `hidden sm:flex items-center gap-2 rounded-full px-4 py-2 shadow-sm animate-fadeInUp ${tier.class}`;
+  el.innerHTML = `<span class="text-xl">${tier.icon}</span><span class="font-semibold text-sm">${tier.name}</span>`;
+  el.title = tier.message;
+}
+
 const stateCenters = {
   AL:[32.806671,-86.79113], AK:[61.370716,-152.404419], AZ:[33.729759,-111.431221], AR:[34.969704,-92.373123],
   CA:[36.116203,-119.681564], CO:[39.059811,-105.311104], CT:[41.597782,-72.755371], DE:[39.318523,-75.507141],
@@ -56,6 +89,7 @@ function renderClientMap(consumers){
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  renderDeletionTier();
   const feedEl = document.getElementById('newsFeed');
   if (feedEl) {
     const rssUrl = 'https://hnrss.org/frontpage';


### PR DESCRIPTION
## Summary
- replace streak pill with deletion tier badge on host dashboard
- compute tier from deletion count with new client-side script
- add product tier badge and dispute round summary to client portal

## Testing
- `node --check public/client-portal.js`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68af4ea18fa08323aafa3897d08bc525