### PR TITLE
Include HIBP breach list in data breach letters

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -385,6 +385,9 @@ function buildLetterHTML({
   const intro = colorize(mc.intro);
   const ask = colorize(mc.ask);
   const afterIssuesPara = mc.afterIssues ? `<p>${colorize(mc.afterIssues)}</p>` : "";
+  const breachSection = (modeKey === "breach" && consumer.breaches && consumer.breaches.length)
+    ? `<h2>Data Breaches</h2><ul>${consumer.breaches.map(b=>`<li>${safe(b)}</li>`).join("")}</ul>`
+    : "";
   const verifyLine = colorize(
     "Please provide the method of verification... if you cannot verify... delete the item and send me an updated report."
   );
@@ -428,6 +431,7 @@ function buildLetterHTML({
     <h1>${colorize(mc.heading)}</h1>
     <p>${intro}</p>
     <p>${ask}</p>
+    ${breachSection}
     <h2>Comparison (All Available Bureaus)</h2>
     ${compTable}
     <h2>Bureau‑Specific Details (${bureau})</h2>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -810,10 +810,11 @@ $("#btnDataBreach").addEventListener("click", async ()=>{
     const res = await api(`/api/databreach`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: c.email })
+      body: JSON.stringify({ email: c.email, consumerId: c.id })
     });
     if(!res?.ok) return showErr(res?.error || "Breach check failed.");
     const list = res.breaches || [];
+    c.breaches = list.map(b=>b.Name || b.name || "");
     const msg = list.length
       ? `${c.email} found in:\n\n${list.map(b=>b.Name || b.name || "unknown").join("\n")}`
       : `${c.email} not found in known breaches.`;


### PR DESCRIPTION
## Summary
- store Have I Been Pwned breach names for consumers when checking
- send consumerId with data breach lookup from UI
- include stored breach list in generated breach-mode letters

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af830704448323a24a67dfbffe7d16