### PR TITLE
Style breach lookup and add breach audit PDFs

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -385,6 +385,12 @@ function buildLetterHTML({
   const intro = colorize(mc.intro);
   const ask = colorize(mc.ask);
   const afterIssuesPara = mc.afterIssues ? `<p>${colorize(mc.afterIssues)}</p>` : "";
+  const breachSection =
+    modeKey === "breach" && consumer.breaches && consumer.breaches.length
+      ? `<h2>Data Breaches</h2><p>The following breaches exposed my information:</p><ul>${consumer.breaches
+          .map((b) => `<li>${safe(b)}</li>`)
+          .join("")}</ul>`
+      : "";
   const verifyLine = colorize(
     "Please provide the method of verification... if you cannot verify... delete the item and send me an updated report."
   );
@@ -428,6 +434,7 @@ function buildLetterHTML({
     <h1>${colorize(mc.heading)}</h1>
     <p>${intro}</p>
     <p>${ask}</p>
+    ${breachSection}
     <h2>Comparison (All Available Bureaus)</h2>
     ${compTable}
     <h2>Bureau‑Specific Details (${bureau})</h2>

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -370,6 +370,20 @@
   </div>
 </div>
 
+<!-- Data Breach Results Modal -->
+<div id="breachModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.55)] z-50">
+  <div class="glass card w-[min(600px,95vw)]">
+    <div class="flex items-center justify-between mb-2">
+      <div class="font-semibold">Data Breach Results</div>
+      <button id="breachClose" class="btn">×</button>
+    </div>
+    <div id="breachBody" class="text-sm max-h-64 overflow-y-auto"></div>
+    <div class="text-right mt-3">
+      <button id="breachSend" class="btn">Send Audit PDF</button>
+    </div>
+  </div>
+</div>
+
 <!-- Help Modal (unchanged logic, bound in index.js hotkeys too) -->
 <div id="helpModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)] z-50">
   <div class="glass card w-[min(720px,92vw)]">

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -61,6 +61,11 @@ function formatEvent(ev){
     title = "Audit generated";
     const link = file ? `<a href="${escapeHtml(file)}" target="_blank" class="text-blue-600 underline">open</a>` : "";
     body = `<div class="text-xs mt-1">Report ${escapeHtml(reportId||"")} ${link}</div>`;
+  } else if(ev.type === "breach_audit_generated"){
+    const { file } = ev.payload || {};
+    title = "Data breach audit generated";
+    const link = file ? `<a href="${escapeHtml(file)}" target="_blank" class="text-blue-600 underline">open</a>` : "";
+    body = `<div class="text-xs mt-1">${link}</div>`;
   } else if(ev.type === "consumer_created"){
     const { name } = ev.payload || {};
     title = "Consumer created";
@@ -810,14 +815,46 @@ $("#btnDataBreach").addEventListener("click", async ()=>{
     const res = await api(`/api/databreach`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: c.email })
+      body: JSON.stringify({ email: c.email, consumerId: c.id })
     });
     if(!res?.ok) return showErr(res?.error || "Breach check failed.");
     const list = res.breaches || [];
-    const msg = list.length
-      ? `${c.email} found in:\n\n${list.map(b=>b.Name || b.name || "unknown").join("\n")}`
-      : `${c.email} not found in known breaches.`;
-    alert(msg);
+    c.breaches = list.map(b=>b.Name || b.name || "");
+    const body = $("#breachBody");
+    const content = list.length
+      ? `<p>${escapeHtml(c.email)} found in:</p><ul>${list.map(b=>`<li>${escapeHtml(b.Name || b.name || "unknown")}</li>`).join("")}</ul>`
+      : `<p>No breaches found for ${escapeHtml(c.email)}.</p>`;
+    body.innerHTML = content;
+    const modal = $("#breachModal");
+    modal.classList.remove("hidden");
+    modal.classList.add("flex");
+  }catch(err){
+    showErr(String(err));
+  }finally{
+    btn.textContent = old;
+    btn.disabled = false;
+  }
+});
+
+// Data breach modal handlers
+$("#breachClose").addEventListener("click", ()=>{
+  const m = $("#breachModal");
+  m.classList.add("hidden");
+  m.classList.remove("flex");
+});
+
+$("#breachSend").addEventListener("click", async ()=>{
+  if(!currentConsumerId) return showErr("Select a consumer first.");
+  const btn = $("#breachSend");
+  const old = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = "Generating...";
+  try{
+    const res = await fetch(`/api/consumers/${currentConsumerId}/databreach/audit`, { method:"POST" }).then(r=>r.json());
+    if(!res?.ok) return showErr(res?.error || "Failed to generate audit.");
+    if(res.url) window.open(res.url, "_blank");
+    if(res.warning) showErr(res.warning);
+    await loadConsumerState();
   }catch(err){
     showErr(String(err));
   }finally{

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -589,22 +589,93 @@ async function hibpLookup(email) {
   }
 }
 
-async function handleDataBreach(email, res) {
+function escapeHtml(str) {
+  return String(str || "").replace(/[&<>"']/g, c => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[c]);
+}
+
+function renderBreachAuditHtml(consumer) {
+  const list = (consumer.breaches || []).map(b => `<li>${escapeHtml(b)}</li>`).join("") || "<li>No breaches found.</li>";
+  const dateStr = new Date().toLocaleString();
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"/><style>body{font-family:Arial, sans-serif;margin:20px;}h1{text-align:center;}ul{margin-top:10px;}</style></head><body><h1>${escapeHtml(consumer.name || "Consumer")}</h1><h2>Data Breach Audit</h2><p>Email: ${escapeHtml(consumer.email || "")}</p><ul>${list}</ul><footer><hr/><div style="font-size:0.8em;color:#555;margin-top:20px;">Generated ${escapeHtml(dateStr)}</div></footer></body></html>`;
+}
+
+async function handleDataBreach(email, consumerId, res) {
   const result = await hibpLookup(email);
+  if (result.ok && consumerId) {
+    try {
+      const db = loadDB();
+      const c = db.consumers.find(x => x.id === consumerId);
+      if (c) {
+        c.breaches = (result.breaches || []).map(b => b.Name || b.name || "");
+        saveDB(db);
+      }
+    } catch (err) {
+      console.error("Failed to store breach info", err);
+    }
+  }
   if (result.ok) return res.json(result);
   res.status(result.status || 500).json({ ok: false, error: result.error });
 }
 
 app.post("/api/databreach", async (req, res) => {
   const email = String(req.body.email || "").trim();
+  const consumerId = String(req.body.consumerId || "").trim();
   if (!email) return res.status(400).json({ ok: false, error: "Email required" });
-  await handleDataBreach(email, res);
+  await handleDataBreach(email, consumerId, res);
 });
 
 app.get("/api/databreach", async (req, res) => {
   const email = String(req.query.email || "").trim();
+  const consumerId = String(req.query.consumerId || "").trim();
   if (!email) return res.status(400).json({ ok: false, error: "Email required" });
-  await handleDataBreach(email, res);
+  await handleDataBreach(email, consumerId, res);
+});
+
+app.post("/api/consumers/:id/databreach/audit", async (req, res) => {
+  const db = loadDB();
+  const c = db.consumers.find(x => x.id === req.params.id);
+  if (!c) return res.status(404).json({ ok: false, error: "Consumer not found" });
+  try {
+    const html = renderBreachAuditHtml(c);
+    const result = await savePdf(html);
+    let ext = path.extname(result.path);
+    if (result.warning || ext !== ".pdf") {
+      ext = ".html";
+    }
+    const mime = ext === ".pdf" ? "application/pdf" : "text/html";
+    try {
+      const uploadsDir = consumerUploadsDir(c.id);
+      const id = nanoid(10);
+      const storedName = `${id}${ext}`;
+      const safe = (c.name || "client").toLowerCase().replace(/[^a-z0-9]+/g, "_");
+      const date = new Date().toISOString().slice(0, 10);
+      const originalName = `${safe}_${date}_breach_audit${ext}`;
+      const dest = path.join(uploadsDir, storedName);
+      await fs.promises.copyFile(result.path, dest);
+      const stat = await fs.promises.stat(dest);
+      addFileMeta(c.id, {
+        id,
+        originalName,
+        storedName,
+        type: "breach-audit",
+        size: stat.size,
+        mimetype: mime,
+        uploadedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      console.error("Failed to store breach audit file", err);
+    }
+    addEvent(c.id, "breach_audit_generated", { file: result.url });
+    res.json({ ok: true, url: result.url, warning: result.warning });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
 });
 
 
@@ -712,7 +783,8 @@ app.post("/api/generate", async (req,res)=>{
     const consumerForLetter = {
       name: consumer.name, email: consumer.email, phone: consumer.phone,
       addr1: consumer.addr1, addr2: consumer.addr2, city: consumer.city, state: consumer.state, zip: consumer.zip,
-      ssn_last4: consumer.ssn_last4, dob: consumer.dob
+      ssn_last4: consumer.ssn_last4, dob: consumer.dob,
+      breaches: consumer.breaches || []
     };
 
     const letters = generateLetters({ report: reportWrap.data, selections, consumer: consumerForLetter, requestType });


### PR DESCRIPTION
## Summary
- replace alert-based breach lookup with styled modal and "Send Audit PDF" action
- generate and store data breach audit PDFs via new server endpoint
- log and display breach audit generation events in activity feed

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af830704448323a24a67dfbffe7d16