### PR TITLE
feat: add ChatGPT rewording and bulk letter send options

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -385,6 +385,12 @@ function buildLetterHTML({
   const intro = colorize(mc.intro);
   const ask = colorize(mc.ask);
   const afterIssuesPara = mc.afterIssues ? `<p>${colorize(mc.afterIssues)}</p>` : "";
+  const breachSection =
+    modeKey === "breach" && consumer.breaches && consumer.breaches.length
+      ? `<h2>Data Breaches</h2><p>The following breaches exposed my information:</p><ul>${consumer.breaches
+          .map((b) => `<li>${safe(b)}</li>`)
+          .join("")}</ul>`
+      : "";
   const verifyLine = colorize(
     "Please provide the method of verification... if you cannot verify... delete the item and send me an updated report."
   );
@@ -428,6 +434,7 @@ function buildLetterHTML({
     <h1>${colorize(mc.heading)}</h1>
     <p>${intro}</p>
     <p>${ask}</p>
+    ${breachSection}
     <h2>Comparison (All Available Bureaus)</h2>
     ${compTable}
     <h2>Bureau‑Specific Details (${bureau})</h2>

--- a/metro2 (copy 1)/crm/logger.js
+++ b/metro2 (copy 1)/crm/logger.js
@@ -1,0 +1,13 @@
+export function logInfo(code, message, meta = {}) {
+  const entry = { level: 'info', time: new Date().toISOString(), code, message, ...meta };
+  console.log(JSON.stringify(entry));
+}
+
+export function logError(code, message, err, meta = {}) {
+  const entry = { level: 'error', time: new Date().toISOString(), code, message, ...meta };
+  if (err) {
+    entry.error = err.message;
+    if (err.stack) entry.stack = err.stack;
+  }
+  console.error(JSON.stringify(entry));
+}

--- a/metro2 (copy 1)/crm/public/app.js
+++ b/metro2 (copy 1)/crm/public/app.js
@@ -311,6 +311,15 @@ function renderTradelines(tradelines){
       });
     });
 
+    const gptCb = card.querySelector('.use-gpt');
+    const toneSel = card.querySelector('.gpt-tone');
+    if (gptCb && toneSel) {
+      toneSel.disabled = true;
+      gptCb.addEventListener('change', () => {
+        toneSel.disabled = !gptCb.checked;
+      });
+    }
+
     // initialize special badges if any from previous state (when re-rendering)
     updateCardSpecialVisual(card);
 
@@ -345,8 +354,14 @@ function collectSelections(){
     if (specialSelections.breach.has(tradelineIndex))   special.push("data_breach");
     if (specialSelections.assault.has(tradelineIndex))  special.push("sexual_assault");
 
+    const aiTone = card.querySelector('.use-gpt')?.checked
+      ? card.querySelector('.gpt-tone')?.value || ''
+      : '';
+
     if (bureaus.length || special.length){
-      selections.push({ tradelineIndex, bureaus, violationIdxs, special });
+      const entry = { tradelineIndex, bureaus, violationIdxs, special };
+      if (aiTone) entry.aiTone = aiTone;
+      selections.push(entry);
     }
   });
   return selections;

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -258,6 +258,17 @@
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="Equifax" /> Equifax</label>
     </div>
 
+    <div class="mt-2 flex items-center gap-2 text-xs">
+      <label class="flex items-center gap-1"><input type="checkbox" class="use-gpt" /> AI Reword</label>
+      <select class="gpt-tone border rounded px-1 py-0.5">
+        <option value="Professional & Polite">Professional & Polite</option>
+        <option value="Firm / Legalistic (No-Nonsense)">Firm / Legalistic (No-Nonsense)</option>
+        <option value="Plain-English / Conversational">Plain-English / Conversational</option>
+        <option value="Cooperative / Helpful (Problem-Solving)">Cooperative / Helpful (Problem-Solving)</option>
+        <option value="Urgent / Concerned (Still Respectful)">Urgent / Concerned (Still Respectful)</option>
+      </select>
+    </div>
+
     <div class="tl-tags flex gap-2 mt-2 flex-wrap"></div>
     <div class="mt-3">
       <div class="space-y-1 tl-violations text-sm"></div>
@@ -367,6 +378,20 @@
       <button id="zoomClose" class="btn">×</button>
     </div>
     <div id="zoomBody" class="text-sm"></div>
+  </div>
+</div>
+
+<!-- Data Breach Results Modal -->
+<div id="breachModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.55)] z-50">
+  <div class="glass card w-[min(600px,95vw)]">
+    <div class="flex items-center justify-between mb-2">
+      <div class="font-semibold">Data Breach Results</div>
+      <button id="breachClose" class="btn">×</button>
+    </div>
+    <div id="breachBody" class="text-sm max-h-64 overflow-y-auto"></div>
+    <div class="text-right mt-3">
+      <button id="breachSend" class="btn">Send Audit PDF</button>
+    </div>
   </div>
 </div>
 

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -53,8 +53,9 @@
       <div class="flex flex-wrap items-center justify-between gap-2">
         <div class="font-medium">Letters</div>
         <div class="flex items-center gap-2">
-          <button id="btnDownloadAll" class="btn">Download All</button>
-          <button id="btnEmailAll" class="btn">Email All</button>
+          <button id="btnDownloadAll" class="btn" data-tip="Download all letters as ZIP">Download All</button>
+          <button id="btnPortalAll" class="btn" data-tip="Upload letters to client portal">Send to Portal</button>
+          <button id="btnEmailAll" class="btn" data-tip="Email letters as PDF attachments">Email All</button>
           <button id="btnBack" class="btn">← Back to CRM</button>
         </div>
 

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -14,6 +14,8 @@ import archiver from "archiver";
 
 import { PassThrough } from "stream";
 
+import { logInfo, logError } from "./logger.js";
+
 import { generateLetters, generatePersonalInfoLetters, generateInquiryLetters, generateDebtCollectorLetters } from "./letterEngine.js";
 import { PLAYBOOKS } from "./playbook.js";
 import { normalizeReport, renderHtml, savePdf } from "./creditAuditTool.js";
@@ -59,6 +61,43 @@ app.use((req, res, next) => {
   });
   next();
 });
+
+process.on("unhandledRejection", err => {
+  logError("UNHANDLED_REJECTION", "Unhandled promise rejection", err);
+});
+process.on("uncaughtException", err => {
+  logError("UNCAUGHT_EXCEPTION", "Uncaught exception", err);
+});
+
+async function rewordWithAI(text, tone) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key || !text) return text;
+  try {
+    const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: "You reword credit dispute statements." },
+          {
+            role: "user",
+            content: `Tone: ${tone}\nReword the following text. Do not use the \"—\" character.\nText: ${text}`,
+          },
+        ],
+      }),
+    });
+    const data = await resp.json().catch(() => ({}));
+    const out = data.choices?.[0]?.message?.content?.trim() || text;
+    return out.replace(/—/g, "-");
+  } catch (e) {
+    console.error("AI reword failed", e);
+    return text;
+  }
+}
 
 // periodically surface due letter reminders
 processAllReminders();
@@ -589,22 +628,93 @@ async function hibpLookup(email) {
   }
 }
 
-async function handleDataBreach(email, res) {
+function escapeHtml(str) {
+  return String(str || "").replace(/[&<>"']/g, c => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[c]);
+}
+
+function renderBreachAuditHtml(consumer) {
+  const list = (consumer.breaches || []).map(b => `<li>${escapeHtml(b)}</li>`).join("") || "<li>No breaches found.</li>";
+  const dateStr = new Date().toLocaleString();
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"/><style>body{font-family:Arial, sans-serif;margin:20px;}h1{text-align:center;}ul{margin-top:10px;}</style></head><body><h1>${escapeHtml(consumer.name || "Consumer")}</h1><h2>Data Breach Audit</h2><p>Email: ${escapeHtml(consumer.email || "")}</p><ul>${list}</ul><footer><hr/><div style="font-size:0.8em;color:#555;margin-top:20px;">Generated ${escapeHtml(dateStr)}</div></footer></body></html>`;
+}
+
+async function handleDataBreach(email, consumerId, res) {
   const result = await hibpLookup(email);
+  if (result.ok && consumerId) {
+    try {
+      const db = loadDB();
+      const c = db.consumers.find(x => x.id === consumerId);
+      if (c) {
+        c.breaches = (result.breaches || []).map(b => b.Name || b.name || "");
+        saveDB(db);
+      }
+    } catch (err) {
+      console.error("Failed to store breach info", err);
+    }
+  }
   if (result.ok) return res.json(result);
   res.status(result.status || 500).json({ ok: false, error: result.error });
 }
 
 app.post("/api/databreach", async (req, res) => {
   const email = String(req.body.email || "").trim();
+  const consumerId = String(req.body.consumerId || "").trim();
   if (!email) return res.status(400).json({ ok: false, error: "Email required" });
-  await handleDataBreach(email, res);
+  await handleDataBreach(email, consumerId, res);
 });
 
 app.get("/api/databreach", async (req, res) => {
   const email = String(req.query.email || "").trim();
+  const consumerId = String(req.query.consumerId || "").trim();
   if (!email) return res.status(400).json({ ok: false, error: "Email required" });
-  await handleDataBreach(email, res);
+  await handleDataBreach(email, consumerId, res);
+});
+
+app.post("/api/consumers/:id/databreach/audit", async (req, res) => {
+  const db = loadDB();
+  const c = db.consumers.find(x => x.id === req.params.id);
+  if (!c) return res.status(404).json({ ok: false, error: "Consumer not found" });
+  try {
+    const html = renderBreachAuditHtml(c);
+    const result = await savePdf(html);
+    let ext = path.extname(result.path);
+    if (result.warning || ext !== ".pdf") {
+      ext = ".html";
+    }
+    const mime = ext === ".pdf" ? "application/pdf" : "text/html";
+    try {
+      const uploadsDir = consumerUploadsDir(c.id);
+      const id = nanoid(10);
+      const storedName = `${id}${ext}`;
+      const safe = (c.name || "client").toLowerCase().replace(/[^a-z0-9]+/g, "_");
+      const date = new Date().toISOString().slice(0, 10);
+      const originalName = `${safe}_${date}_breach_audit${ext}`;
+      const dest = path.join(uploadsDir, storedName);
+      await fs.promises.copyFile(result.path, dest);
+      const stat = await fs.promises.stat(dest);
+      addFileMeta(c.id, {
+        id,
+        originalName,
+        storedName,
+        type: "breach-audit",
+        size: stat.size,
+        mimetype: mime,
+        uploadedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      console.error("Failed to store breach audit file", err);
+    }
+    addEvent(c.id, "breach_audit_generated", { file: result.url });
+    res.json({ ok: true, url: result.url, warning: result.warning });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
 });
 
 
@@ -712,8 +822,24 @@ app.post("/api/generate", async (req,res)=>{
     const consumerForLetter = {
       name: consumer.name, email: consumer.email, phone: consumer.phone,
       addr1: consumer.addr1, addr2: consumer.addr2, city: consumer.city, state: consumer.state, zip: consumer.zip,
-      ssn_last4: consumer.ssn_last4, dob: consumer.dob
+      ssn_last4: consumer.ssn_last4, dob: consumer.dob,
+      breaches: consumer.breaches || []
     };
+
+    for (const sel of selections || []) {
+      if (sel.aiTone) {
+        const tl = reportWrap.data?.tradelines?.[sel.tradelineIndex];
+        if (tl && Array.isArray(sel.violationIdxs)) {
+          for (const vidx of sel.violationIdxs) {
+            const v = tl.violations?.[vidx];
+            if (v) {
+              v.title = await rewordWithAI(v.title || "", sel.aiTone);
+              if (v.detail) v.detail = await rewordWithAI(v.detail, sel.aiTone);
+            }
+          }
+        }
+      }
+    }
 
     const letters = generateLetters({ report: reportWrap.data, selections, consumer: consumerForLetter, requestType });
     if (personalInfo) {
@@ -902,7 +1028,10 @@ app.get("/api/letters/:jobId/all.zip", async (req,res)=>{
   res.setHeader("Content-Type","application/zip");
   res.setHeader("Content-Disposition",`attachment; filename="letters_${jobId}.zip"`);
   const archive = archiver('zip',{ zlib:{ level:9 } });
-  archive.on('error', err => { console.error(err); try{ res.status(500).end("Zip error"); }catch{} });
+  archive.on('error', err => {
+    logError('ARCHIVE_STREAM_ERROR', 'Archive stream error', err, { jobId });
+    try{ res.status(500).json({ ok:false, errorCode:'ARCHIVE_STREAM_ERROR', message:'Zip error' }); }catch{}
+  });
 
   // determine consumer for logging and file storage
   let fileStream, storedName, originalName, consumer, id;
@@ -948,7 +1077,12 @@ app.get("/api/letters/:jobId/all.zip", async (req,res)=>{
       const pdf = await page.pdf({ format:"Letter", printBackground:true, margin:{top:"1in",right:"1in",bottom:"1in",left:"1in"} });
       await page.close();
       const name = (L.filename||`letter${i}`).replace(/\.html?$/i,"") + '.pdf';
-      archive.append(pdf,{ name });
+      try{
+        archive.append(pdf,{ name });
+      }catch(err){
+        logError('ZIP_APPEND_FAILED', 'Failed to append PDF to archive', err, { jobId, letter: name });
+        throw err;
+      }
     }
     await archive.finalize();
 
@@ -966,11 +1100,12 @@ app.get("/api/letters/:jobId/all.zip", async (req,res)=>{
           uploadedAt: new Date().toISOString(),
         });
         addEvent(consumer.id, 'letters_downloaded', { jobId, file: `/api/consumers/${consumer.id}/state/files/${storedName}` });
-      }catch(err){ console.error('Failed to record zip', err); }
+      }catch(err){ logError('ZIP_RECORD_FAILED', 'Failed to record zip', err, { jobId, consumerId: consumer.id }); }
     }
+    logInfo('ZIP_BUILD_SUCCESS', 'Letters zip created', { jobId });
   }catch(e){
-    console.error("Zip generation failed:", e);
-    try{ res.status(500).end("Failed to create zip."); }catch{}
+    logError('ZIP_BUILD_FAILED', 'Zip generation failed', e, { jobId });
+    try{ res.status(500).json({ ok:false, errorCode:'ZIP_BUILD_FAILED', message:'Failed to create zip.' }); }catch{}
   }finally{
     try{ await browser?.close(); }catch{}
   }
@@ -987,8 +1122,38 @@ app.post("/api/letters/:jobId/email", async (req,res)=>{
     if(disk){ job = { letters: disk.letters.map(d=>({ filename: path.basename(d.htmlPath), htmlPath: d.htmlPath })) }; }
   }
   if(!job) return res.status(404).json({ ok:false, error:"Job not found or expired" });
+
+  // find consumer for logging
+  let consumer = null;
   try{
-    const attachments = job.letters.map(L=>({ filename: L.filename, path: L.htmlPath || path.join(LETTERS_DIR, L.filename) }));
+    const ldb = loadLettersDB();
+    const meta = ldb.jobs.find(j=>j.jobId === jobId);
+    if(meta?.consumerId){
+      const db = loadDB();
+      consumer = db.consumers.find(c=>c.id === meta.consumerId) || null;
+    }
+  }catch{}
+
+  let browser;
+  try{
+    browser = await launchBrowser();
+    const attachments = [];
+    for(let i=0;i<job.letters.length;i++){
+      const L = job.letters[i];
+      const html = L.html || (L.htmlPath ? fs.readFileSync(L.htmlPath, "utf-8") : fs.readFileSync(path.join(LETTERS_DIR, L.filename), "utf-8"));
+      const page = await browser.newPage();
+      const dataUrl = "data:text/html;charset=utf-8," + encodeURIComponent(html);
+      await page.goto(dataUrl,{ waitUntil:"load", timeout:60000 });
+      await page.emulateMediaType("screen");
+      try{ await page.waitForFunction(()=>document.readyState==="complete",{timeout:60000}); }catch{}
+      try{ await page.evaluate(()=> (document.fonts && document.fonts.ready) || Promise.resolve()); }catch{}
+      await page.evaluate(()=> new Promise(r=>setTimeout(r,80)));
+      const pdf = await page.pdf({ format:"Letter", printBackground:true, margin:{top:"1in",right:"1in",bottom:"1in",left:"1in"} });
+      await page.close();
+      const name = (L.filename || `letter${i}`).replace(/\.html?$/i,"") + '.pdf';
+      attachments.push({ filename: name, content: pdf, contentType: 'application/pdf' });
+    }
+
     await mailer.sendMail({
       from: process.env.SMTP_FROM || process.env.SMTP_USER,
       to,
@@ -996,10 +1161,102 @@ app.post("/api/letters/:jobId/email", async (req,res)=>{
       text: `Attached letters for job ${jobId}`,
       attachments
     });
+
+    if(consumer){
+      try{ addEvent(consumer.id, 'letters_emailed', { jobId, to, count: attachments.length }); }catch{}
+    }
+
+    res.json({ ok:true });
+    logInfo('EMAIL_SEND_SUCCESS', 'Letters emailed', { jobId, to, count: attachments.length });
+  }catch(e){
+    logError('EMAIL_SEND_FAILED', 'Failed to email letters', e, { jobId, to });
+    res.status(500).json({ ok:false, errorCode:'EMAIL_SEND_FAILED', message:String(e) });
+  }finally{
+    try{ await browser?.close(); }catch{}
+  }
+});
+
+app.post("/api/letters/:jobId/portal", async (req,res)=>{
+  const { jobId } = req.params;
+  let job = getJobMem(jobId);
+  if(!job){
+    const disk = loadJobFromDisk(jobId);
+    if(disk){ job = { letters: disk.letters.map(d=>({ filename: path.basename(d.htmlPath), htmlPath: d.htmlPath })) }; }
+  }
+  if(!job) return res.status(404).json({ ok:false, error:"Job not found or expired" });
+
+  // locate consumer for storage
+  let consumer = null;
+  try{
+    const ldb = loadLettersDB();
+    const meta = ldb.jobs.find(j=>j.jobId === jobId);
+    if(meta?.consumerId){
+      const db = loadDB();
+      consumer = db.consumers.find(c=>c.id === meta.consumerId) || null;
+    }
+  }catch{}
+  if(!consumer) return res.status(400).json({ ok:false, error:"Consumer not found" });
+
+  let browser;
+  try{
+    logInfo('PORTAL_UPLOAD_START', 'Building portal ZIP', { jobId, consumerId: consumer.id });
+    browser = await launchBrowser();
+    const dir = consumerUploadsDir(consumer.id);
+    const id = nanoid(10);
+    const storedName = `${id}.zip`;
+    const safe = (consumer.name || 'client').toLowerCase().replace(/[^a-z0-9]+/g,'_');
+    const date = new Date().toISOString().slice(0,10);
+    const originalName = `${safe}_${date}_letters.zip`;
+    const fullPath = path.join(dir, storedName);
+    const out = fs.createWriteStream(fullPath);
+    const archive = archiver('zip',{ zlib:{ level:9 } });
+    archive.on('error', err => {
+      logError('ARCHIVE_STREAM_ERROR', 'Archive stream error', err, { jobId });
+      try{ res.status(500).json({ ok:false, errorCode:'ARCHIVE_STREAM_ERROR', message:'Zip error' }); }catch{}
+    });
+    archive.pipe(out);
+
+    for(let i=0;i<job.letters.length;i++){
+      const L = job.letters[i];
+      const html = L.html || (L.htmlPath ? fs.readFileSync(L.htmlPath, 'utf-8') : fs.readFileSync(path.join(LETTERS_DIR, L.filename), 'utf-8'));
+      const page = await browser.newPage();
+      const dataUrl = "data:text/html;charset=utf-8," + encodeURIComponent(html);
+      await page.goto(dataUrl,{ waitUntil:'load', timeout:60000 });
+      await page.emulateMediaType('screen');
+      try{ await page.waitForFunction(()=>document.readyState==='complete',{timeout:60000}); }catch{}
+      try{ await page.evaluate(()=> (document.fonts && document.fonts.ready) || Promise.resolve()); }catch{}
+      await page.evaluate(()=> new Promise(r=>setTimeout(r,80)));
+      const pdf = await page.pdf({ format:'Letter', printBackground:true, margin:{top:'1in',right:'1in',bottom:'1in',left:'1in'} });
+      await page.close();
+      const name = (L.filename||`letter${i}`).replace(/\.html?$/i,"") + '.pdf';
+      try{
+        archive.append(pdf,{ name });
+      }catch(err){
+        logError('ZIP_APPEND_FAILED', 'Failed to append PDF to archive', err, { jobId, letter: name });
+        throw err;
+      }
+    }
+
+    await archive.finalize();
+    await new Promise(resolve => out.on('close', resolve));
+    const stat = await fs.promises.stat(fullPath);
+    addFileMeta(consumer.id, {
+      id,
+      originalName,
+      storedName,
+      type: 'letters_zip',
+      size: stat.size,
+      mimetype: 'application/zip',
+      uploadedAt: new Date().toISOString(),
+    });
+    addEvent(consumer.id, 'letters_portal_sent', { jobId, file: `/api/consumers/${consumer.id}/state/files/${storedName}` });
+    logInfo('PORTAL_UPLOAD_SUCCESS', 'Portal ZIP stored', { jobId, consumerId: consumer.id });
     res.json({ ok:true });
   }catch(e){
-    console.error(e);
-    res.status(500).json({ ok:false, error:String(e) });
+    logError('PORTAL_UPLOAD_FAILED', 'Letters portal upload failed', e, { jobId });
+    res.status(500).json({ ok:false, errorCode:'PORTAL_UPLOAD_FAILED', message:String(e) });
+  }finally{
+    try{ await browser?.close(); }catch{}
   }
 });
 
@@ -1074,3 +1331,4 @@ app.listen(PORT, ()=> {
 
 
 
+// End of server.js


### PR DESCRIPTION
## Summary
- add "AI Reword" checkbox with tone picker to each tradeline card
- include selected tone in letter generation request
- rephrase selected violation text through the ChatGPT API using `OPENAI_API_KEY`
- enable bulk actions on the letters page to download a ZIP, upload to the client portal, or email all letters with progress feedback
- ensure server starts cleanly without syntax errors
- introduce centralized JSON logger and error codes around letter download, portal upload, and email flows

## Testing
- `npm run start`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af830704448323a24a67dfbffe7d16