### PR TITLE
refactor: centralize JSON db helpers

### DIFF
--- a/metro2 (copy 1)/crm/db-utils.js
+++ b/metro2 (copy 1)/crm/db-utils.js
@@ -1,0 +1,13 @@
+import fs from "fs";
+
+export function readJson(filePath, defaultObj){
+  try{
+    return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  }catch{
+    return JSON.parse(JSON.stringify(defaultObj));
+  }
+}
+
+export function writeJson(filePath, data){
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}


### PR DESCRIPTION
## Summary
- add generic read/write JSON helpers
- switch server to use shared JSON DB utilities for consumers, letters, leads, and invoices

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68afc7b8bd088323a2979ee0047fd465