### PR TITLE
refactor: centralize PDF buffer handling

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -16,6 +16,8 @@ import { PassThrough } from "stream";
 
 import { logInfo, logError, logWarn } from "./logger.js";
 
+import { ensureBuffer } from "./utils.js";
+
 
 import { generateLetters, generatePersonalInfoLetters, generateInquiryLetters, generateDebtCollectorLetters } from "./letterEngine.js";
 import { PLAYBOOKS } from "./playbook.js";
@@ -1049,7 +1051,7 @@ app.get("/api/letters/:jobId/:idx.pdf", async (req,res)=>{
     await page.evaluate(()=> new Promise(r=>setTimeout(r,80)));
     const pdf = await page.pdf({ format:"Letter", printBackground:true, margin:{top:"1in",right:"1in",bottom:"1in",left:"1in"} });
     await page.close();
-    const pdfBuffer = Buffer.isBuffer(pdf) ? pdf : Buffer.from(pdf);
+    const pdfBuffer = ensureBuffer(pdf);
     if(!pdfBuffer || pdfBuffer.length === 0){
       throw new Error("Generated PDF is empty");
     }
@@ -1132,7 +1134,7 @@ app.get("/api/letters/:jobId/all.zip", async (req,res)=>{
       await page.evaluate(()=> new Promise(r=>setTimeout(r,80)));
       const pdf = await page.pdf({ format:"Letter", printBackground:true, margin:{top:"1in",right:"1in",bottom:"1in",left:"1in"} });
       await page.close();
-      const pdfBuffer = Buffer.isBuffer(pdf) ? pdf : Buffer.from(pdf);
+      const pdfBuffer = ensureBuffer(pdf);
       const name = (L.filename||`letter${i}`).replace(/\.html?$/i,"") + '.pdf';
       try{
         archive.append(pdfBuffer,{ name });
@@ -1208,7 +1210,7 @@ app.post("/api/letters/:jobId/email", async (req,res)=>{
       await page.evaluate(()=> new Promise(r=>setTimeout(r,80)));
       const pdf = await page.pdf({ format:"Letter", printBackground:true, margin:{top:"1in",right:"1in",bottom:"1in",left:"1in"} });
       await page.close();
-      const pdfBuffer = Buffer.isBuffer(pdf) ? pdf : Buffer.from(pdf);
+      const pdfBuffer = ensureBuffer(pdf);
       const name = (L.filename || `letter${i}`).replace(/\.html?$/i,"") + '.pdf';
       attachments.push({ filename: name, content: pdfBuffer, contentType: 'application/pdf' });
     }
@@ -1290,7 +1292,7 @@ app.post("/api/letters/:jobId/portal", async (req,res)=>{
       await page.evaluate(()=> new Promise(r=>setTimeout(r,80)));
       const pdf = await page.pdf({ format:'Letter', printBackground:true, margin:{top:'1in',right:'1in',bottom:'1in',left:'1in'} });
       await page.close();
-      const pdfBuffer = Buffer.isBuffer(pdf) ? pdf : Buffer.from(pdf);
+      const pdfBuffer = ensureBuffer(pdf);
       const name = (L.filename||`letter${i}`).replace(/\.html?$/i,"") + '.pdf';
       try{
         archive.append(pdfBuffer,{ name });

--- a/metro2 (copy 1)/crm/utils.js
+++ b/metro2 (copy 1)/crm/utils.js
@@ -1,0 +1,3 @@
+export function ensureBuffer(data) {
+  return Buffer.isBuffer(data) ? data : Buffer.from(data);
+}


### PR DESCRIPTION
## Summary
- add `ensureBuffer` helper to normalize input to Node.js `Buffer`
- use `ensureBuffer` wherever PDFs were manually wrapped

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68afc7c8361083238bb56371ad70fe07