### PR TITLE
refactor: centralize PDF buffer handling

### DIFF
--- a/metro2 (copy 1)/crm/utils.js
+++ b/metro2 (copy 1)/crm/utils.js
@@ -1,0 +1,17 @@
+import fs from "fs";
+
+export function ensureBuffer(data) {
+  return Buffer.isBuffer(data) ? data : Buffer.from(data);
+}
+
+export function readJson(filePath, fallback){
+  try{
+    return JSON.parse(fs.readFileSync(filePath,"utf-8"));
+  }catch{
+    return fallback;
+  }
+}
+
+export function writeJson(filePath, data){
+  fs.writeFileSync(filePath, JSON.stringify(data,null,2));
+}


### PR DESCRIPTION
## Summary
- add `ensureBuffer` helper to normalize input to Node.js `Buffer`
- use `ensureBuffer` wherever PDFs were manually wrapped
- scope Puppeteer usage to `browserInstance` variables to avoid `browser` reference errors
- introduce `readJson`/`writeJson` utilities and replace direct JSON file access

## Testing
- `node server.js` (exit after startup)
- `curl -s http://localhost:3000/api/consumers`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68afc7c8361083238bb56371ad70fe07