### PR TITLE
Improve dashboard layout and client listing

### DIFF
--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -38,7 +38,7 @@
   </div>
 </header>
 <main class="max-w-7xl mx-auto p-4 space-y-4">
-  <div class="glass card relative overflow-hidden">
+  <div class="glass card relative overflow-hidden text-center">
     <div class="pointer-events-none absolute -top-16 -right-16 h-56 w-56 rounded-full bg-gradient-to-tr from-emerald-400 to-cyan-400 opacity-20 blur-3xl animate-blob"></div>
     <h2 class="mb-2 text-2xl font-bold">Welcome back!</h2>
     <p class="text-sm text-gray-600">Let’s knock out today’s tasks.</p>

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -71,10 +71,15 @@ function renderClientMap(consumers){
   const mapEl = document.getElementById('clientMap');
   if(!mapEl || typeof L === 'undefined') return;
   if(!mapEl.style.height) mapEl.style.height = '16rem';
-  const map = L.map(mapEl).setView([37.8,-96],4);
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
-    attribution:'© OpenStreetMap contributors'
-  }).addTo(map);
+  const map = L.map(mapEl, { zoomControl: true }).setView([37.8,-96],4);
+  mapEl.style.background = '#e5e7eb';
+  fetch('https://raw.githubusercontent.com/PublicaMundi/MappingAPI/master/data/geojson/us-states.json')
+    .then(r=>r.json())
+    .then(data=>{
+      L.geoJSON(data, {
+        style:{ color:'#ffffff', weight:1, fillColor:'#7c3aed', fillOpacity:1 }
+      }).addTo(map);
+    });
   setTimeout(()=>map.invalidateSize(),0);
 
   consumers.forEach(c=>{

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -80,7 +80,7 @@
 
 <!-- Quick Actions -->
 <div class="max-w-7xl mx-auto">
-  <div class="glass card space-y-4">
+  <div class="glass card space-y-4 text-center">
     <div>
       <div class="mb-1 flex items-center justify-center gap-2">
 
@@ -94,7 +94,7 @@
       </div>
     <div>
         <div class="font-medium mb-2">Quick Actions</div>
-      <div id="modeBar" class="flex gap-2 flex-wrap"></div>
+      <div id="modeBar" class="flex gap-2 flex-wrap justify-center"></div>
       <div class="text-sm muted mt-1">
         Click a mode, then click tradeline cards to tag them. Click the mode again to exit.
       </div>
@@ -116,7 +116,7 @@
         </div>
       </div>
       <input id="consumerSearch" placeholder="Search consumers..." class="w-full border rounded px-2 py-1 text-sm" />
-      <div id="consumerList" class="space-y-2"></div>
+      <div id="consumerList" class="space-y-2 max-h-96 overflow-y-auto"></div>
       <div class="flex items-center justify-between pt-2">
         <button id="consPrev" class="btn text-sm">Prev</button>
         <div class="text-sm muted">Page <span id="consPage">1</span> / <span id="consPages">1</span></div>


### PR DESCRIPTION
## Summary
- Center dashboard welcome panel and quick-action elements
- Limit consumer list height and center action chips
- Render client locations on a stylized US map

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68afd0dcf9588323900eb9cf1ab6821e