### PR TITLE
Improve dashboard, billing, and schedule layouts

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -27,9 +27,9 @@
   <div id="noClient" class="glass card hidden">Select a client from the Clients page first.</div>
 
   <div id="billingContent" class="space-y-4 hidden">
-    <div class="glass card">
-      <div class="font-medium mb-2">Invoices</div>
-      <table id="invoiceTable" class="invoice-table w-full">
+    <div class="glass card max-w-3xl mx-auto">
+      <div class="font-medium mb-2 text-center">Invoices</div>
+      <table id="invoiceTable" class="invoice-table w-full text-sm">
         <thead>
           <tr>
             <th class="text-left">Description</th>
@@ -42,7 +42,7 @@
         <tbody id="invoiceBody"></tbody>
       </table>
 
-      <form id="invoiceForm" class="mt-4 flex flex-wrap items-end gap-2">
+      <form id="invoiceForm" class="mt-4 flex flex-wrap items-end gap-2 justify-center">
         <input id="invDesc" class="border rounded px-2 py-1 text-sm flex-1" placeholder="Description" />
         <input id="invAmount" type="number" step="0.01" class="border rounded px-2 py-1 text-sm w-32" placeholder="Amount" />
         <input id="invDue" type="date" class="border rounded px-2 py-1 text-sm" />

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -38,7 +38,7 @@
   </div>
 </header>
 <main class="max-w-7xl mx-auto p-4 space-y-4">
-  <div class="glass card relative overflow-hidden">
+  <div class="glass card relative overflow-hidden text-center">
     <div class="pointer-events-none absolute -top-16 -right-16 h-56 w-56 rounded-full bg-gradient-to-tr from-emerald-400 to-cyan-400 opacity-20 blur-3xl animate-blob"></div>
     <h2 class="mb-2 text-2xl font-bold">Welcome back!</h2>
     <p class="text-sm text-gray-600">Let’s knock out today’s tasks.</p>
@@ -46,7 +46,7 @@
     <div id="confetti" class="pointer-events-none absolute inset-0"></div>
   </div>
 
-  <div class="glass card">
+  <div class="glass card max-w-2xl mx-auto">
     <div class="font-medium mb-2">News</div>
     <div id="newsFeed" class="text-sm space-y-1">Loading...</div>
   </div>

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -71,10 +71,15 @@ function renderClientMap(consumers){
   const mapEl = document.getElementById('clientMap');
   if(!mapEl || typeof L === 'undefined') return;
   if(!mapEl.style.height) mapEl.style.height = '16rem';
-  const map = L.map(mapEl).setView([37.8,-96],4);
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
-    attribution:'© OpenStreetMap contributors'
-  }).addTo(map);
+  const map = L.map(mapEl, { zoomControl: true }).setView([37.8,-96],4);
+  mapEl.style.background = '#e5e7eb';
+  fetch('https://raw.githubusercontent.com/PublicaMundi/MappingAPI/master/data/geojson/us-states.json')
+    .then(r=>r.json())
+    .then(data=>{
+      L.geoJSON(data, {
+        style:{ color:'#ffffff', weight:1, fillColor:'#7c3aed', fillOpacity:1 }
+      }).addTo(map);
+    });
   setTimeout(()=>map.invalidateSize(),0);
 
   consumers.forEach(c=>{

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -81,7 +81,7 @@
 <!-- Quick Actions -->
 <div class="max-w-7xl mx-auto">
   <div class="glass card space-y-4">
-    <div>
+    <div class="text-center">
       <div class="mb-1 flex items-center justify-center gap-2">
 
         <div class="font-medium">Client Tracker</div>
@@ -91,10 +91,10 @@
 
       </div>
       <div id="trackerSteps" class="flex flex-wrap justify-center gap-4 text-sm"></div>
-      </div>
-    <div>
+    </div>
+    <div class="text-center">
         <div class="font-medium mb-2">Quick Actions</div>
-      <div id="modeBar" class="flex gap-2 flex-wrap"></div>
+      <div id="modeBar" class="flex gap-2 flex-wrap justify-center"></div>
       <div class="text-sm muted mt-1">
         Click a mode, then click tradeline cards to tag them. Click the mode again to exit.
       </div>
@@ -116,7 +116,7 @@
         </div>
       </div>
       <input id="consumerSearch" placeholder="Search consumers..." class="w-full border rounded px-2 py-1 text-sm" />
-      <div id="consumerList" class="space-y-2"></div>
+      <div id="consumerList" class="space-y-2 max-h-96 overflow-y-auto"></div>
       <div class="flex items-center justify-between pt-2">
         <button id="consPrev" class="btn text-sm">Prev</button>
         <div class="text-sm muted">Page <span id="consPage">1</span> / <span id="consPages">1</span></div>

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -49,21 +49,19 @@
     <div class="text-sm muted">Job: <span id="jobId">—</span></div>
     <div id="err" class="hidden p-3 bg-red-50 border border-red-200 text-red-700 rounded-lg"></div>
 
-    <div class="glass card">
-      <div class="flex flex-wrap items-center justify-between gap-2">
+    <div class="glass card text-center">
+      <div class="flex flex-col items-center gap-2">
         <div class="font-medium">Letters</div>
-        <div class="flex items-center gap-2">
+        <div class="flex flex-wrap items-center justify-center gap-2">
           <button id="btnDownloadAll" class="btn" data-tip="Download all letters as ZIP">Download All</button>
           <button id="btnPortalAll" class="btn" data-tip="Upload letters to client portal">Send to Portal</button>
           <button id="btnEmailAll" class="btn" data-tip="Email letters as PDF attachments">Email All</button>
-
           <button id="btnBack" class="btn">← Back to CRM</button>
         </div>
-
       </div>
 
       <div id="count" class="text-sm muted mt-1"></div>
-      <div id="cards" class="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 mt-3"></div>
+      <div id="cards" class="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 mt-3 justify-items-center"></div>
 
       <div class="flex items-center justify-between mt-4">
         <button id="prev" class="btn">‹ Prev</button>

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -25,21 +25,23 @@
 </header>
 <main class="max-w-7xl mx-auto p-4">
   <h1 class="text-2xl font-bold mb-4">Schedule</h1>
-  <div class="max-w-3xl mx-auto">
-    <div class="flex items-center justify-between mb-2">
-      <button id="prevMonth" class="btn">&lt;</button>
-      <div id="calTitle" class="font-semibold"></div>
-      <button id="nextMonth" class="btn">&gt;</button>
+  <div class="grid md:grid-cols-3 gap-4">
+    <div id="appointmentList" class="glass card md:col-span-1"></div>
+    <div class="md:col-span-2">
+      <div class="flex items-center justify-between mb-2">
+        <button id="prevMonth" class="btn">&lt;</button>
+        <div id="calTitle" class="font-semibold"></div>
+        <button id="nextMonth" class="btn">&gt;</button>
+      </div>
+      <div class="flex justify-end mb-2">
+        <button id="googleBtn" class="btn">Connect Google</button>
+      </div>
+      <div class="grid grid-cols-7 text-center font-medium mb-1">
+        <div>Sun</div><div>Mon</div><div>Tue</div><div>Wed</div><div>Thu</div><div>Fri</div><div>Sat</div>
+      </div>
+      <div id="calendar" class="grid grid-cols-7 gap-2"></div>
     </div>
-    <div class="flex justify-end mb-2">
-      <button id="googleBtn" class="btn">Connect Google</button>
-    </div>
-    <div class="grid grid-cols-7 text-center font-medium mb-1">
-      <div>Sun</div><div>Mon</div><div>Tue</div><div>Wed</div><div>Thu</div><div>Fri</div><div>Sat</div>
-    </div>
-    <div id="calendar" class="grid grid-cols-7 gap-2"></div>
   </div>
-  <div id="appointmentList" class="max-w-3xl mx-auto mt-4"></div>
 </main>
 <script src="/common.js"></script>
 <script src="/hotkeys.js"></script>


### PR DESCRIPTION
## Summary
- Center dashboard news card for a balanced layout
- Style billing invoices section with centered content
- Place "Upcoming" list beside schedule calendar

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68afd0dcf9588323900eb9cf1ab6821e