### PR TITLE
Add dashboard messages card and dispute letter library editor

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -19,7 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
-      <!-- Library placeholder -->
+      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
     </div>
   </div>
@@ -28,7 +28,7 @@
   <div id="noClient" class="glass card hidden">Select a client from the Clients page first.</div>
 
   <div id="billingContent" class="space-y-4 hidden">
-    <div class="glass card max-w-3xl mx-auto">
+    <div class="glass card max-w-lg mx-auto">
       <div class="font-medium mb-2 text-center">Invoices</div>
       <table id="invoiceTable" class="invoice-table w-full text-sm">
         <thead>
@@ -40,15 +40,16 @@
             <th class="text-left">Actions</th>
           </tr>
         </thead>
-        <tbody id="invoiceBody"></tbody>
+        <tbody id="invoiceBody">
+          <tr id="invNewRow">
+            <td><input id="invDesc" class="border rounded px-2 py-1 text-sm w-full" placeholder="Description" /></td>
+            <td><input id="invAmount" type="number" step="0.01" class="border rounded px-2 py-1 text-sm w-full" placeholder="Amount" /></td>
+            <td><input id="invDue" type="date" class="border rounded px-2 py-1 text-sm w-full" /></td>
+            <td></td>
+            <td><button id="invAdd" class="btn text-sm" type="button">Add</button></td>
+          </tr>
+        </tbody>
       </table>
-
-      <form id="invoiceForm" class="mt-4 flex flex-wrap items-end gap-2 justify-center">
-        <input id="invDesc" class="border rounded px-2 py-1 text-sm flex-1" placeholder="Description" />
-        <input id="invAmount" type="number" step="0.01" class="border rounded px-2 py-1 text-sm w-32" placeholder="Amount" />
-        <input id="invDue" type="date" class="border rounded px-2 py-1 text-sm" />
-        <button class="btn text-sm" type="submit">Add</button>
-      </form>
     </div>
   </div>
 </main>

--- a/metro2 (copy 1)/crm/public/billing.js
+++ b/metro2 (copy 1)/crm/public/billing.js
@@ -15,7 +15,9 @@ if(!consumerId){
 async function loadInvoices(){
   const data = await api(`/api/invoices/${consumerId}`);
   const body = $('#invoiceBody');
+  const newRow = document.getElementById('invNewRow');
   body.innerHTML = '';
+  if(newRow) body.appendChild(newRow);
   (data.invoices||[]).forEach(inv=>{
     const tr = document.createElement('tr');
     tr.innerHTML = `
@@ -38,12 +40,11 @@ async function loadInvoices(){
   });
 }
 
-$('#invoiceForm')?.addEventListener('submit', async e=>{
-  e.preventDefault();
+document.getElementById('invAdd')?.addEventListener('click', async ()=>{
   const desc = $('#invDesc').value.trim();
   const amount = parseFloat($('#invAmount').value) || 0;
   const due = $('#invDue').value;
-  if(!desc || !amount){ return; }
+  if(!desc || !amount) return;
   const company = JSON.parse(localStorage.getItem('companyInfo')||'{}');
   await api('/api/invoices', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ consumerId, desc, amount, due, company }) });
   $('#invDesc').value='';

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -29,7 +29,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
-      <!-- Library placeholder -->
+      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You've started your journey.">
         <span class="text-xl">📄</span>
@@ -47,9 +47,20 @@
     <div id="confetti" class="pointer-events-none absolute inset-0"></div>
   </div>
 
-  <div class="glass card max-w-2xl mx-auto">
-    <div class="font-medium mb-2">News</div>
-    <div id="newsFeed" class="text-sm space-y-1">Loading...</div>
+  <div class="grid gap-4 md:grid-cols-2">
+    <div class="glass card">
+      <div class="font-medium mb-2">News</div>
+      <div id="newsFeed" class="text-sm space-y-1">Loading...</div>
+    </div>
+
+    <div class="glass card">
+      <div class="font-medium mb-2">Messages</div>
+      <div id="msgList" class="text-sm space-y-1 min-h-[80px] max-h-48 overflow-y-auto muted">No messages.</div>
+      <div class="flex gap-2 mt-2">
+        <input id="msgInput" class="flex-1 border rounded px-2 py-1 text-sm" placeholder="Type message..." />
+        <button id="msgSend" class="btn text-sm">Send</button>
+      </div>
+    </div>
   </div>
 
   <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -73,7 +73,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
-      <!-- Library placeholder -->
+      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
     </div>
   </div>

--- a/metro2 (copy 1)/crm/public/leads.html
+++ b/metro2 (copy 1)/crm/public/leads.html
@@ -19,7 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
-      <!-- Library placeholder -->
+      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
     </div>
   </div>

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -34,7 +34,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
-      <!-- Library placeholder -->
+      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
     </div>
   </div>
@@ -62,7 +62,7 @@
       </div>
 
       <div id="count" class="text-sm muted mt-1"></div>
-      <div id="cards" class="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 mt-3 justify-items-center"></div>
+      <div id="cards" class="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 mt-3"></div>
 
       <div class="flex items-center justify-between mt-4">
         <button id="prev" class="btn">‹ Prev</button>

--- a/metro2 (copy 1)/crm/public/letters.js
+++ b/metro2 (copy 1)/crm/public/letters.js
@@ -42,12 +42,12 @@ function renderCards(){
   }
   items.forEach((L) => {
     const div = document.createElement("div");
-    div.className = "glass card tl-card";
+    div.className = "glass card tl-card w-full";
     div.innerHTML = `
       <div class="flex items-start justify-between">
         <div>
           <div class="font-semibold">${escapeHtml(L.creditor || "Unknown Creditor")}</div>
-          <div class="text-sm muted">${escapeHtml(L.bureau)} &nbsp;•&nbsp; ${escapeHtml(L.filename)}</div>
+          <div class="text-sm muted">${escapeHtml(L.bureau)}</div>
         </div>
         <div class="flex flex-wrap gap-2 justify-end">
           <a class="btn text-xs open-html" href="${L.htmlUrl}" target="_blank" data-tip="Open HTML (H)">Open HTML</a>
@@ -74,8 +74,8 @@ function renderCards(){
 
 function openPreview(L){
   lastPreview = L;
-  $("#pvTitle").textContent = L.filename;
-  $("#pvMeta").textContent  = `${L.bureau} • ${L.creditor || "Unknown Creditor"}`;
+  $("#pvTitle").textContent = L.creditor || "Letter";
+  $("#pvMeta").textContent  = `${L.bureau}`;
   $("#pvOpen").href = L.htmlUrl;
   $("#pvFrame").src = L.htmlUrl;
   $("#previewModal").style.display = "flex";

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -3,8 +3,65 @@
 <head>
   <meta charset="utf-8" />
   <title>Library</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-  <p>Library placeholder</p>
+<header class="p-4">
+  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
+    <div class="text-xl font-semibold">Metro 2 CRM</div>
+    <div class="flex items-center gap-2">
+      <a href="/dashboard" class="btn">Dashboard</a>
+      <a href="/clients" class="btn">Clients</a>
+      <a href="/leads" class="btn">Leads</a>
+      <a href="/schedule" class="btn">Schedule</a>
+      <a id="navCompany" href="/my-company" class="btn">My Company</a>
+      <a href="/billing" class="btn">Billing</a>
+      <a href="/letters" class="btn">Letter</a>
+      <a href="/settings" class="btn">Settings</a>
+      <a href="/library" class="btn">Library</a>
+      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+    </div>
+  </div>
+</header>
+
+<main class="max-w-5xl mx-auto p-4 space-y-4">
+  <div class="glass card space-y-4">
+    <div class="font-medium">Letter Templates</div>
+    <div class="flex gap-4">
+      <div class="w-1/3">
+        <button id="newTemplate" class="btn w-full mb-2">New Template</button>
+        <div id="templateList" class="space-y-1 text-sm"></div>
+      </div>
+      <div class="flex-1 space-y-2">
+        <input id="tplHeading" class="w-full border rounded px-2 py-1 text-sm" placeholder="Heading" />
+        <textarea id="tplIntro" class="w-full border rounded px-2 py-1 text-sm" placeholder="Intro"></textarea>
+        <textarea id="tplAsk" class="w-full border rounded px-2 py-1 text-sm" placeholder="Ask"></textarea>
+        <textarea id="tplAfter" class="w-full border rounded px-2 py-1 text-sm" placeholder="After Issues"></textarea>
+        <textarea id="tplEvidence" class="w-full border rounded px-2 py-1 text-sm" placeholder="Evidence"></textarea>
+        <button id="saveTemplate" class="btn text-sm">Save Template</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="glass card space-y-4">
+    <div class="font-medium">Sequences</div>
+    <div class="flex gap-4">
+      <div class="w-1/3">
+        <button id="newSequence" class="btn w-full mb-2">New Sequence</button>
+        <div id="sequenceList" class="space-y-1 text-sm"></div>
+      </div>
+      <div class="flex-1 space-y-2">
+        <input id="seqName" class="w-full border rounded px-2 py-1 text-sm" placeholder="Sequence Name" />
+        <input id="seqTemplates" class="w-full border rounded px-2 py-1 text-sm" placeholder="Template IDs (comma separated)" />
+        <button id="saveSequence" class="btn text-sm">Save Sequence</button>
+      </div>
+    </div>
+  </div>
+</main>
+
+<script src="/library.js"></script>
 </body>
 </html>
+

--- a/metro2 (copy 1)/crm/public/library.js
+++ b/metro2 (copy 1)/crm/public/library.js
@@ -1,1 +1,122 @@
-// Library placeholder
+let templates = [];
+let sequences = [];
+let currentTemplateId = null;
+let currentSequenceId = null;
+
+async function loadLibrary(){
+  const res = await fetch('/api/templates');
+  const data = await res.json().catch(()=>({}));
+  templates = data.templates || [];
+  sequences = data.sequences || [];
+  renderTemplates();
+  renderSequences();
+}
+
+function renderTemplates(){
+  const list = document.getElementById('templateList');
+  list.innerHTML = '';
+  templates.forEach(t => {
+    const div = document.createElement('div');
+    div.textContent = t.heading || '(no heading)';
+    div.className = 'chip';
+    div.onclick = () => editTemplate(t.id);
+    list.appendChild(div);
+  });
+}
+
+function editTemplate(id){
+  const tpl = templates.find(t => t.id === id) || {};
+  currentTemplateId = id;
+  document.getElementById('tplHeading').value = tpl.heading || '';
+  document.getElementById('tplIntro').value = tpl.intro || '';
+  document.getElementById('tplAsk').value = tpl.ask || '';
+  document.getElementById('tplAfter').value = tpl.afterIssues || '';
+  document.getElementById('tplEvidence').value = tpl.evidence || '';
+}
+
+function newTemplate(){
+  currentTemplateId = null;
+  document.getElementById('tplHeading').value = '';
+  document.getElementById('tplIntro').value = '';
+  document.getElementById('tplAsk').value = '';
+  document.getElementById('tplAfter').value = '';
+  document.getElementById('tplEvidence').value = '';
+}
+
+async function saveTemplate(){
+  const payload = {
+    id: currentTemplateId,
+    heading: document.getElementById('tplHeading').value,
+    intro: document.getElementById('tplIntro').value,
+    ask: document.getElementById('tplAsk').value,
+    afterIssues: document.getElementById('tplAfter').value,
+    evidence: document.getElementById('tplEvidence').value
+  };
+  const res = await fetch('/api/templates', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json().catch(()=>({}));
+  if(data.template){
+    const existing = templates.find(t => t.id === data.template.id);
+    if(existing){ Object.assign(existing, data.template); }
+    else { templates.push(data.template); }
+    renderTemplates();
+    editTemplate(data.template.id);
+  }
+}
+
+function renderSequences(){
+  const list = document.getElementById('sequenceList');
+  list.innerHTML = '';
+  sequences.forEach(s => {
+    const div = document.createElement('div');
+    div.textContent = s.name || '(no name)';
+    div.className = 'chip';
+    div.onclick = () => editSequence(s.id);
+    list.appendChild(div);
+  });
+}
+
+function editSequence(id){
+  const seq = sequences.find(s => s.id === id) || {};
+  currentSequenceId = id;
+  document.getElementById('seqName').value = seq.name || '';
+  document.getElementById('seqTemplates').value = (seq.templates || []).join(', ');
+}
+
+function newSequence(){
+  currentSequenceId = null;
+  document.getElementById('seqName').value = '';
+  document.getElementById('seqTemplates').value = '';
+}
+
+async function saveSequence(){
+  const payload = {
+    id: currentSequenceId,
+    name: document.getElementById('seqName').value,
+    templates: document.getElementById('seqTemplates').value.split(',').map(s=>s.trim()).filter(Boolean)
+  };
+  const res = await fetch('/api/sequences', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json().catch(()=>({}));
+  if(data.sequence){
+    const existing = sequences.find(s => s.id === data.sequence.id);
+    if(existing){ Object.assign(existing, data.sequence); }
+    else { sequences.push(data.sequence); }
+    renderSequences();
+    editSequence(data.sequence.id);
+  }
+}
+
+document.getElementById('saveTemplate').onclick = saveTemplate;
+document.getElementById('newTemplate').onclick = newTemplate;
+document.getElementById('saveSequence').onclick = saveSequence;
+document.getElementById('newSequence').onclick = newSequence;
+
+loadLibrary();
+

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -19,7 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
-      <!-- Library placeholder -->
+      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
     </div>
   </div>

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -20,7 +20,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
-      <!-- Library placeholder -->
+      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
     </div>
   </div>

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -19,7 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
-      <!-- Library placeholder -->
+      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
     </div>
   </div>

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -19,7 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
-      <!-- Library placeholder -->
+      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
     </div>
   </div>

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -131,6 +131,7 @@ app.get("/billing", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "billing.h
 app.get(["/letters", "/letters/:jobId"], (_req, res) =>
   res.sendFile(path.join(PUBLIC_DIR, "letters.html"))
 );
+app.get("/library", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "library.html")));
 app.get("/quiz", (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "quiz.html")));
 app.get("/settings", (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "settings.html")));
 app.get("/portal/:id", (req, res) => {
@@ -159,6 +160,7 @@ function loadDB(){ return readJson(DB_PATH, { consumers: [] }); }
 function saveDB(db){ writeJson(DB_PATH, db); }
 
 const LETTERS_DB_PATH = path.join(__dirname, "letters-db.json");
+const LETTERS_DEFAULT = { jobs: [], templates: [], sequences: [], contracts: [] };
 function loadLettersDB(){
   const db = readJson(LETTERS_DB_PATH, null);
   if(db){
@@ -460,18 +462,24 @@ app.get("/api/templates", (_req,res)=>{
 
 app.post("/api/templates", (req,res)=>{
   const db = loadLettersDB();
-  const tpl = { id: nanoid(8), name: req.body.name || "", body: req.body.body || "" };
   db.templates = db.templates || [];
-  db.templates.push(tpl);
+  const { id = nanoid(8), heading = "", intro = "", ask = "", afterIssues = "", evidence = "" } = req.body || {};
+  const existing = db.templates.find(t => t.id === id);
+  const tpl = { id, heading, intro, ask, afterIssues, evidence };
+  if(existing){ Object.assign(existing, tpl); }
+  else { db.templates.push(tpl); }
   saveLettersDB(db);
   res.json({ ok:true, template: tpl });
 });
 
 app.post("/api/sequences", (req,res)=>{
   const db = loadLettersDB();
-  const seq = { id: nanoid(8), name: req.body.name || "", templates: req.body.templates || [] };
   db.sequences = db.sequences || [];
-  db.sequences.push(seq);
+  const { id = nanoid(8), name = "", templates = [] } = req.body || {};
+  const existing = db.sequences.find(s => s.id === id);
+  const seq = { id, name, templates };
+  if(existing){ Object.assign(existing, seq); }
+  else { db.sequences.push(seq); }
   saveLettersDB(db);
   res.json({ ok:true, sequence: seq });
 });


### PR DESCRIPTION
## Summary
- Add Library link to navigation and create Library page for editing letter templates and sequences.
- Implement client-side editor and backend endpoints for managing templates and sequences.
- Previously added dashboard messages card and refined billing and letters layout.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b03d5a50848323a9b807895fbfc250