### PR TITLE
Use theme palette for accent color

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -4,7 +4,7 @@ const productTiers = [
   { deletions:125, score:760, name:'Elite Borrower', icon:'🦸', class:'bg-red-100 text-red-700', message:'You’ve achieved elite borrower status — lenders see you as top-tier.' },
   { deletions:100, score:750, name:'Funding Power', icon:'🏆', class:'bg-yellow-200 text-yellow-800', message:'You’ve become a funding champion — major approvals are within reach.' },
   { deletions:75, score:740, name:'Travel & Rewards', icon:'✈️', class:'bg-indigo-100 text-indigo-700', message:'You now qualify for premium travel rewards and lifestyle cards.' },
-  { deletions:50, score:720, name:'Credit Line Access', icon:'💼', class:'bg-blue-100 text-blue-700', message:'Business and personal credit lines are opening up.' },
+  { deletions:50, score:720, name:'Credit Line Access', icon:'💼', class:'bg-accent-subtle', message:'Business and personal credit lines are opening up.' },
   { deletions:40, score:700, name:'Mortgage Ready', icon:'🏡', class:'bg-green-100 text-green-700', message:'You’re building toward homeownership — mortgage approvals are now within reach.' },
   { deletions:30, score:680, name:'Loan Lever', icon:'🏦', class:'bg-lime-100 text-lime-700', message:'Personal loan doors are opening — leverage your clean report.' },
   { deletions:20, score:650, name:'Prime Plastic', icon:'💳', class:'bg-cyan-100 text-cyan-700', message:'You’re climbing into prime cards with real rewards.' },

--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -1,17 +1,18 @@
 /* public/common.js */
 const THEMES = {
-  blue:   { accent: '#007AFF', hover: '#005bb5', glassBg: 'rgba(0,122,255,0.15)', glassBrd: 'rgba(0,122,255,0.3)' },
-  green:  { accent: '#34C759', hover: '#248a3d', glassBg: 'rgba(52,199,89,0.15)', glassBrd: 'rgba(52,199,89,0.3)' },
-  orange: { accent: '#FF9500', hover: '#cc7600', glassBg: 'rgba(255,149,0,0.15)', glassBrd: 'rgba(255,149,0,0.3)' },
-  red:    { accent: '#FF3B30', hover: '#c82d24', glassBg: 'rgba(255,59,48,0.15)', glassBrd: 'rgba(255,59,48,0.3)' },
-  purple: { accent: '#AF52DE', hover: '#893dba', glassBg: 'rgba(175,82,222,0.15)', glassBrd: 'rgba(175,82,222,0.3)' }
+  blue:   { accent: '#007AFF', hover: '#005bb5', bg: 'rgba(0,122,255,0.12)', glassBg: 'rgba(0,122,255,0.15)', glassBrd: 'rgba(0,122,255,0.3)' },
+  green:  { accent: '#34C759', hover: '#248a3d', bg: 'rgba(52,199,89,0.12)', glassBg: 'rgba(52,199,89,0.15)', glassBrd: 'rgba(52,199,89,0.3)' },
+  orange: { accent: '#FF9500', hover: '#cc7600', bg: 'rgba(255,149,0,0.12)', glassBg: 'rgba(255,149,0,0.15)', glassBrd: 'rgba(255,149,0,0.3)' },
+  red:    { accent: '#FF3B30', hover: '#c82d24', bg: 'rgba(255,59,48,0.12)', glassBg: 'rgba(255,59,48,0.15)', glassBrd: 'rgba(255,59,48,0.3)' },
+  purple: { accent: '#AF52DE', hover: '#893dba', bg: 'rgba(175,82,222,0.12)', glassBg: 'rgba(175,82,222,0.15)', glassBrd: 'rgba(175,82,222,0.3)' }
 };
 
 function applyTheme(name){
-  const t = THEMES[name] || THEMES.blue;
+  const t = THEMES[name] || THEMES.purple;
   const root = document.documentElement.style;
   root.setProperty('--accent', t.accent);
   root.setProperty('--accent-hover', t.hover);
+  root.setProperty('--accent-bg', t.bg);
   root.setProperty('--glass-bg', t.glassBg);
   root.setProperty('--glass-brd', t.glassBrd);
   localStorage.setItem('theme', name);
@@ -43,7 +44,7 @@ function initPalette(){
     if(!b) return;
     applyTheme(b.dataset.theme);
   });
-  const saved = localStorage.getItem('theme') || 'blue';
+  const saved = localStorage.getItem('theme') || 'purple';
   applyTheme(saved);
 }
 

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -9,7 +9,7 @@ const deletionTiers = [
   { threshold: 60, name: 'Credit Surgeon', icon: '🩺', class: 'bg-cyan-100 text-cyan-700', message: 'Precision deletions.' },
   { threshold: 50, name: 'Dispute Master', icon: '🥋', class: 'bg-purple-100 text-purple-700', message: 'Mastering the dispute process.' },
   { threshold: 40, name: 'Debt Slayer', icon: '⚔️', class: 'bg-gray-100 text-gray-700', message: 'Slaying negative accounts.' },
-  { threshold: 30, name: 'Report Scrubber', icon: '🧼', class: 'bg-blue-100 text-blue-700', message: 'Deep cleaning your credit.' },
+  { threshold: 30, name: 'Report Scrubber', icon: '🧼', class: 'bg-accent-subtle', message: 'Deep cleaning your credit.' },
   { threshold: 20, name: 'Score Shifter', icon: '📊', class: 'bg-green-100 text-green-700', message: 'Scores are improving.' },
   { threshold: 15, name: 'Credit Cleaner', icon: '🧽', class: 'bg-yellow-100 text-yellow-700', message: 'Your report is shining.' },
   { threshold: 10, name: 'Balance Buster', icon: '💥', class: 'bg-orange-100 text-orange-700', message: 'Breaking negative balances.' },
@@ -108,7 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
         feedEl.innerHTML = items.slice(0,5).map(item => {
-          return `<div class="news-item"><a href="${item.link}" target="_blank" class="text-blue-600 underline">${item.title}</a></div>`;
+          return `<div class="news-item"><a href="${item.link}" target="_blank" class="text-accent underline">${item.title}</a></div>`;
         }).join('');
       })
       .catch(err => {

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Metro 2 CRM</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <meta name="theme-color" content="#007AFF" />
+  <meta name="theme-color" content="#AF52DE" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
   <style>
@@ -14,8 +14,8 @@
       --muted:#6b7280;
       --green:#22c55e;
       --green-bg:rgba(34,197,94,.12);
-      --accent:#007AFF;
-      --accent-bg:rgba(0,122,255,.12);
+      --accent:#AF52DE;
+      --accent-bg:rgba(175,82,222,.12);
     }
     .glass{ background:var(--glass-bg); border:1px solid var(--glass-brd); border-radius:18px; backdrop-filter:blur(12px) saturate(180%); box-shadow:0 8px 24px rgba(0,0,0,.1) }
     .card{ border-radius:18px; padding:16px }

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -59,17 +59,17 @@ function formatEvent(ev){
   } else if(ev.type === "audit_generated"){
     const { reportId, file } = ev.payload || {};
     title = "Audit generated";
-    const link = file ? `<a href="${escapeHtml(file)}" target="_blank" class="text-blue-600 underline">open</a>` : "";
+    const link = file ? `<a href="${escapeHtml(file)}" target="_blank" class="text-accent underline">open</a>` : "";
     body = `<div class="text-xs mt-1">Report ${escapeHtml(reportId||"")} ${link}</div>`;
   } else if(ev.type === "breach_audit_generated"){
     const { file } = ev.payload || {};
     title = "Data breach audit generated";
-    const link = file ? `<a href="${escapeHtml(file)}" target="_blank" class="text-blue-600 underline">open</a>` : "";
+    const link = file ? `<a href="${escapeHtml(file)}" target="_blank" class="text-accent underline">open</a>` : "";
     body = `<div class="text-xs mt-1">${link}</div>`;
   } else if(ev.type === "letters_portal_sent"){
     const { file } = ev.payload || {};
     title = "Letters sent to portal";
-    const link = file ? `<a href="${escapeHtml(file)}" target="_blank" class="text-blue-600 underline">open</a>` : "";
+    const link = file ? `<a href="${escapeHtml(file)}" target="_blank" class="text-accent underline">open</a>` : "";
     body = `<div class="text-xs mt-1">${link}</div>`;
 
   } else if(ev.type === "consumer_created"){

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -29,7 +29,7 @@
     <div class="bg-white rounded-2xl shadow p-6">
       <div class="flex items-center justify-between">
         <h1 class="text-xl font-semibold">Metro 2 CRM — Hotkey Quiz</h1>
-        <a class="text-sm text-blue-600 hover:underline" href="/" target="_blank">Back to CRM</a>
+        <a class="text-sm text-accent hover:underline" href="/" target="_blank">Back to CRM</a>
       </div>
       <p class="text-sm text-slate-600 mt-1">Quick 6-question multiple-choice to learn the keyboard shortcuts.</p>
 

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -3,9 +3,9 @@
   --glass-bg: rgba(255,255,255,0.25);
   --glass-brd: rgba(255,255,255,0.15);
   --muted: #6b7280;
-  --accent: #007AFF;
-  --accent-hover: #005bb5;
-  --accent-bg: rgba(0,122,255,0.12);
+  --accent: #AF52DE;
+  --accent-hover: #893dba;
+  --accent-bg: rgba(175,82,222,0.12);
   --green-bg: rgba(34,197,94,0.12);
 }
 body {
@@ -34,6 +34,9 @@ body {
 }
 .btn:hover { background: var(--accent-hover); }
 .muted { color: var(--muted); }
+
+.text-accent { color: var(--accent); }
+.bg-accent-subtle { background: var(--accent-bg); color: var(--accent); }
 
 #themePalette {
   position: fixed;


### PR DESCRIPTION
## Summary
- replace hard-coded blue defaults with purple theme variables
- add accent utility classes and switch links and badges to use them
- allow theme palette to control accent background color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0442ee2808323b640a11148b9b11d