### PR TITLE
Use solid highlight colors across UI

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -13,18 +13,18 @@
       --glass-brd: rgba(255,255,255,0.25);
       --muted:#6b7280;
       --green:#22c55e;
-      --green-bg:rgba(34,197,94,.12);
+      --green-bg:#22c55e;
       --accent:#007AFF;
-      --accent-bg:rgba(0,122,255,.12);
+      --accent-bg:#007AFF;
     }
     .glass{ background:var(--glass-bg); border:1px solid var(--glass-brd); border-radius:18px; backdrop-filter:blur(12px) saturate(180%); box-shadow:0 8px 24px rgba(0,0,0,.1) }
     .card{ border-radius:18px; padding:16px }
     .chip{ border:1px solid var(--glass-brd); padding:4px 10px; border-radius:999px; font-size:12px; background:rgba(255,255,255,.7); cursor:pointer; user-select:none }
-    .chip.active{ background:var(--accent-bg); border-color:var(--accent) }
+    .chip.active{ background:var(--accent-bg); border-color:var(--accent); color:#fff }
     .muted{ color:var(--muted) }
     .tl-card{ transition:transform .2s ease, box-shadow .15s ease, background .15s ease; }
     .tl-card:hover{ transform: translateY(-1px) scale(1.01) }
-    .tl-card.selected{ box-shadow:0 0 0 2px var(--green) inset; background:var(--green-bg) }
+    .tl-card.selected{ box-shadow:0 0 0 2px var(--green) inset; background:var(--green-bg); color:#fff }
     .tl-card.negative{ box-shadow:0 0 0 2px #ef4444 inset, 0 8px 24px rgba(0,0,0,.1); background:rgba(239,68,68,.12); }
     .wrap-anywhere{ overflow-wrap:anywhere; word-break:break-word }
     .hidden{ display:none }

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -9,7 +9,7 @@
   <style>
     :root {
       --green:#22c55e;
-      --green-bg: rgba(34,197,94,.12);
+      --green-bg: #22c55e;
     }
     .tl-card{ transition:transform .15s ease, box-shadow .15s ease, background .15s ease; cursor:pointer; }
     .tl-card:hover{ transform:translateY(-1px); }

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -5,8 +5,8 @@
   --muted: #6b7280;
   --accent: #007AFF;
   --accent-hover: #005bb5;
-  --accent-bg: rgba(0,122,255,0.12);
-  --green-bg: rgba(34,197,94,0.12);
+  --accent-bg: #007AFF;
+  --green-bg: #22C55E;
 }
 body {
   /* Use root-relative path so asset resolves regardless of deployment directory */
@@ -163,9 +163,11 @@ body.voice-active #voiceNotes{display:block;}
 /* Messaging */
 .msg-host {
   background: var(--accent-bg);
+  color: #fff;
 }
 .msg-client {
   background: var(--green-bg);
+  color: #fff;
 }
 
 


### PR DESCRIPTION
## Summary
- Use solid accent and green values for highlight backgrounds
- Ensure selected tradelines and chips show white text for legibility
- Make message bubbles and letter pages use the same solid highlight palette

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0457172888323ab1c8f2b7fefc1ce