### PR TITLE
feat: seed default templates and expand theme options

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -771,7 +771,7 @@ function generateLetters({ report, selections, consumer, requestType = "correct"
   return letters;
 }
 
-export { generateLetters, generatePersonalInfoLetters, generateInquiryLetters, generateDebtCollectorLetters };
+export { generateLetters, generatePersonalInfoLetters, generateInquiryLetters, generateDebtCollectorLetters, modeCopy };
 
 
 

--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -4,7 +4,9 @@ const THEMES = {
   green:  { accent: '#34C759', hover: '#248a3d', bg: 'rgba(52,199,89,0.12)', glassBg: 'rgba(52,199,89,0.15)', glassBrd: 'rgba(52,199,89,0.3)' },
   orange: { accent: '#FF9500', hover: '#cc7600', bg: 'rgba(255,149,0,0.12)', glassBg: 'rgba(255,149,0,0.15)', glassBrd: 'rgba(255,149,0,0.3)' },
   red:    { accent: '#FF3B30', hover: '#c82d24', bg: 'rgba(255,59,48,0.12)', glassBg: 'rgba(255,59,48,0.15)', glassBrd: 'rgba(255,59,48,0.3)' },
-  purple: { accent: '#AF52DE', hover: '#893dba', bg: 'rgba(175,82,222,0.12)', glassBg: 'rgba(175,82,222,0.15)', glassBrd: 'rgba(175,82,222,0.3)' }
+  purple: { accent: '#AF52DE', hover: '#893dba', bg: 'rgba(175,82,222,0.12)', glassBg: 'rgba(175,82,222,0.15)', glassBrd: 'rgba(175,82,222,0.3)' },
+  teal:   { accent: '#14B8A6', hover: '#0d9488', bg: 'rgba(20,184,166,0.12)', glassBg: 'rgba(20,184,166,0.15)', glassBrd: 'rgba(20,184,166,0.3)' },
+  pink:   { accent: '#EC4899', hover: '#c0347a', bg: 'rgba(236,72,153,0.12)', glassBg: 'rgba(236,72,153,0.15)', glassBrd: 'rgba(236,72,153,0.3)' }
 };
 
 function applyTheme(name){
@@ -15,6 +17,7 @@ function applyTheme(name){
   root.setProperty('--accent-bg', t.bg);
   root.setProperty('--glass-bg', t.glassBg);
   root.setProperty('--glass-brd', t.glassBrd);
+  document.querySelector('meta[name="theme-color"]')?.setAttribute('content', t.accent);
   localStorage.setItem('theme', name);
 }
 
@@ -23,15 +26,12 @@ function initPalette(){
   const wrap = document.createElement('div');
   wrap.id = 'themePalette';
   wrap.className = 'collapsed';
+  const bubbles = Object.entries(THEMES)
+    .map(([name, t]) => `<div class="bubble" data-theme="${name}" style="background:${t.accent}"></div>`)
+    .join('');
   wrap.innerHTML = `
     <button class="toggle">▶</button>
-    <div class="palette-bubbles">
-      <div class="bubble" data-theme="blue" style="background:#007AFF"></div>
-      <div class="bubble" data-theme="green" style="background:#34C759"></div>
-      <div class="bubble" data-theme="orange" style="background:#FF9500"></div>
-      <div class="bubble" data-theme="red" style="background:#FF3B30"></div>
-      <div class="bubble" data-theme="purple" style="background:#AF52DE"></div>
-    </div>
+    <div class="palette-bubbles">${bubbles}</div>
     <button id="voiceMic" class="mic">🎤</button>`;
   document.body.appendChild(wrap);
   const toggle = wrap.querySelector('.toggle');

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -63,7 +63,7 @@
     </div>
   </div>
 </main>
-
+<script src="/common.js"></script>
 <script src="/library.js"></script>
 </body>
 </html>

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -38,6 +38,20 @@ body {
 .text-accent { color: var(--accent); }
 .bg-accent-subtle { background: var(--accent-bg); color: var(--accent); }
 
+.chip {
+  border: 1px solid var(--glass-brd);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  background: rgba(255,255,255,.7);
+  cursor: pointer;
+  user-select: none;
+}
+.chip.active {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+}
+
 #themePalette {
   position: fixed;
   top: 50%;

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -20,7 +20,7 @@ import { ensureBuffer, readJson, writeJson } from "./utils.js";
 
 
 
-import { generateLetters, generatePersonalInfoLetters, generateInquiryLetters, generateDebtCollectorLetters } from "./letterEngine.js";
+import { generateLetters, generatePersonalInfoLetters, generateInquiryLetters, generateDebtCollectorLetters, modeCopy } from "./letterEngine.js";
 import { PLAYBOOKS } from "./playbook.js";
 import { normalizeReport, renderHtml, savePdf } from "./creditAuditTool.js";
 import {
@@ -450,11 +450,23 @@ app.post("/api/messages/:consumerId", (req,res)=>{
 });
 
 // =================== Templates / Sequences / Contracts ===================
+function defaultTemplates(){
+  return [
+    { id: "identity", ...modeCopy("identity", "delete", true) },
+    { id: "breach",   ...modeCopy("breach", "delete", true) },
+    { id: "assault",  ...modeCopy("assault", "delete", true) },
+    { id: "standard", ...modeCopy(null, "delete", true) }
+  ];
+}
 app.get("/api/templates", (_req,res)=>{
   const db = loadLettersDB();
+  if(!db.templates || db.templates.length === 0){
+    db.templates = defaultTemplates();
+    saveLettersDB(db);
+  }
   res.json({
     ok: true,
-    templates: db.templates || [],
+    templates: db.templates,
     sequences: db.sequences || [],
     contracts: db.contracts || []
   });


### PR DESCRIPTION
## Summary
- provide default letter templates when none exist
- centralize chip styles and enable theming across pages
- add more theme colors and dynamic palette rendering

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b046b416048323b7355fc9502d8fcc