### PR TITLE
Show host messages in portal banner

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -326,8 +326,9 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(data => {
         const msgs = data.messages || [];
         if (messageBanner) {
-          if (msgs.length) {
-            messageBanner.textContent = msgs[0].payload?.text || '';
+          const hostMsg = msgs.find(m => m.payload?.from === 'host');
+          if (hostMsg) {
+            messageBanner.textContent = hostMsg.payload?.text || '';
             messageBanner.classList.remove('hidden');
           } else {
             messageBanner.classList.add('hidden');


### PR DESCRIPTION
## Summary
- Display the most recent host message in the client portal banner instead of the last sent message

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b04c3d4d888323ae65410793e7593c