### PR TITLE
Style checkbox accents for selected cards

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -26,6 +26,7 @@
     .tl-card{ transition:transform .2s ease, box-shadow .15s ease, background .15s ease; }
     .tl-card:hover{ transform: translateY(-1px) scale(1.01) }
     .tl-card.selected{ box-shadow:0 0 0 2px var(--green) inset; background:var(--green-bg); color:#fff }
+    .tl-card.selected input[type="checkbox"]{ accent-color: currentColor; }
     .tl-card.negative{ box-shadow:0 0 0 2px #ef4444 inset, 0 8px 24px rgba(0,0,0,.1); background:rgba(239,68,68,.12); }
     .wrap-anywhere{ overflow-wrap:anywhere; word-break:break-word }
     .hidden{ display:none }

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -188,4 +188,8 @@ body.voice-active #voiceNotes{display:block;}
   color: #fff;
 }
 
+.tl-card.selected input[type="checkbox"] {
+  accent-color: currentColor;
+}
+
 


### PR DESCRIPTION
## Summary
- Keep checkboxes visible on highlighted timeline cards by matching checkbox accent to card text color

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b04cafc23c8323af99826e1e6d2b5e