### PR TITLE
Add Invite button to navigation header

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -21,6 +21,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>
   </div>
 </header>

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -31,6 +31,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
       <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You've started your journey.">
         <span class="text-xl">📄</span>
         <span class="font-semibold text-sm">Rookie</span>

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -76,6 +76,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>
   </div>
 </header>

--- a/metro2 (copy 1)/crm/public/leads.html
+++ b/metro2 (copy 1)/crm/public/leads.html
@@ -21,6 +21,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>
   </div>
 </header>

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -36,6 +36,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>
   </div>
 </header>

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -22,6 +22,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>
   </div>
 </header>

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -21,6 +21,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>
   </div>
 </header>

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -22,6 +22,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>
   </div>
 </header>

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -21,6 +21,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>
   </div>
 </header>

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -21,6 +21,7 @@
       <a href="/settings" class="btn">Settings</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- Add a green "Invite" button to the navigation bar across host-side HTML pages.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b04d432af083238ef24f4beac26592