### PR TITLE
Enable selecting templates when building sequences

### DIFF
--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -58,7 +58,7 @@
       </div>
       <div class="flex-1 space-y-2">
         <input id="seqName" class="w-full border rounded px-2 py-1 text-sm" placeholder="Sequence Name" />
-        <input id="seqTemplates" class="w-full border rounded px-2 py-1 text-sm" placeholder="Template IDs (comma separated)" />
+        <div id="seqTemplates" class="border rounded px-2 py-1 text-sm space-y-1 max-h-60 overflow-y-auto"></div>
         <button id="saveSequence" class="btn text-sm">Save Sequence</button>
       </div>
     </div>

--- a/metro2 (copy 1)/crm/public/library.js
+++ b/metro2 (copy 1)/crm/public/library.js
@@ -10,6 +10,7 @@ async function loadLibrary(){
   sequences = data.sequences || [];
   renderTemplates();
   renderSequences();
+  renderSeqTemplateOptions([]);
 }
 
 function renderTemplates(){
@@ -91,24 +92,41 @@ function renderSequences(){
   });
 }
 
+function renderSeqTemplateOptions(selected){
+  const container = document.getElementById('seqTemplates');
+  container.innerHTML = '';
+  templates.forEach(t => {
+    const label = document.createElement('label');
+    label.className = 'flex items-center gap-1 text-xs';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.value = t.id;
+    cb.checked = selected.includes(t.id);
+    label.appendChild(cb);
+    label.append(t.heading || '(no heading)');
+    container.appendChild(label);
+  });
+}
+
 function editSequence(id){
   const seq = sequences.find(s => s.id === id) || {};
   currentSequenceId = id;
   document.getElementById('seqName').value = seq.name || '';
-  document.getElementById('seqTemplates').value = (seq.templates || []).join(', ');
+  renderSeqTemplateOptions(seq.templates || []);
 }
 
 function newSequence(){
   currentSequenceId = null;
   document.getElementById('seqName').value = '';
-  document.getElementById('seqTemplates').value = '';
+  renderSeqTemplateOptions([]);
 }
 
 async function saveSequence(){
+  const selected = Array.from(document.querySelectorAll('#seqTemplates input[type="checkbox"]:checked')).map(cb => cb.value);
   const payload = {
     id: currentSequenceId,
     name: document.getElementById('seqName').value,
-    templates: document.getElementById('seqTemplates').value.split(',').map(s=>s.trim()).filter(Boolean)
+    templates: selected
   };
   const res = await fetch('/api/sequences', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Replace manual template ID entry with UI to pick templates when creating sequences
- Persist selected templates when editing and saving sequences

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b04fa5870c832397dcf02f172fa103