### PR TITLE
Enable selecting templates when building sequences

### DIFF
--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -41,7 +41,10 @@
         <textarea id="tplAsk" class="w-full border rounded px-2 py-1 text-sm" placeholder="Ask"></textarea>
         <textarea id="tplAfter" class="w-full border rounded px-2 py-1 text-sm" placeholder="After Issues"></textarea>
         <textarea id="tplEvidence" class="w-full border rounded px-2 py-1 text-sm" placeholder="Evidence"></textarea>
-        <button id="saveTemplate" class="btn text-sm">Save Template</button>
+        <div class="flex gap-2">
+          <button id="saveTemplate" class="btn text-sm">Save Template</button>
+          <button id="saveTemplateCopy" class="btn text-sm">Save As New</button>
+        </div>
       </div>
       <div class="flex-1">
         <div id="tplPreview" class="w-full border rounded px-2 py-1 text-sm whitespace-pre-line"></div>
@@ -58,7 +61,7 @@
       </div>
       <div class="flex-1 space-y-2">
         <input id="seqName" class="w-full border rounded px-2 py-1 text-sm" placeholder="Sequence Name" />
-        <input id="seqTemplates" class="w-full border rounded px-2 py-1 text-sm" placeholder="Template IDs (comma separated)" />
+        <div id="seqTemplates" class="border rounded px-2 py-1 text-sm space-y-1 max-h-60 overflow-y-auto"></div>
         <button id="saveSequence" class="btn text-sm">Save Sequence</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace manual template ID entry with UI to pick templates when creating sequences
- Persist selected templates when editing and saving sequences
- Allow saving templates as new copies and refresh sequence template options

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b04fa5870c832397dcf02f172fa103