### PR TITLE
Move Quick Actions to dedicated card

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -82,27 +82,17 @@
   </div>
 </header>
 
-<!-- Quick Actions -->
+<!-- Client Tracker -->
 <div class="max-w-7xl mx-auto">
-  <div class="glass card space-y-4">
+  <div class="glass card">
     <div class="text-center">
-
       <div class="mb-1 flex items-center justify-center gap-2">
-
         <div class="font-medium">Client Tracker</div>
         <div id="stepControls" class="flex items-center gap-2 text-sm">
           <button id="addStep" class="btn text-[10px]" title="Add step">+</button>
         </div>
-
       </div>
       <div id="trackerSteps" class="flex flex-wrap justify-center gap-4 text-sm"></div>
-    </div>
-    <div class="text-center">
-        <div class="font-medium mb-2">Quick Actions</div>
-      <div id="modeBar" class="flex gap-2 flex-wrap justify-center"></div>
-      <div class="text-sm muted mt-1">
-        Click a mode, then click tradeline cards to tag them. Click the mode again to exit.
-      </div>
     </div>
   </div>
 </div>
@@ -170,6 +160,14 @@
         <div class="font-semibold mb-2">Filters</div>
         <div id="filterBar" class="flex flex-wrap gap-2"></div>
         <button id="btnClearFilters" class="btn mt-2" data-tip="Clear Filters (C)">Clear Filters</button>
+      </div>
+
+      <div class="glass card text-center">
+        <div class="font-medium mb-2">Quick Actions</div>
+        <div id="modeBar" class="flex gap-2 flex-wrap justify-center"></div>
+        <div class="text-sm muted mt-1">
+          Click a mode, then click tradeline cards to tag them. Click the mode again to exit.
+        </div>
       </div>
 
       <div class="glass card">


### PR DESCRIPTION
## Summary
- Show client tracker by itself at the top of the page
- Add a separate Quick Actions card before the Tradelines list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68b05e80304083238be4c4feeaab626c