### PR TITLE
Add OCR-resistant PDF option for tradelines

### DIFF
--- a/metro2 (copy 1)/crm/ocr_resistant_pdf.py
+++ b/metro2 (copy 1)/crm/ocr_resistant_pdf.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+ocr_resistant_pdf.py
+Create human-readable but OCR-resistant PDFs with a neutral watermark.
+
+Features
+- Neutral diagonal-stripe watermark (no text)
+- Light grid background
+- Random speckle noise
+- Strength presets (subtle / strong)
+- Safe zones to keep overlays off address/signature blocks
+- CLI and importable API
+
+Usage examples
+--------------
+# Strong preset with overlays everywhere:
+python ocr_resistant_pdf.py --in letter.txt --out Dispute_Strong.pdf --preset strong
+
+# Subtle preset, and keep overlays off a 4"x1.5" address window at 1" from top/left:
+python ocr_resistant_pdf.py --in letter.txt --out Dispute_Subtle.pdf --preset subtle \
+  --safe-zone 72 72 288 108 # all values in points (1 pt = 1/72 inch)
+
+# Fully custom:
+python ocr_resistant_pdf.py --in letter.txt --out Custom.pdf \
+  --page 1700x2200 --margin 140 --font-size 28 \
+  --grid-spacing 32 --grid-alpha 28 \
+  --wm-spacing 200 --wm-width 4 --wm-alpha 35 \
+  --speckles 3200 --speckle-radius 1 2 --speckle-alpha 90
+"""
+
+import argparse
+import os
+import textwrap
+import random
+from dataclasses import dataclass, field
+from typing import List, Tuple, Optional
+from PIL import Image, ImageDraw, ImageFont
+
+@dataclass
+class OCRStyle:
+    page_w: int = 1700
+    page_h: int = 2200
+    margin: int = 140
+    font_paths: List[str] = field(default_factory=lambda: [
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        "/System/Library/Fonts/SFNS.ttf",
+    ])
+    font_size: int = 28
+
+    grid_on: bool = True
+    grid_spacing: int = 32
+    grid_rgba: Tuple[int, int, int, int] = (100, 100, 100, 28)
+
+    wm_on: bool = True
+    wm_spacing: int = 200
+    wm_width: int = 4
+    wm_rgba: Tuple[int, int, int, int] = (120, 120, 120, 35)
+
+    speckles_on: bool = True
+    speckle_count: int = 3200
+    speckle_radius_range: Tuple[int, int] = (1, 2)
+    speckle_rgba: Tuple[int, int, int, int] = (0, 0, 0, 90)
+
+    safe_zones: List[Tuple[int, int, int, int]] = field(default_factory=list)
+
+def _load_font(paths: List[str], size: int) -> ImageFont.FreeTypeFont:
+    for p in paths:
+        if os.path.exists(p):
+            try:
+                return ImageFont.truetype(p, size)
+            except Exception:
+                pass
+    return ImageFont.load_default()
+
+def _draw_text_block(draw: ImageDraw.ImageDraw, text: str, x: int, y: int, max_w: int, font: ImageFont.FreeTypeFont, line_height_mult: float = 1.35, fill=(0,0,0)) -> int:
+    lines: List[str] = []
+    for paragraph in text.split("\n"):
+        if not paragraph.strip():
+            lines.append("")
+            continue
+        try:
+            avg = font.getlength("abcdefghijklmnopqrstuvwxyz") / 26.0
+        except Exception:
+            avg = font.size * 0.6
+        est_chars = max(8, int(max_w / max(1, avg)))
+        wrapped = textwrap.wrap(paragraph, width=est_chars)
+        refined: List[str] = []
+        for line in wrapped:
+            while True:
+                try:
+                    if font.getlength(line) <= max_w:
+                        break
+                except Exception:
+                    break
+                if " " not in line:
+                    break
+                line = line.rsplit(" ", 1)[0]
+            refined.append(line)
+        lines.extend(refined)
+
+    line_h = int(font.size * line_height_mult)
+    cy = y
+    for line in lines:
+        draw.text((x, cy), line, font=font, fill=fill)
+        cy += line_h
+    return cy
+
+def _apply_mask_for_safe_zones(layer: Image.Image, safe_zones: List[Tuple[int, int, int, int]]) -> Image.Image:
+    if not safe_zones:
+        return layer
+    w, h = layer.size
+    mask = Image.new("L", (w, h), 255)
+    md = ImageDraw.Draw(mask)
+    for (sx, sy, sw, sh) in safe_zones:
+        md.rectangle([sx, sy, sx + sw, sy + sh], fill=0)
+    rgba = layer.split()
+    new_alpha = Image.eval(rgba[3], lambda a: int(a))
+    black = Image.new("L", (w, h), 0)
+    inv = Image.eval(mask, lambda v: 255 - v)
+    new_alpha.paste(black, mask=inv)
+    return Image.merge("RGBA", (rgba[0], rgba[1], rgba[2], new_alpha))
+
+def add_light_grid(base: Image.Image, style: OCRStyle) -> None:
+    if not style.grid_on:
+        return
+    grid = Image.new("RGBA", base.size, (0,0,0,0))
+    g = ImageDraw.Draw(grid)
+    w, h = base.size
+    for x in range(0, w, style.grid_spacing):
+        g.line([(x,0),(x,h)], fill=style.grid_rgba, width=1)
+    for y in range(0, h, style.grid_spacing):
+        g.line([(0,y),(w,y)], fill=style.grid_rgba, width=1)
+    grid = _apply_mask_for_safe_zones(grid, style.safe_zones)
+    base.alpha_composite(grid)
+
+def add_neutral_watermark(base: Image.Image, style: OCRStyle) -> None:
+    if not style.wm_on:
+        return
+    wm = Image.new("RGBA", base.size, (0,0,0,0))
+    d = ImageDraw.Draw(wm)
+    w, h = wm.size
+    step = style.wm_spacing
+    for i in range(-h, w, step):
+        d.line([(i,0),(i+h,h)], fill=style.wm_rgba, width=style.wm_width)
+    wm = _apply_mask_for_safe_zones(wm, style.safe_zones)
+    base.alpha_composite(wm)
+
+def add_speckles(base: Image.Image, style: OCRStyle) -> None:
+    if not style.speckles_on or style.speckle_count <= 0:
+        return
+    speck = Image.new("RGBA", base.size, (0,0,0,0))
+    d = ImageDraw.Draw(speck)
+    w, h = base.size
+    rmin, rmax = style.speckle_radius_range
+    for _ in range(style.speckle_count):
+        r = random.randint(rmin, rmax)
+        x = random.randint(0, w-1)
+        y = random.randint(0, h-1)
+        if r <= 0:
+            d.point((x,y), fill=style.speckle_rgba)
+        else:
+            d.ellipse((x-r,y-r,x+r,y+r), fill=style.speckle_rgba, outline=None)
+    speck = _apply_mask_for_safe_zones(speck, style.safe_zones)
+    base.alpha_composite(speck)
+
+def render_ocr_resistant_pdf(text: str, out_path: str, style: Optional[OCRStyle]=None) -> str:
+    style = style or OCRStyle()
+    page = Image.new("RGBA", (style.page_w, style.page_h), (255,255,255,255))
+    add_light_grid(page, style)
+    add_neutral_watermark(page, style)
+    font = _load_font(style.font_paths, style.font_size)
+    d = ImageDraw.Draw(page)
+    x = style.margin
+    y = style.margin
+    max_w = style.page_w - style.margin*2
+    _draw_text_block(d, text, x, y, max_w, font)
+    add_speckles(page, style)
+    rgb = page.convert("RGB")
+    os.makedirs(os.path.dirname(out_path) or '.', exist_ok=True)
+    rgb.save(out_path)
+    return out_path
+
+def _parse_pt_rect(val: List[str]) -> Tuple[int,int,int,int]:
+    if len(val) != 4:
+        raise ValueError("safe-zone needs 4 integers: x y w h")
+    return tuple(int(v) for v in val)
+
+def _make_preset(name: str) -> OCRStyle:
+    s = OCRStyle()
+    if name == "subtle":
+        s.grid_spacing = 48
+        s.grid_rgba = (100,100,100,24)
+        s.wm_spacing = 240
+        s.wm_width = 3
+        s.wm_rgba = (120,120,120,28)
+        s.speckle_count = 1200
+        s.speckle_radius_range = (0,1)
+        s.speckle_rgba = (0,0,0,70)
+    elif name == "strong":
+        s.grid_spacing = 32
+        s.grid_rgba = (100,100,100,28)
+        s.wm_spacing = 200
+        s.wm_width = 4
+        s.wm_rgba = (120,120,120,35)
+        s.speckle_count = 3200
+        s.speckle_radius_range = (1,2)
+        s.speckle_rgba = (0,0,0,90)
+    else:
+        raise ValueError("preset must be 'subtle' or 'strong'")
+    return s
+
+def main():
+    ap = argparse.ArgumentParser(description="Generate OCR-resistant PDF with neutral watermark.")
+    ap.add_argument("--in", dest="infile", required=True, help="Path to input .txt")
+    ap.add_argument("--out", dest="outfile", required=True, help="Path to output .pdf")
+    ap.add_argument("--preset", choices=["subtle","strong"], default="strong", help="Strength preset")
+    ap.add_argument("--page", default=None, help="Custom page size WxH (e.g., 1700x2200)")
+    ap.add_argument("--margin", type=int, default=None, help="Page margin in pixels")
+    ap.add_argument("--font-size", type=int, default=None, help="Font size in pixels")
+    ap.add_argument("--font-path", action="append", default=None, help="Add a font path (can repeat)")
+    ap.add_argument("--no-grid", action="store_true")
+    ap.add_argument("--grid-spacing", type=int, default=None)
+    ap.add_argument("--grid-alpha", type=int, default=None)
+    ap.add_argument("--no-watermark", action="store_true")
+    ap.add_argument("--wm-spacing", type=int, default=None)
+    ap.add_argument("--wm-width", type=int, default=None)
+    ap.add_argument("--wm-alpha", type=int, default=None)
+    ap.add_argument("--no-speckles", action="store_true")
+    ap.add_argument("--speckles", type=int, default=None, help="Number of speckles")
+    ap.add_argument("--speckle-radius", nargs=2, type=int, default=None, metavar=("RMIN","RMAX"))
+    ap.add_argument("--speckle-alpha", type=int, default=None)
+    ap.add_argument("--safe-zone", nargs=4, action="append", metavar=("X","Y","W","H"), help="Rectangle (px) where overlays are disabled (can repeat)")
+    args = ap.parse_args()
+    with open(args.infile, "r", encoding="utf-8", errors="ignore") as f:
+        text = f.read()
+    style = _make_preset(args.preset)
+    if args.page:
+        w,h = args.page.lower().split("x")
+        style.page_w, style.page_h = int(w), int(h)
+    if args.margin is not None:
+        style.margin = args.margin
+    if args.font_size is not None:
+        style.font_size = args.font_size
+    if args.font_path:
+        style.font_paths = args.font_path + style.font_paths
+    if args.no_grid:
+        style.grid_on = False
+    if args.grid_spacing is not None:
+        style.grid_spacing = args.grid_spacing
+    if args.grid_alpha is not None:
+        r,g,b,_ = style.grid_rgba
+        style.grid_rgba = (r,g,b,max(0,min(255,args.grid_alpha)))
+    if args.no_watermark:
+        style.wm_on = False
+    if args.wm_spacing is not None:
+        style.wm_spacing = args.wm_spacing
+    if args.wm_width is not None:
+        style.wm_width = args.wm_width
+    if args.wm_alpha is not None:
+        r,g,b,_ = style.wm_rgba
+        style.wm_rgba = (r,g,b,max(0,min(255,args.wm_alpha)))
+    if args.no_speckles:
+        style.speckles_on = False
+    if args.speckles is not None:
+        style.speckle_count = args.speckles
+    if args.speckle_radius is not None:
+        style.speckle_radius_range = tuple(args.speckle_radius)
+    if args.speckle_alpha is not None:
+        r,g,b,_ = style.speckle_rgba
+        style.speckle_rgba = (r,g,b,max(0,min(255,args.speckle_alpha)))
+    if args.safe_zone:
+        style.safe_zones = [tuple(map(int,sz)) for sz in args.safe_zone]
+    out = render_ocr_resistant_pdf(text, args.outfile, style)
+    print(f"Saved: {out}")
+
+if __name__ == "__main__":
+    main()

--- a/metro2 (copy 1)/crm/public/app.js
+++ b/metro2 (copy 1)/crm/public/app.js
@@ -320,6 +320,11 @@ function renderTradelines(tradelines){
       });
     }
 
+    const ocrCb = card.querySelector('.use-ocr');
+    if (ocrCb) {
+      // no extra behavior needed; presence indicates OCR request
+    }
+
     // initialize special badges if any from previous state (when re-rendering)
     updateCardSpecialVisual(card);
 
@@ -358,9 +363,12 @@ function collectSelections(){
       ? card.querySelector('.gpt-tone')?.value || ''
       : '';
 
+    const useOcr = card.querySelector('.use-ocr')?.checked || false;
+
     if (bureaus.length || special.length){
       const entry = { tradelineIndex, bureaus, violationIdxs, special };
       if (aiTone) entry.aiTone = aiTone;
+      if (useOcr) entry.useOcr = true;
       selections.push(entry);
     }
   });

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -269,6 +269,7 @@
         <option value="Cooperative / Helpful (Problem-Solving)">Cooperative / Helpful (Problem-Solving)</option>
         <option value="Urgent / Concerned (Still Respectful)">Urgent / Concerned (Still Respectful)</option>
       </select>
+      <label class="flex items-center gap-1"><input type="checkbox" class="use-ocr" /> OCR</label>
     </div>
 
     <div class="tl-tags flex gap-2 mt-2 flex-wrap"></div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -427,7 +427,8 @@ function updateSelectionStateFromCard(card){
   const violationIdxs = preserved.concat(visibleChecked);
   const specialMode = getSpecialModeForCard(card);
   const playbook = card.querySelector('.tl-playbook-select')?.value || null;
-  selectionState[idx] = { bureaus, violationIdxs, specialMode, playbook };
+  const useOcr = card.querySelector('.use-ocr')?.checked || false;
+  selectionState[idx] = { bureaus, violationIdxs, specialMode, playbook, useOcr };
 }
 
 function renderTradelines(tradelines){
@@ -507,6 +508,10 @@ function renderTradelines(tradelines){
     renderViolations();
     prevBtn.addEventListener("click", ()=>{ if(vStart>0){ vStart -= 3; renderViolations(); }});
     nextBtn.addEventListener("click", ()=>{ if(vStart + 3 < vs.length){ vStart += 3; renderViolations(); }});
+
+    const ocrCb = node.querySelector('.use-ocr');
+    if (selectionState[idx]?.useOcr) ocrCb.checked = true;
+    ocrCb.addEventListener('change', () => updateSelectionStateFromCard(card));
 
     node.querySelector(".tl-remove").addEventListener("click",(e)=>{
       e.stopPropagation();
@@ -668,6 +673,9 @@ function collectSelections(){
     };
     if (data.violationIdxs && data.violationIdxs.length){
       sel.violationIdxs = data.violationIdxs;
+    }
+    if (data.useOcr){
+      sel.useOcr = true;
     }
     return sel;
   });

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -33,6 +33,40 @@ import {
   processAllReminders,
 } from "./state.js";
 
+function htmlToPlainText(html){
+  return html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<(br|BR)\s*\/?>(\n)?/g, '\n')
+    .replace(/<\/(p|div|h[1-6]|li|tr|table)>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function generateOcrPdf(text){
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-'));
+  const txtPath = path.join(tmpDir, 'letter.txt');
+  const pdfPath = path.join(tmpDir, 'letter.pdf');
+  fs.writeFileSync(txtPath, text, 'utf8');
+  const script = path.join(__dirname, 'ocr_resistant_pdf.py');
+  const res = spawnSync('python3', [script, '--in', txtPath, '--out', pdfPath, '--preset', 'strong']);
+  if(res.status !== 0){
+    console.error(res.stderr?.toString() || 'OCR script failed');
+    throw new Error('OCR script failed');
+  }
+  const buf = fs.readFileSync(pdfPath);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  return buf;
+}
+
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -876,7 +910,8 @@ function persistJobToDisk(jobId, letters){
     letters: letters.map(L => ({
       filename: L.filename,
       bureau: L.bureau,
-      creditor: L.creditor
+      creditor: L.creditor,
+      useOcr: !!L.useOcr
     }))
   };
   saveJobsIndex(idx);
@@ -942,6 +977,11 @@ app.post("/api/generate", async (req,res)=>{
     }
     if (Array.isArray(collectors) && collectors.length) {
       letters.push(...generateDebtCollectorLetters({ consumer: consumerForLetter, collectors }));
+    }
+
+    for (const L of letters) {
+      const sel = (selections || []).find(s => s.tradelineIndex === L.tradelineIndex);
+      if (sel?.useOcr) L.useOcr = true;
     }
 
     console.log(`Generated ${letters.length} letters for consumer ${consumer.id}`);
@@ -1021,7 +1061,8 @@ app.get("/api/letters/:jobId", (req,res)=>{
         filename: path.basename(d.htmlPath),
         bureau: d.bureau,
         creditor: d.creditor,
-        html: fs.existsSync(d.htmlPath) ? fs.readFileSync(d.htmlPath,"utf-8") : "<html><body>Missing file.</body></html>"
+        html: fs.existsSync(d.htmlPath) ? fs.readFileSync(d.htmlPath,"utf-8") : "<html><body>Missing file.</body></html>",
+        useOcr: d.useOcr
       })));
       job = getJobMem(jobId);
     }
@@ -1058,6 +1099,7 @@ app.get("/api/letters/:jobId/:idx.pdf", async (req,res)=>{
   console.log(`Generating PDF for job ${jobId} letter ${idx}`);
   let html;
   let filenameBase = "letter";
+  let useOcr = false;
 
   let job = getJobMem(jobId);
   if(job){
@@ -1065,6 +1107,7 @@ app.get("/api/letters/:jobId/:idx.pdf", async (req,res)=>{
     if(!L) return res.status(404).send("Letter not found.");
     html = L.html;
     filenameBase = (L.filename||"letter").replace(/\.html?$/i,"");
+    useOcr = !!L.useOcr;
   }else{
     const disk = loadJobFromDisk(jobId);
     if(!disk) return res.status(404).send("Job not found or expired.");
@@ -1072,11 +1115,26 @@ app.get("/api/letters/:jobId/:idx.pdf", async (req,res)=>{
     if(!Lm || !fs.existsSync(Lm.htmlPath)) return res.status(404).send("Letter not found.");
     html = fs.readFileSync(Lm.htmlPath,"utf-8");
     filenameBase = path.basename(Lm.htmlPath).replace(/\.html?$/i,"");
+    useOcr = !!Lm.useOcr;
   }
 
   if(!html || !html.trim()){
     logError("LETTER_HTML_MISSING", "No HTML content for PDF generation", null, { jobId, idx });
     return res.status(500).send("No HTML content to render");
+  }
+
+  if(useOcr){
+    try{
+      const text = htmlToPlainText(html);
+      const pdfBuffer = generateOcrPdf(text);
+      res.setHeader("Content-Type","application/pdf");
+      res.setHeader("Content-Disposition",`attachment; filename="${filenameBase}.pdf"`);
+      console.log(`Generated OCR PDF for ${filenameBase} (${pdfBuffer.length} bytes)`);
+      return res.send(pdfBuffer);
+    }catch(e){
+      console.error("OCR PDF error:", e);
+      return res.status(500).send("Failed to render OCR PDF.");
+    }
   }
 
   let browserInstance;
@@ -1119,7 +1177,8 @@ app.get("/api/letters/:jobId/all.zip", async (req,res)=>{
         filename: path.basename(d.htmlPath),
         bureau: d.bureau,
         creditor: d.creditor,
-        html: fs.existsSync(d.htmlPath) ? fs.readFileSync(d.htmlPath,"utf-8") : "<html><body>Missing file.</body></html>"
+        html: fs.existsSync(d.htmlPath) ? fs.readFileSync(d.htmlPath,"utf-8") : "<html><body>Missing file.</body></html>",
+        useOcr: d.useOcr
       })));
       job = getJobMem(jobId);
     }
@@ -1163,12 +1222,24 @@ app.get("/api/letters/:jobId/all.zip", async (req,res)=>{
     archive.pipe(res);
   }
 
+  const needsBrowser = job.letters.some(l => !l.useOcr);
   let browserInstance;
   try{
-    browserInstance = await launchBrowser();
+    if (needsBrowser) browserInstance = await launchBrowser();
 
     for(let i=0;i<job.letters.length;i++){
       const L = job.letters[i];
+      const name = (L.filename||`letter${i}`).replace(/\.html?$/i,"") + '.pdf';
+
+      if (L.useOcr) {
+        const pdfBuffer = generateOcrPdf(htmlToPlainText(L.html));
+        try{ archive.append(pdfBuffer,{ name }); }catch(err){
+          logError('ZIP_APPEND_FAILED', 'Failed to append PDF to archive', err, { jobId, letter: name });
+          throw err;
+        }
+        continue;
+      }
+
       const page = await browserInstance.newPage();
       const dataUrl = "data:text/html;charset=utf-8," + encodeURIComponent(L.html);
       await page.goto(dataUrl,{ waitUntil:"load", timeout:60000 });
@@ -1179,11 +1250,7 @@ app.get("/api/letters/:jobId/all.zip", async (req,res)=>{
       const pdf = await page.pdf({ format:"Letter", printBackground:true, margin:{top:"1in",right:"1in",bottom:"1in",left:"1in"} });
       await page.close();
       const pdfBuffer = ensureBuffer(pdf);
-
-      const name = (L.filename||`letter${i}`).replace(/\.html?$/i,"") + '.pdf';
-      try{
-        archive.append(pdfBuffer,{ name });
-      }catch(err){
+      try{ archive.append(pdfBuffer,{ name }); }catch(err){
         logError('ZIP_APPEND_FAILED', 'Failed to append PDF to archive', err, { jobId, letter: name });
         throw err;
       }
@@ -1224,7 +1291,7 @@ app.post("/api/letters/:jobId/email", async (req,res)=>{
   let job = getJobMem(jobId);
   if(!job){
     const disk = loadJobFromDisk(jobId);
-    if(disk){ job = { letters: disk.letters.map(d=>({ filename: path.basename(d.htmlPath), htmlPath: d.htmlPath })) }; }
+    if(disk){ job = { letters: disk.letters.map(d=>({ filename: path.basename(d.htmlPath), htmlPath: d.htmlPath, useOcr: d.useOcr })) }; }
   }
   if(!job) return res.status(404).json({ ok:false, error:"Job not found or expired" });
 
@@ -1239,25 +1306,31 @@ app.post("/api/letters/:jobId/email", async (req,res)=>{
     }
   }catch{}
 
+  const needsBrowser = job.letters.some(l => !l.useOcr);
   let browserInstance;
   try{
-
-    browserInstance = await launchBrowser();
+    if (needsBrowser) browserInstance = await launchBrowser();
 
     const attachments = [];
     for(let i=0;i<job.letters.length;i++){
       const L = job.letters[i];
       const html = L.html || (L.htmlPath ? fs.readFileSync(L.htmlPath, "utf-8") : fs.readFileSync(path.join(LETTERS_DIR, L.filename), "utf-8"));
-      const page = await browserInstance.newPage();
-      const dataUrl = "data:text/html;charset=utf-8," + encodeURIComponent(html);
-      await page.goto(dataUrl,{ waitUntil:"load", timeout:60000 });
-      await page.emulateMediaType("screen");
-      try{ await page.waitForFunction(()=>document.readyState==="complete",{timeout:60000}); }catch{}
-      try{ await page.evaluate(()=> (document.fonts && document.fonts.ready) || Promise.resolve()); }catch{}
-      await page.evaluate(()=> new Promise(r=>setTimeout(r,80)));
-      const pdf = await page.pdf({ format:"Letter", printBackground:true, margin:{top:"1in",right:"1in",bottom:"1in",left:"1in"} });
-      await page.close();
-      const pdfBuffer = ensureBuffer(pdf);
+
+      let pdfBuffer;
+      if (L.useOcr) {
+        pdfBuffer = generateOcrPdf(htmlToPlainText(html));
+      } else {
+        const page = await browserInstance.newPage();
+        const dataUrl = "data:text/html;charset=utf-8," + encodeURIComponent(html);
+        await page.goto(dataUrl,{ waitUntil:"load", timeout:60000 });
+        await page.emulateMediaType("screen");
+        try{ await page.waitForFunction(()=>document.readyState==="complete",{timeout:60000}); }catch{}
+        try{ await page.evaluate(()=> (document.fonts && document.fonts.ready) || Promise.resolve()); }catch{}
+        await page.evaluate(()=> new Promise(r=>setTimeout(r,80)));
+        const pdf = await page.pdf({ format:"Letter", printBackground:true, margin:{top:"1in",right:"1in",bottom:"1in",left:"1in"} });
+        await page.close();
+        pdfBuffer = ensureBuffer(pdf);
+      }
 
       const name = (L.filename || `letter${i}`).replace(/\.html?$/i,"") + '.pdf';
       attachments.push({ filename: name, content: pdfBuffer, contentType: 'application/pdf' });
@@ -1292,7 +1365,7 @@ app.post("/api/letters/:jobId/portal", async (req,res)=>{
   let job = getJobMem(jobId);
   if(!job){
     const disk = loadJobFromDisk(jobId);
-    if(disk){ job = { letters: disk.letters.map(d=>({ filename: path.basename(d.htmlPath), htmlPath: d.htmlPath })) }; }
+    if(disk){ job = { letters: disk.letters.map(d=>({ filename: path.basename(d.htmlPath), htmlPath: d.htmlPath, useOcr: d.useOcr })) }; }
   }
   if(!job) return res.status(404).json({ ok:false, error:"Job not found or expired" });
 
@@ -1308,11 +1381,12 @@ app.post("/api/letters/:jobId/portal", async (req,res)=>{
   }catch{}
   if(!consumer) return res.status(400).json({ ok:false, error:"Consumer not found" });
 
+  const needsBrowser = job.letters.some(l => !l.useOcr);
   let browserInstance;
   try{
     logInfo('PORTAL_UPLOAD_START', 'Building portal ZIP', { jobId, consumerId: consumer.id });
 
-    browserInstance = await launchBrowser();
+    if (needsBrowser) browserInstance = await launchBrowser();
 
     const dir = consumerUploadsDir(consumer.id);
     const id = nanoid(10);
@@ -1333,6 +1407,18 @@ app.post("/api/letters/:jobId/portal", async (req,res)=>{
     for(let i=0;i<job.letters.length;i++){
       const L = job.letters[i];
       const html = L.html || (L.htmlPath ? fs.readFileSync(L.htmlPath, 'utf-8') : fs.readFileSync(path.join(LETTERS_DIR, L.filename), 'utf-8'));
+
+      const name = (L.filename||`letter${i}`).replace(/\.html?$/i,"") + '.pdf';
+
+      if (L.useOcr) {
+        const pdfBuffer = generateOcrPdf(htmlToPlainText(html));
+        try{ archive.append(pdfBuffer,{ name }); }catch(err){
+          logError('ZIP_APPEND_FAILED', 'Failed to append PDF to archive', err, { jobId, letter: name });
+          throw err;
+        }
+        continue;
+      }
+
       const page = await browserInstance.newPage();
       const dataUrl = "data:text/html;charset=utf-8," + encodeURIComponent(html);
       await page.goto(dataUrl,{ waitUntil:'load', timeout:60000 });
@@ -1344,10 +1430,7 @@ app.post("/api/letters/:jobId/portal", async (req,res)=>{
       await page.close();
       const pdfBuffer = ensureBuffer(pdf);
 
-      const name = (L.filename||`letter${i}`).replace(/\.html?$/i,"") + '.pdf';
-      try{
-        archive.append(pdfBuffer,{ name });
-      }catch(err){
+      try{ archive.append(pdfBuffer,{ name }); }catch(err){
         logError('ZIP_APPEND_FAILED', 'Failed to append PDF to archive', err, { jobId, letter: name });
         throw err;
       }


### PR DESCRIPTION
## Summary
- add Python utility to render OCR-resistant PDFs with noise and watermarks
- add OCR toggle on tradeline cards and propagate selection to server
- generate OCR-resistant PDFs when OCR is selected
- preserve basic letter formatting when converting HTML to text for OCR PDFs

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 ocr_resistant_pdf.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b06a7624b883238fa5e7bca81435c7