### PR TITLE
Aggregate client messages on dashboard

### DIFF
--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -85,13 +85,11 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const msgList = document.getElementById('msgList');
-  let activeConsumer = null;
-
 
   async function renderMessages(){
     if(!msgList) return;
     try{
-      const resp = await fetch(`/api/messages/${activeConsumer}`);
+      const resp = await fetch('/api/messages');
       if(!resp.ok) throw new Error('bad response');
       const data = await resp.json().catch(()=>({}));
       const msgs = Array.isArray(data.messages) ? data.messages : [];
@@ -100,7 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
         msgList.textContent = 'No messages.';
         return;
       }
-      msgList.innerHTML = msgs.map(m=>`<div><span class="font-medium">${escapeHtml(m.consumer.name || '')} - ${m.payload?.from==='host'?'You':'Client'}:</span> ${escapeHtml(m.payload?.text || '')}</div>`).join('');
+      msgList.innerHTML = msgs.map(m=>`<div><span class="font-medium">${escapeHtml(m.consumer?.name || '')} - ${m.payload?.from==='host'?'You':'Client'}:</span> ${escapeHtml(m.payload?.text || '')}</div>`).join('');
     }catch(e){
       console.error('Failed to load messages', e);
       msgList.textContent = 'Failed to load messages.';
@@ -108,22 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if(msgList){
-    fetch('/api/consumers')
-      .then(r=>r.json())
-      .then(data=>{
-        const list = data.consumers || [];
-        if(list.length){
-          activeConsumer = list[0].id;
-          renderMessages();
-        } else {
-          msgList.textContent = 'No messages.';
-        }
-      })
-      .catch(err=>{
-        console.error('Failed to load consumers', err);
-        msgList.textContent = 'Failed to load messages.';
-      });
-
+    renderMessages();
   }
 
   const noteEl = document.getElementById('dashNote');

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -486,6 +486,20 @@ app.put("/api/invoices/:id", (req,res)=>{
 });
 
 // =================== Messages ===================
+app.get("/api/messages", (_req, res) => {
+  const db = loadDB();
+  const all = [];
+  for (const c of db.consumers || []) {
+    const cstate = listConsumerState(c.id);
+    const msgs = (cstate.events || [])
+      .filter(e => e.type === "message")
+      .map(m => ({ ...m, consumer: { id: c.id, name: c.name || "" } }));
+    all.push(...msgs);
+  }
+  all.sort((a, b) => new Date(b.at) - new Date(a.at));
+  res.json({ ok: true, messages: all });
+});
+
 app.get("/api/messages/:consumerId", (req,res)=>{
   const cstate = listConsumerState(req.params.consumerId);
   const msgs = (cstate.events || []).filter(e=>e.type === "message");


### PR DESCRIPTION
## Summary
- Add API endpoint to collect messages from all consumers
- Update dashboard to fetch and display aggregate messages

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b090381c0c83238a1cc5f3a73553db