### PR TITLE
Improve AI reword error handling

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -155,11 +155,21 @@ async function rewordWithAI(text, tone) {
         ],
       }),
     });
+    if (!resp.ok) {
+      const errText = await resp.text().catch(() => "");
+      logError(
+        "AI_REWORD_FAILED",
+        "OpenAI API error",
+        null,
+        { status: resp.status, body: errText }
+      );
+      return text;
+    }
     const data = await resp.json().catch(() => ({}));
     const out = data.choices?.[0]?.message?.content?.trim() || text;
     return out.replace(/—/g, "-");
   } catch (e) {
-    console.error("AI reword failed", e);
+    logError("AI_REWORD_FAILED", "AI reword request failed", e);
     return text;
   }
 }


### PR DESCRIPTION
## Summary
- Gracefully handle OpenAI API failures when rewording text
- Log API errors with `logError` and fall back to original text

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0980bc4fc83238746848718114d61