### PR TITLE
Highlight Metro 2 violations by severity

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -495,6 +495,8 @@ function renderTradelines(tradelines){
     const prevBtn = node.querySelector(".tl-reason-prev");
     const nextBtn = node.querySelector(".tl-reason-next");
     const vs = tl.violations || [];
+    const maxSeverity = vs.reduce((m, v) => Math.max(m, v.severity || 0), 0);
+    if (maxSeverity) card.classList.add(`severity-${maxSeverity}`);
     let vStart = 0;
     function renderViolations(){
       if(!vs.length){
@@ -504,10 +506,10 @@ function renderTradelines(tradelines){
         return;
       }
       vWrap.innerHTML = vs.slice(vStart, vStart + 3).map((v, vidx) => `
-        <label class="flex items-start gap-2 p-2 rounded hover:bg-gray-50 cursor-pointer">
+        <label class="violation-item flex items-start gap-2 p-2 rounded hover:bg-gray-50 cursor-pointer severity-${v.severity || 1}">
           <input type="checkbox" class="violation" value="${vidx + vStart}"/>
           <div>
-            <div class="font-medium text-sm wrap-anywhere">${escapeHtml(v.category || "")} – ${escapeHtml(v.title || "")}</div>
+            <div class="font-medium text-sm wrap-anywhere">${escapeHtml(v.category || "")} – ${escapeHtml(v.title || "")}${v.severity ? `<span class="severity-tag severity-${v.severity}">S${v.severity}</span>` : ""}</div>
             ${v.detail ? `<div class="text-sm text-gray-600 wrap-anywhere">${escapeHtml(v.detail)}</div>` : ""}
           </div>
         </label>`).join("");

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -197,4 +197,52 @@ body.voice-active #voiceNotes{display:block;}
   accent-color: var(--green);
 }
 
+/* Violation severity styling */
+.violation-item {
+  border-left: 4px solid transparent;
+}
+.violation-item.severity-5 {
+  border-left-color: #991B1B;
+  background: #FEE2E2;
+}
+.violation-item.severity-4 {
+  border-left-color: #B45309;
+  background: #FFEDD5;
+}
+.violation-item.severity-3 {
+  border-left-color: #F59E0B;
+  background: #FEF3C7;
+}
+.violation-item.severity-2 {
+  border-left-color: #3B82F6;
+  background: #DBEAFE;
+}
+.violation-item.severity-1 {
+  border-left-color: #10B981;
+  background: #D1FAE5;
+}
+
+.severity-tag {
+  margin-left: 4px;
+  padding: 0 4px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 500;
+}
+.severity-tag.severity-5 { background: #991B1B; color: #fff; }
+.severity-tag.severity-4 { background: #B45309; color: #fff; }
+.severity-tag.severity-3 { background: #F59E0B; color: #fff; }
+.severity-tag.severity-2 { background: #3B82F6; color: #fff; }
+.severity-tag.severity-1 { background: #10B981; color: #fff; }
+
+/* Tradeline card severity borders */
+.tl-card.severity-5 { box-shadow: 0 0 0 2px #991B1B; }
+.tl-card.severity-4 { box-shadow: 0 0 0 2px #B45309; }
+.tl-card.severity-3 { box-shadow: 0 0 0 2px #F59E0B; }
+.tl-card.severity-2 { box-shadow: 0 0 0 2px #3B82F6; }
+.tl-card.severity-1 { box-shadow: 0 0 0 2px #10B981; }
+
+/* Ensure selection highlight overrides severity */
+.tl-card.selected { box-shadow: 0 0 0 2px var(--green); }
+
 


### PR DESCRIPTION
## Summary
- Color-code tradeline cards by highest Metro 2 violation severity.
- Display violation entries with severity badges and highlight styles.
- Add CSS rules for severity-based borders and tags.

## Testing
- `npm test` *(fails: Missing script "test" – no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b09a2539988323967f85844fa74308