### PR TITLE
feat: add SimpleCertifiedMail mailing option

### DIFF
--- a/metro2 (copy 1)/crm/simpleCertifiedMail.js
+++ b/metro2 (copy 1)/crm/simpleCertifiedMail.js
@@ -1,0 +1,31 @@
+import fs from "fs";
+import nodeFetch from "node-fetch";
+
+const fetchFn = globalThis.fetch || nodeFetch;
+
+export async function sendCertifiedMail({ filePath, toName = "", toAddress = "", toCity = "", toState = "", toZip = "" }) {
+  const apiKey = process.env.SCM_API_KEY;
+  if(!apiKey) throw new Error("SCM_API_KEY not configured");
+  const pdf = await fs.promises.readFile(filePath);
+  const body = {
+    toName,
+    toAddress,
+    toCity,
+    toState,
+    toZip,
+    file: pdf.toString("base64")
+  };
+  const resp = await fetchFn("https://api.simplecertifiedmail.com/v1/letters", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(body)
+  });
+  if(!resp.ok){
+    const text = await resp.text().catch(()=>"");
+    throw new Error(`SimpleCertifiedMail error ${resp.status}: ${text}`);
+  }
+  return resp.json();
+}


### PR DESCRIPTION
## Summary
- integrate Simple Certified Mail API for mailing letters
- add server endpoint to send portal letters via the API
- wire client portal "Mail" button to new mailing endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`
- `node --check simpleCertifiedMail.js`
- `node --check public/client-portal.js`


------
https://chatgpt.com/codex/tasks/task_e_68b09df2753c8323acae746829145653