### PR TITLE
feat: centralize ai reword option

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -186,6 +186,16 @@
             <label class="text-sm flex items-center gap-2" title="Generate personal information letters">
               <input type="checkbox" id="cbPersonalInfo" /> Personal Info
             </label>
+            <label class="text-sm flex items-center gap-2" title="Use AI to reword letters">
+              <input type="checkbox" id="cbUseGpt" /> AI Reword
+            </label>
+            <select id="gptTone" class="border rounded text-sm px-1 py-0.5" disabled>
+              <option value="Professional & Polite">Professional & Polite</option>
+              <option value="Firm / Legalistic (No-Nonsense)">Firm / Legalistic (No-Nonsense)</option>
+              <option value="Plain-English / Conversational">Plain-English / Conversational</option>
+              <option value="Cooperative / Helpful (Problem-Solving)">Cooperative / Helpful (Problem-Solving)</option>
+              <option value="Urgent / Concerned (Still Respectful)">Urgent / Concerned (Still Respectful)</option>
+            </select>
             <button id="btnSelectAll" class="btn text-sm" data-tip="Select or deselect all tradelines">Select All</button>
             <button id="btnSelectNegative" class="btn text-sm" data-tip="Select or deselect negative tradelines">Select Negative</button>
             <button id="btnGenerate" class="btn" data-tip="Generate Letters (G)">Generate Letters</button>
@@ -263,14 +273,6 @@
     </div>
 
     <div class="mt-2 flex items-center gap-2 text-xs">
-      <label class="flex items-center gap-1"><input type="checkbox" class="use-gpt" /> AI Reword</label>
-      <select class="gpt-tone border rounded px-1 py-0.5">
-        <option value="Professional & Polite">Professional & Polite</option>
-        <option value="Firm / Legalistic (No-Nonsense)">Firm / Legalistic (No-Nonsense)</option>
-        <option value="Plain-English / Conversational">Plain-English / Conversational</option>
-        <option value="Cooperative / Helpful (Problem-Solving)">Cooperative / Helpful (Problem-Solving)</option>
-        <option value="Urgent / Concerned (Still Respectful)">Urgent / Concerned (Still Respectful)</option>
-      </select>
       <label class="flex items-center gap-1"><input type="checkbox" class="use-ocr" /> OCR</label>
     </div>
 

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -17,6 +17,15 @@ const collectorSelection = {};
 const trackerData = JSON.parse(localStorage.getItem("trackerData")||"{}");
 const trackerSteps = JSON.parse(localStorage.getItem("trackerSteps") || '["Step 1","Step 2"]');
 
+const gptCb = $("#cbUseGpt");
+const gptToneSel = $("#gptTone");
+if (gptCb && gptToneSel) {
+  gptToneSel.disabled = true;
+  gptCb.addEventListener("change", () => {
+    gptToneSel.disabled = !gptCb.checked;
+  });
+}
+
 function updatePortalLink(){
   const links = ["#clientPortalLink", "#activityPortalLink"].map(sel => $(sel));
   links.forEach(a => {
@@ -727,6 +736,7 @@ function getSpecialModeForCard(card){
   return null;
 }
 function collectSelections(){
+  const aiTone = gptCb?.checked ? gptToneSel?.value || "" : "";
   return Object.entries(selectionState).map(([tradelineIndex, data]) => {
     const sel = {
       tradelineIndex: Number(tradelineIndex),
@@ -739,6 +749,9 @@ function collectSelections(){
     }
     if (data.useOcr){
       sel.useOcr = true;
+    }
+    if (aiTone){
+      sel.aiTone = aiTone;
     }
     return sel;
   });


### PR DESCRIPTION
## Summary
- Move AI reword toggle and tone selector to top-level controls near Personal Info
- Remove per-card AI reword checkbox from tradeline templates
- Wire selection logic to send a single AI tone for all tradelines

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0a355e55c8323ba6be14b518109b1