### PR TITLE
Use GPT-4.1 mini model for rewording

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -146,7 +146,7 @@ async function rewordWithAI(text, tone) {
         Authorization: `Bearer ${key}`,
       },
       body: JSON.stringify({
-        model: "gpt-4o-mini",
+        model: "gpt-4.1-mini",
         messages: [
           { role: "system", content: "You reword credit dispute statements." },
           {


### PR DESCRIPTION
## Summary
- switch rewording helper to OpenAI's `gpt-4.1-mini` model

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0abfbee6c8323bf13a485912a4eec