### PR TITLE
feat: make RSS feed configurable

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -98,9 +98,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const feedEl = document.getElementById('newsFeed');
   if (feedEl) {
-    const rssUrl = 'https://hnrss.org/frontpage';
-    const apiUrl = 'https://api.rss2json.com/v1/api.json?rss_url=' + encodeURIComponent(rssUrl);
-    fetch(apiUrl)
+    fetch('/api/settings')
+      .then(r => r.json())
+      .then(cfg => {
+        const rssUrl = cfg.settings?.rssFeedUrl || 'https://hnrss.org/frontpage';
+        const apiUrl = 'https://api.rss2json.com/v1/api.json?rss_url=' + encodeURIComponent(rssUrl);
+        return fetch(apiUrl);
+      })
       .then(r => r.json())
       .then(data => {
         const items = data.items || [];

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -64,9 +64,13 @@ function renderClientMap(consumers){
 document.addEventListener('DOMContentLoaded', () => {
   const feedEl = document.getElementById('newsFeed');
   if (feedEl) {
-    const rssUrl = 'https://hnrss.org/frontpage';
-    const apiUrl = 'https://api.rss2json.com/v1/api.json?rss_url=' + encodeURIComponent(rssUrl);
-    fetch(apiUrl)
+    fetch('/api/settings')
+      .then(r => r.json())
+      .then(cfg => {
+        const rssUrl = cfg.settings?.rssFeedUrl || 'https://hnrss.org/frontpage';
+        const apiUrl = 'https://api.rss2json.com/v1/api.json?rss_url=' + encodeURIComponent(rssUrl);
+        return fetch(apiUrl);
+      })
       .then(r => r.json())
       .then(data => {
         const items = data.items || [];

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -32,6 +32,7 @@
     <div class="font-medium">API Keys</div>
     <input id="openaiKey" class="w-full border rounded px-2 py-1 text-sm" placeholder="OpenAI API Key" />
     <input id="hibpKey" class="w-full border rounded px-2 py-1 text-sm" placeholder="HIBP API Key" />
+    <input id="rssFeedUrl" class="w-full border rounded px-2 py-1 text-sm" placeholder="RSS Feed URL" />
     <button id="saveSettings" class="btn text-sm">Save</button>
     <div id="saveMsg" class="text-sm muted hidden">Saved!</div>
   </div>

--- a/metro2 (copy 1)/crm/public/settings.js
+++ b/metro2 (copy 1)/crm/public/settings.js
@@ -2,6 +2,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const openaiEl = document.getElementById('openaiKey');
   const hibpEl = document.getElementById('hibpKey');
+  const rssEl = document.getElementById('rssFeedUrl');
   const saveBtn = document.getElementById('saveSettings');
   const msgEl = document.getElementById('saveMsg');
 
@@ -11,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = await resp.json();
       if (openaiEl) openaiEl.value = data.settings?.openaiApiKey || '';
       if (hibpEl) hibpEl.value = data.settings?.hibpApiKey || '';
+      if (rssEl) rssEl.value = data.settings?.rssFeedUrl || '';
     } catch (e) {
       console.error('Failed to load settings', e);
     }
@@ -20,7 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
     saveBtn.addEventListener('click', async () => {
       const body = {
         openaiApiKey: openaiEl.value.trim(),
-        hibpApiKey: hibpEl.value.trim()
+        hibpApiKey: hibpEl.value.trim(),
+        rssFeedUrl: rssEl.value.trim()
       };
       try {
         await fetch('/api/settings', {

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -68,7 +68,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const SETTINGS_PATH = path.join(__dirname, "settings.json");
-function loadSettings(){ return readJson(SETTINGS_PATH, { openaiApiKey: "", hibpApiKey: "" }); }
+function loadSettings(){ return readJson(SETTINGS_PATH, { openaiApiKey: "", hibpApiKey: "", rssFeedUrl: "https://hnrss.org/frontpage" }); }
 function saveSettings(data){ writeJson(SETTINGS_PATH, data); }
 
 async function detectChromium(){
@@ -378,8 +378,8 @@ app.get("/api/settings", (_req, res) => {
 });
 
 app.post("/api/settings", (req, res) => {
-  const { openaiApiKey = "", hibpApiKey = "" } = req.body || {};
-  saveSettings({ openaiApiKey, hibpApiKey });
+  const { openaiApiKey = "", hibpApiKey = "", rssFeedUrl = "" } = req.body || {};
+  saveSettings({ openaiApiKey, hibpApiKey, rssFeedUrl });
   res.json({ ok: true });
 });
 

--- a/metro2 (copy 1)/crm/settings.json
+++ b/metro2 (copy 1)/crm/settings.json
@@ -1,5 +1,6 @@
 {
   "openaiApiKey": "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",
-  "hibpApiKey": "63a05b3069ff4e6ba75ceb1112885749"
+  "hibpApiKey": "63a05b3069ff4e6ba75ceb1112885749",
+  "rssFeedUrl": "https://hnrss.org/frontpage"
 }
 


### PR DESCRIPTION
## Summary
- allow configuring RSS feed URL in settings
- load configured feed on dashboard and client portal

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1c4a43cb88323968cf42bf66ff22b