### PR TITLE
style: make negative cards red

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -27,7 +27,12 @@
     .tl-card:hover{ transform: translateY(-1px) scale(1.01) }
     .tl-card.selected{ box-shadow:0 0 0 2px var(--green); }
     .tl-card.selected input[type="checkbox"]{ accent-color: var(--green); }
-    .tl-card.negative{ box-shadow:0 0 0 2px #ef4444 inset, 0 8px 24px rgba(0,0,0,.1); background:rgba(239,68,68,.12); }
+    .tl-card.negative{
+      border:2px solid #ef4444;
+      background:#ef4444;
+      color:white;
+      box-shadow:0 8px 24px rgba(0,0,0,.1);
+    }
     .wrap-anywhere{ overflow-wrap:anywhere; word-break:break-word }
     .hidden{ display:none }
     .focus-ring{ outline: 2px dashed #6366f1; outline-offset: 4px; }

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -13,7 +13,12 @@
     }
     .tl-card{ transition:transform .15s ease, box-shadow .15s ease, background .15s ease; cursor:pointer; }
     .tl-card:hover{ transform:translateY(-1px); }
-    .tl-card.negative{ box-shadow:0 0 0 2px #ef4444 inset, 0 8px 24px rgba(0,0,0,.1); background:rgba(239,68,68,.12); }
+    .tl-card.negative{
+      border:2px solid #ef4444;
+      background:#ef4444;
+      color:white;
+      box-shadow:0 8px 24px rgba(0,0,0,.1);
+    }
     .hidden{ display:none }
     .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:none;align-items:center;justify-content:center;z-index:50}
     .modal{width:min(1100px,96vw);height:min(90vh,900px);border-radius:18px;box-shadow:0 20px 60px rgba(0,0,0,.25);background:white;display:flex;flex-direction:column;overflow:hidden}


### PR DESCRIPTION
## Summary
- make negative tradeline cards render with solid red background and border

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1d83cb60083239e5d1dd948f48adf