### PR TITLE
fix: restore glass styling and filter risk factor cards

### DIFF
--- a/metro2 (copy 1)/crm/public/app.js
+++ b/metro2 (copy 1)/crm/public/app.js
@@ -108,13 +108,56 @@ async function loadReportJSON(){
   const data = await api(`/api/consumers/${currentConsumerId}/report/${currentReportId}`).catch(()=>({}));
   if(!data?.ok) return showErr(data?.error || "Failed to load report");
   CURRENT_REPORT = data.report;
+  CURRENT_REPORT.tradelines = dedupeTradelines(CURRENT_REPORT.tradelines || []);
 
   renderFilterBar();
-  renderTradelines(CURRENT_REPORT.tradelines || []);
+  renderTradelines(CURRENT_REPORT.tradelines);
 }
 
 function hasWord(s, w){ return (s||"").toLowerCase().includes(w.toLowerCase()); }
 function maybeNum(x){ return typeof x==="number" ? x : null; }
+
+function dedupeTradelines(lines){
+  const seen = new Set();
+  return (lines||[]).filter(tl=>{
+    const name = (tl.meta?.creditor || "").trim();
+    if (!name || name.toLowerCase() === "risk factors") return false;
+    const per = tl.per_bureau || {};
+    const hasData = ["TransUnion","Experian","Equifax"].some(b => Object.keys(per[b]||{}).length);
+    const hasViolations = (tl.violations||[]).length > 0;
+    if (!hasData && !hasViolations) return false;
+    const key = [
+      name,
+      tl.per_bureau?.TransUnion?.account_number || "",
+      tl.per_bureau?.Experian?.account_number || "",
+      tl.per_bureau?.Equifax?.account_number || ""
+    ].join("|");
+    if(seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function mergeBureauViolations(vs){
+  const map = new Map();
+  (vs||[]).forEach(v=>{
+    const m = v.title?.match(/^(.*?)(?:\s*\((TransUnion|Experian|Equifax)\))?$/) || [];
+    const base = (m[1] || v.title || "").trim();
+    const bureau = m[2];
+    const key = `${v.category||""}|${base}`;
+    if(!map.has(key)) map.set(key,{category:v.category,title:base,bureaus:new Set(),details:new Set(),severity:v.severity||0});
+    const entry = map.get(key);
+    if(bureau) entry.bureaus.add(bureau);
+    if(v.detail) entry.details.add(v.detail.replace(/\s*\((TransUnion|Experian|Equifax)\)$/,""));
+    if((v.severity||0) > entry.severity) entry.severity = v.severity||0;
+  });
+  return Array.from(map.values()).map(e=>({
+    category:e.category,
+    title: e.bureaus.size ? `${e.title} (${Array.from(e.bureaus).join(', ')})` : e.title,
+    detail: Array.from(e.details).join(' '),
+    severity: e.severity
+  }));
+}
 
 function deriveTags(tl){
   const tags = new Set();
@@ -140,7 +183,7 @@ function deriveTags(tl){
   if (medical.some(k => hasWord(name, k))) tags.add("Medical Bills");
 
   if (tags.size === 0) tags.add("Other");
-  return Array.from(tags);
+  return Array.from(tags).map(t => t.trim());
 }
 
 function renderFilterBar(){
@@ -272,7 +315,7 @@ function renderTradelines(tradelines){
 
     // violations list
     const vWrap = node.querySelector(".tl-violations");
-    const vs = tl.violations || [];
+    const vs = mergeBureauViolations(tl.violations || []);
     vWrap.innerHTML = vs.length
       ? vs.map((v, vidx) => `
         <label class="flex items-start gap-2 p-2 rounded hover:bg-gray-50 cursor-pointer">

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -27,7 +27,11 @@
     .tl-card:hover{ transform: translateY(-1px) scale(1.01) }
     .tl-card.selected{ box-shadow:0 0 0 2px var(--green); }
     .tl-card.selected input[type="checkbox"]{ accent-color: var(--green); }
-    .tl-card.negative{ box-shadow:0 0 0 2px #ef4444 inset, 0 8px 24px rgba(0,0,0,.1); background:rgba(239,68,68,.12); }
+    .tl-card.negative{
+      border:2px solid #ef4444;
+      background: rgba(239,68,68,.15);
+      box-shadow:0 8px 24px rgba(0,0,0,.1);
+    }
     .wrap-anywhere{ overflow-wrap:anywhere; word-break:break-word }
     .hidden{ display:none }
     .focus-ring{ outline: 2px dashed #6366f1; outline-offset: 4px; }

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -370,11 +370,12 @@ async function loadReportJSON(){
   const data = await api(`/api/consumers/${currentConsumerId}/report/${currentReportId}`);
   if(!data?.ok) return showErr(data?.error || "Failed to load report JSON.");
   CURRENT_REPORT = data.report;
+  CURRENT_REPORT.tradelines = dedupeTradelines(CURRENT_REPORT.tradelines || []);
   tlPage = 1;
   hiddenTradelines.clear();
   Object.keys(selectionState).forEach(k=> delete selectionState[k]);
   renderFilterBar();
-  renderTradelines(CURRENT_REPORT.tradelines || []);
+  renderTradelines(CURRENT_REPORT.tradelines);
   renderCollectors(CURRENT_REPORT.creditor_contacts || []);
 
 }
@@ -387,6 +388,47 @@ const selectionState = {};
 
 function hasWord(s, w){ return (s||"").toLowerCase().includes(w.toLowerCase()); }
 function maybeNum(x){ return typeof x === "number" ? x : null; }
+function dedupeTradelines(lines){
+  const seen = new Set();
+  return (lines||[]).filter(tl=>{
+    const name = (tl.meta?.creditor || "").trim();
+    if (!name || name.toLowerCase() === "risk factors") return false;
+    const per = tl.per_bureau || {};
+    const hasData = ["TransUnion","Experian","Equifax"].some(b => Object.keys(per[b]||{}).length);
+    const hasViolations = (tl.violations||[]).length > 0;
+    if (!hasData && !hasViolations) return false;
+    const key = [
+      name,
+      tl.per_bureau?.TransUnion?.account_number || "",
+      tl.per_bureau?.Experian?.account_number || "",
+      tl.per_bureau?.Equifax?.account_number || ""
+    ].join("|");
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function mergeBureauViolations(vs){
+  const map = new Map();
+  (vs||[]).forEach(v=>{
+    const m = v.title?.match(/^(.*?)(?:\s*\((TransUnion|Experian|Equifax)\))?$/) || [];
+    const base = (m[1] || v.title || "").trim();
+    const bureau = m[2];
+    const key = `${v.category||""}|${base}`;
+    if(!map.has(key)) map.set(key,{category:v.category,title:base,bureaus:new Set(),details:new Set(),severity:v.severity||0});
+    const entry = map.get(key);
+    if(bureau) entry.bureaus.add(bureau);
+    if(v.detail) entry.details.add(v.detail.replace(/\s*\((TransUnion|Experian|Equifax)\)$/,""));
+    if((v.severity||0) > entry.severity) entry.severity = v.severity||0;
+  });
+  return Array.from(map.values()).map(e=>({
+    category:e.category,
+    title: e.bureaus.size ? `${e.title} (${Array.from(e.bureaus).join(', ')})` : e.title,
+    detail: Array.from(e.details).join(' '),
+    severity: e.severity
+  }));
+}
 function deriveTags(tl){
   const tags = new Set();
   const name = (tl.meta?.creditor || "");
@@ -410,7 +452,7 @@ function deriveTags(tl){
   if (medical.some(k => hasWord(name, k))) tags.add("Medical Bills");
 
   if (tags.size === 0) tags.add("Other");
-  return Array.from(tags);
+  return Array.from(tags).map(t => t.trim());
 }
 
 function renderFilterBar(){
@@ -482,7 +524,7 @@ function autoSelectBestViolation(card){
   const idx = Number(card.dataset.index);
   const tl = CURRENT_REPORT?.tradelines?.[idx];
   if (!tl) return;
-  const vs = tl.violations || [];
+  const vs = mergeBureauViolations(tl.violations || []);
   if (!vs.length) return;
   let bestIdx = 0;
   let bestSeverity = -Infinity;
@@ -545,7 +587,7 @@ function renderTradelines(tradelines){
     const vWrap = node.querySelector(".tl-violations");
     const prevBtn = node.querySelector(".tl-reason-prev");
     const nextBtn = node.querySelector(".tl-reason-next");
-    const vs = tl.violations || [];
+    const vs = mergeBureauViolations(tl.violations || []);
     const maxSeverity = vs.reduce((m, v) => Math.max(m, v.severity || 0), 0);
     if (maxSeverity) card.classList.add(`severity-${maxSeverity}`);
     let vStart = 0;
@@ -690,7 +732,7 @@ function renderPB(pb){
 }
 function buildZoomHTML(tl){
   const per = tl.per_bureau || {};
-  const vlist = (tl.violations||[]).map(v=>`
+  const vlist = mergeBureauViolations(tl.violations||[]).map(v=>`
     <li class="mb-2">
       <div class="font-medium">${escapeHtml(v.category||"")} – ${escapeHtml(v.title||"")}</div>
       ${v.detail? `<div class="text-gray-600">${escapeHtml(v.detail)}</div>` : ""}

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -13,7 +13,11 @@
     }
     .tl-card{ transition:transform .15s ease, box-shadow .15s ease, background .15s ease; cursor:pointer; }
     .tl-card:hover{ transform:translateY(-1px); }
-    .tl-card.negative{ box-shadow:0 0 0 2px #ef4444 inset, 0 8px 24px rgba(0,0,0,.1); background:rgba(239,68,68,.12); }
+    .tl-card.negative{
+      border:2px solid #ef4444;
+      background: rgba(239,68,68,.15);
+      box-shadow:0 8px 24px rgba(0,0,0,.1);
+    }
     .hidden{ display:none }
     .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:none;align-items:center;justify-content:center;z-index:50}
     .modal{width:min(1100px,96vw);height:min(90vh,900px);border-radius:18px;box-shadow:0 20px 60px rgba(0,0,0,.25);background:white;display:flex;flex-direction:column;overflow:hidden}

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -200,23 +200,13 @@ body.voice-active #voiceNotes{display:block;}
 /* Violation severity styling */
 .violation-item {
   border-left: 4px solid transparent;
+  border: 1px solid var(--glass-brd);
+  background: var(--glass-bg);
 }
-.violation-item.severity-5 {
-  border-left-color: #991B1B;
-  background: #FEE2E2;
-}
-.violation-item.severity-4 {
-  border-left-color: #B45309;
-  background: #FFEDD5;
-}
-.violation-item.severity-3 {
-  border-left-color: #F59E0B;
-  background: #FEF3C7;
-}
-.violation-item.severity-2 {
-  border-left-color: #3B82F6;
-  background: #DBEAFE;
-}
+.violation-item.severity-5 { border-left-color: #991B1B; }
+.violation-item.severity-4 { border-left-color: #B45309; }
+.violation-item.severity-3 { border-left-color: #F59E0B; }
+.violation-item.severity-2 { border-left-color: #3B82F6; }
 
 
 .severity-tag {


### PR DESCRIPTION
## Summary
- keep negative tradeline cards glassmorphic with subtle red tint instead of solid red
- remove yellow backgrounds on violations and filter out empty or "Risk Factors" tradelines

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1d83cb60083239e5d1dd948f48adf