### PR TITLE
Improve OpenAI integration stability

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -192,7 +192,10 @@
               <input type="checkbox" id="cbPersonalInfo" /> Personal Info
             </label>
             <label class="text-sm flex items-center gap-2" title="Use AI to reword letters">
-              <input type="checkbox" id="cbUseGpt" /> AI Reword
+              <input type="checkbox" id="cbUseGpt" /> AI
+            </label>
+            <label class="text-sm flex items-center gap-2" title="Render OCR-resistant PDFs">
+              <input type="checkbox" id="cbUseOcr" /> OCR
             </label>
             <select id="gptTone" class="border rounded text-sm px-1 py-0.5" disabled>
               <option value="Professional & Polite">Professional & Polite</option>
@@ -275,10 +278,6 @@
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="TransUnion" /> TransUnion</label>
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="Experian" /> Experian</label>
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="Equifax" /> Equifax</label>
-    </div>
-
-    <div class="mt-2 flex items-center gap-2 text-xs">
-      <label class="flex items-center gap-1"><input type="checkbox" class="use-ocr" /> OCR</label>
     </div>
 
     <div class="tl-tags flex gap-2 mt-2 flex-wrap"></div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -19,6 +19,7 @@ const trackerSteps = JSON.parse(localStorage.getItem("trackerSteps") || '["Step 
 
 const gptCb = $("#cbUseGpt");
 const gptToneSel = $("#gptTone");
+const ocrCb = $("#cbUseOcr");
 if (gptCb && gptToneSel) {
   gptToneSel.disabled = true;
   gptCb.addEventListener("change", () => {
@@ -517,8 +518,7 @@ function updateSelectionStateFromCard(card){
   const violationIdxs = preserved.concat(visibleChecked);
   const specialMode = getSpecialModeForCard(card);
   const playbook = card.querySelector('.tl-playbook-select')?.value || null;
-  const useOcr = card.querySelector('.use-ocr')?.checked || false;
-  selectionState[idx] = { bureaus, violationIdxs, specialMode, playbook, useOcr };
+  selectionState[idx] = { bureaus, violationIdxs, specialMode, playbook };
   updateSelectAllButton();
 }
 
@@ -622,10 +622,6 @@ function renderTradelines(tradelines){
     renderViolations();
     prevBtn.addEventListener("click", ()=>{ if(vStart>0){ vStart -= 3; renderViolations(); }});
     nextBtn.addEventListener("click", ()=>{ if(vStart + 3 < vs.length){ vStart += 3; renderViolations(); }});
-
-    const ocrCb = node.querySelector('.use-ocr');
-    if (selectionState[idx]?.useOcr) ocrCb.checked = true;
-    ocrCb.addEventListener('change', () => updateSelectionStateFromCard(card));
 
     node.querySelector(".tl-remove").addEventListener("click",(e)=>{
       e.stopPropagation();
@@ -781,6 +777,7 @@ function getSpecialModeForCard(card){
 }
 function collectSelections(){
   const aiTone = gptCb?.checked ? gptToneSel?.value || "" : "";
+  const useOcr = ocrCb?.checked || false;
   return Object.entries(selectionState).map(([tradelineIndex, data]) => {
     const sel = {
       tradelineIndex: Number(tradelineIndex),
@@ -791,7 +788,7 @@ function collectSelections(){
     if (data.violationIdxs && data.violationIdxs.length){
       sel.violationIdxs = data.violationIdxs;
     }
-    if (data.useOcr){
+    if (useOcr){
       sel.useOcr = true;
     }
     if (aiTone){

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -150,6 +150,26 @@ process.on("warning", warn => {
   logWarn("NODE_WARNING", warn.message, { stack: warn.stack });
 });
 
+// Basic resource monitoring to catch memory or CPU spikes
+const MAX_RSS_MB = Number(process.env.MAX_RSS_MB || 512);
+let lastCpu = process.cpuUsage();
+setInterval(() => {
+  try {
+    const { rss } = process.memoryUsage();
+    if (rss > MAX_RSS_MB * 1024 * 1024) {
+      logWarn("HIGH_MEMORY_USAGE", "Memory usage high", { rss });
+    }
+    const cpu = process.cpuUsage(lastCpu);
+    lastCpu = process.cpuUsage();
+    const cpuMs = (cpu.user + cpu.system) / 1000;
+    if (cpuMs > 1000) {
+      logWarn("HIGH_CPU_USAGE", "CPU usage high", { cpuMs });
+    }
+  } catch (e) {
+    logWarn("RESOURCE_MONITOR_FAILED", e.message);
+  }
+}, 60_000);
+
 // Scheduler that respects OpenAI rate-limit headers
 class RateLimitScheduler {
   constructor() {
@@ -167,6 +187,7 @@ class RateLimitScheduler {
     this.queue = [];
     this.slotTimes = [0];
     this.globalReset = 0;
+    this.maxConcurrency = Number(process.env.OPENAI_MAX_CONCURRENCY || Infinity);
   }
 
   get nextAllowed(){
@@ -191,7 +212,8 @@ class RateLimitScheduler {
     this.intervalMs = isFinite(this.limitRequests) ? 60000 / this.limitRequests : 0;
     const safeConcurrency = Math.min(
       this.limitRequests,
-      Math.floor(this.limitTokens / Math.max(this.avgTokens, 1))
+      Math.floor(this.limitTokens / Math.max(this.avgTokens, 1)),
+      this.maxConcurrency
     );
     this.concurrency = Math.max(1, safeConcurrency);
     while (this.slotTimes.length < this.concurrency) this.slotTimes.push(0);
@@ -210,11 +232,12 @@ class RateLimitScheduler {
       this.avgTokens = (this.avgTokens * (this.count - 1) + tokens) / this.count;
       const safeConcurrency = Math.min(
         this.limitRequests,
-        Math.floor(this.limitTokens / Math.max(this.avgTokens, 1))
+        Math.floor(this.limitTokens / Math.max(this.avgTokens, 1)),
+        this.maxConcurrency
       );
       this.concurrency = Math.max(1, safeConcurrency);
-    while (this.slotTimes.length < this.concurrency) this.slotTimes.push(0);
-    if (this.slotTimes.length > this.concurrency) this.slotTimes.length = this.concurrency;
+      while (this.slotTimes.length < this.concurrency) this.slotTimes.push(0);
+      if (this.slotTimes.length > this.concurrency) this.slotTimes.length = this.concurrency;
     }
   }
 
@@ -312,17 +335,26 @@ async function fetchWithRetries(url, options, maxRetries = 5, scheduler, onRespo
 async function rewordWithAI(text, tone) {
   const key = loadSettings().openaiApiKey || process.env.OPENAI_API_KEY;
   if (!key || !text) return text;
+  const CHUNK_SIZE = 2000;
+  const segments = [];
+  for (let i = 0; i < text.length; i += CHUNK_SIZE) {
+    segments.push(text.slice(i, i + CHUNK_SIZE));
+  }
 
-  const payload = {
-    model: "gpt-4.1-mini",
-    messages: [
-      { role: "system", content: "You reword credit dispute statements." },
-      {
-        role: "user",
-        content: `Tone: ${tone}\nReword the following text. Do not use the \"—\" character.\nText: ${text}`,
-      },
-    ],
-  };
+  const results = [];
+  for (const segment of segments) {
+    const payload = {
+      model: "gpt-4.1-mini",
+      max_tokens: 256,
+      stream: true,
+      messages: [
+        { role: "system", content: "You reword credit dispute statements." },
+        {
+          role: "user",
+          content: `Tone: ${tone}\nReword the following text. Do not use the \"—\" character.\nText: ${segment}`,
+        },
+      ],
+    };
 
     try {
       const resp = await fetchWithRetries(
@@ -340,15 +372,34 @@ async function rewordWithAI(text, tone) {
         r => openAIScheduler.updateFromHeaders(r.headers)
       );
 
-      const data = await resp.json().catch(() => ({}));
-      openAIScheduler.updateUsage(data.usage?.total_tokens);
-      const out = data.choices?.[0]?.message?.content?.trim() || text;
-      return out.replace(/—/g, "-");
+      let out = "";
+      const decoder = new TextDecoder();
+      let buffer = "";
+      for await (const streamChunk of resp.body) {
+        buffer += decoder.decode(streamChunk, { stream: true });
+        const parts = buffer.split("\n\n");
+        buffer = parts.pop();
+        for (const part of parts) {
+          const line = part.trim();
+          if (!line.startsWith("data:")) continue;
+          const data = line.slice(5).trim();
+          if (data === "[DONE]") break;
+          try {
+            const json = JSON.parse(data);
+            const token = json.choices?.[0]?.delta?.content;
+            if (token) out += token;
+          } catch {}
+        }
+      }
+      openAIScheduler.updateUsage(payload.max_tokens);
+      results.push((out.trim() || segment).replace(/—/g, "-"));
     } catch (e) {
       logError("AI_REWORD_FAILED", "OpenAI API error", e);
-      return text;
+      results.push(segment);
     }
+  }
 
+  return results.join("");
 }
 
 // periodically surface due letter reminders


### PR DESCRIPTION
## Summary
- monitor memory and CPU usage to detect resource spikes
- cap OpenAI request concurrency and respect rate-limits
- chunk and stream AI rewording to control response sizes and add retries
- move OCR toggle next to renamed "AI" option for global control

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68b1ec58a7e08323b4f3d56bb7936b01