### PR TITLE
Improve OpenAI integration stability

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -177,7 +177,7 @@
       <div class="glass card">
         <div class="flex items-center justify-between">
           <div class="font-semibold">Tradelines</div>
-          <div class="flex items-center gap-3">
+          <div class="flex flex-wrap items-center gap-3">
             <label class="text-sm flex items-center gap-2" title="Generate correction letters">
               <input type="radio" name="rtype" value="correct" checked /> Correct
             </label>
@@ -192,9 +192,12 @@
               <input type="checkbox" id="cbPersonalInfo" /> Personal Info
             </label>
             <label class="text-sm flex items-center gap-2" title="Use AI to reword letters">
-              <input type="checkbox" id="cbUseGpt" /> AI Reword
+              <input type="checkbox" id="cbUseGpt" /> AI
             </label>
-            <select id="gptTone" class="border rounded text-sm px-1 py-0.5" disabled>
+            <label class="text-sm flex items-center gap-2" title="Render OCR-resistant PDFs">
+              <input type="checkbox" id="cbUseOcr" /> OCR
+            </label>
+            <select id="gptTone" class="border rounded text-sm px-1 py-0.5 hidden" disabled>
               <option value="Professional & Polite">Professional & Polite</option>
               <option value="Firm / Legalistic (No-Nonsense)">Firm / Legalistic (No-Nonsense)</option>
               <option value="Plain-English / Conversational">Plain-English / Conversational</option>
@@ -275,10 +278,6 @@
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="TransUnion" /> TransUnion</label>
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="Experian" /> Experian</label>
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="Equifax" /> Equifax</label>
-    </div>
-
-    <div class="mt-2 flex items-center gap-2 text-xs">
-      <label class="flex items-center gap-1"><input type="checkbox" class="use-ocr" /> OCR</label>
     </div>
 
     <div class="tl-tags flex gap-2 mt-2 flex-wrap"></div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -19,10 +19,14 @@ const trackerSteps = JSON.parse(localStorage.getItem("trackerSteps") || '["Step 
 
 const gptCb = $("#cbUseGpt");
 const gptToneSel = $("#gptTone");
+const ocrCb = $("#cbUseOcr");
 if (gptCb && gptToneSel) {
   gptToneSel.disabled = true;
+  gptToneSel.classList.add("hidden");
   gptCb.addEventListener("change", () => {
-    gptToneSel.disabled = !gptCb.checked;
+    const enabled = gptCb.checked;
+    gptToneSel.disabled = !enabled;
+    gptToneSel.classList.toggle("hidden", !enabled);
   });
 }
 
@@ -517,8 +521,7 @@ function updateSelectionStateFromCard(card){
   const violationIdxs = preserved.concat(visibleChecked);
   const specialMode = getSpecialModeForCard(card);
   const playbook = card.querySelector('.tl-playbook-select')?.value || null;
-  const useOcr = card.querySelector('.use-ocr')?.checked || false;
-  selectionState[idx] = { bureaus, violationIdxs, specialMode, playbook, useOcr };
+  selectionState[idx] = { bureaus, violationIdxs, specialMode, playbook };
   updateSelectAllButton();
 }
 
@@ -622,10 +625,6 @@ function renderTradelines(tradelines){
     renderViolations();
     prevBtn.addEventListener("click", ()=>{ if(vStart>0){ vStart -= 3; renderViolations(); }});
     nextBtn.addEventListener("click", ()=>{ if(vStart + 3 < vs.length){ vStart += 3; renderViolations(); }});
-
-    const ocrCb = node.querySelector('.use-ocr');
-    if (selectionState[idx]?.useOcr) ocrCb.checked = true;
-    ocrCb.addEventListener('change', () => updateSelectionStateFromCard(card));
 
     node.querySelector(".tl-remove").addEventListener("click",(e)=>{
       e.stopPropagation();
@@ -781,6 +780,7 @@ function getSpecialModeForCard(card){
 }
 function collectSelections(){
   const aiTone = gptCb?.checked ? gptToneSel?.value || "" : "";
+  const useOcr = ocrCb?.checked || false;
   return Object.entries(selectionState).map(([tradelineIndex, data]) => {
     const sel = {
       tradelineIndex: Number(tradelineIndex),
@@ -791,7 +791,7 @@ function collectSelections(){
     if (data.violationIdxs && data.violationIdxs.length){
       sel.violationIdxs = data.violationIdxs;
     }
-    if (data.useOcr){
+    if (useOcr){
       sel.useOcr = true;
     }
     if (aiTone){


### PR DESCRIPTION
## Summary
- add env-configurable resource monitor interval and rate-limit defaults
- retry OpenAI requests with exponential backoff and logging
- expose chunk and token caps for AI responses
- bound OpenAI scheduler queue and drop unused stream import
- add global OCR toggle and rename AI rephrase to AI
- fix AI/OCR toolbar layout to wrap controls and hide tone selector until needed

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b1ec58a7e08323b4f3d56bb7936b01