### PR TITLE
Remove AI rephrase logic and add Tradelines page

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -19,6 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -29,6 +29,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -80,6 +80,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
@@ -177,7 +178,7 @@
       <div class="glass card">
         <div class="flex items-center justify-between">
           <div class="font-semibold">Tradelines</div>
-          <div class="flex items-center gap-3">
+          <div class="flex flex-wrap items-center gap-3">
             <label class="text-sm flex items-center gap-2" title="Generate correction letters">
               <input type="radio" name="rtype" value="correct" checked /> Correct
             </label>
@@ -192,15 +193,11 @@
               <input type="checkbox" id="cbPersonalInfo" /> Personal Info
             </label>
             <label class="text-sm flex items-center gap-2" title="Use AI to reword letters">
-              <input type="checkbox" id="cbUseGpt" /> AI Reword
+              <input type="checkbox" id="cbUseGpt" /> AI
             </label>
-            <select id="gptTone" class="border rounded text-sm px-1 py-0.5" disabled>
-              <option value="Professional & Polite">Professional & Polite</option>
-              <option value="Firm / Legalistic (No-Nonsense)">Firm / Legalistic (No-Nonsense)</option>
-              <option value="Plain-English / Conversational">Plain-English / Conversational</option>
-              <option value="Cooperative / Helpful (Problem-Solving)">Cooperative / Helpful (Problem-Solving)</option>
-              <option value="Urgent / Concerned (Still Respectful)">Urgent / Concerned (Still Respectful)</option>
-            </select>
+            <label class="text-sm flex items-center gap-2" title="Render OCR-resistant PDFs">
+              <input type="checkbox" id="cbUseOcr" /> OCR
+            </label>
             <button id="btnSelectAll" class="btn text-sm" data-tip="Select or deselect all tradelines">Select All</button>
             <button id="btnSelectNegative" class="btn text-sm" data-tip="Select or deselect negative tradelines">Select Negative</button>
             <button id="btnGenerate" class="btn" data-tip="Generate Letters (G)">Generate Letters</button>
@@ -275,10 +272,6 @@
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="TransUnion" /> TransUnion</label>
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="Experian" /> Experian</label>
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="Equifax" /> Equifax</label>
-    </div>
-
-    <div class="mt-2 flex items-center gap-2 text-xs">
-      <label class="flex items-center gap-1"><input type="checkbox" class="use-ocr" /> OCR</label>
     </div>
 
     <div class="tl-tags flex gap-2 mt-2 flex-wrap"></div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -17,14 +17,7 @@ const collectorSelection = {};
 const trackerData = JSON.parse(localStorage.getItem("trackerData")||"{}");
 const trackerSteps = JSON.parse(localStorage.getItem("trackerSteps") || '["Step 1","Step 2"]');
 
-const gptCb = $("#cbUseGpt");
-const gptToneSel = $("#gptTone");
-if (gptCb && gptToneSel) {
-  gptToneSel.disabled = true;
-  gptCb.addEventListener("change", () => {
-    gptToneSel.disabled = !gptCb.checked;
-  });
-}
+const ocrCb = $("#cbUseOcr");
 
 function updatePortalLink(){
   const links = ["#clientPortalLink", "#activityPortalLink"].map(sel => $(sel));
@@ -517,8 +510,7 @@ function updateSelectionStateFromCard(card){
   const violationIdxs = preserved.concat(visibleChecked);
   const specialMode = getSpecialModeForCard(card);
   const playbook = card.querySelector('.tl-playbook-select')?.value || null;
-  const useOcr = card.querySelector('.use-ocr')?.checked || false;
-  selectionState[idx] = { bureaus, violationIdxs, specialMode, playbook, useOcr };
+  selectionState[idx] = { bureaus, violationIdxs, specialMode, playbook };
   updateSelectAllButton();
 }
 
@@ -622,10 +614,6 @@ function renderTradelines(tradelines){
     renderViolations();
     prevBtn.addEventListener("click", ()=>{ if(vStart>0){ vStart -= 3; renderViolations(); }});
     nextBtn.addEventListener("click", ()=>{ if(vStart + 3 < vs.length){ vStart += 3; renderViolations(); }});
-
-    const ocrCb = node.querySelector('.use-ocr');
-    if (selectionState[idx]?.useOcr) ocrCb.checked = true;
-    ocrCb.addEventListener('change', () => updateSelectionStateFromCard(card));
 
     node.querySelector(".tl-remove").addEventListener("click",(e)=>{
       e.stopPropagation();
@@ -780,7 +768,7 @@ function getSpecialModeForCard(card){
   return null;
 }
 function collectSelections(){
-  const aiTone = gptCb?.checked ? gptToneSel?.value || "" : "";
+  const useOcr = ocrCb?.checked || false;
   return Object.entries(selectionState).map(([tradelineIndex, data]) => {
     const sel = {
       tradelineIndex: Number(tradelineIndex),
@@ -791,11 +779,8 @@ function collectSelections(){
     if (data.violationIdxs && data.violationIdxs.length){
       sel.violationIdxs = data.violationIdxs;
     }
-    if (data.useOcr){
+    if (useOcr){
       sel.useOcr = true;
-    }
-    if (aiTone){
-      sel.aiTone = aiTone;
     }
     return sel;
   });

--- a/metro2 (copy 1)/crm/public/leads.html
+++ b/metro2 (copy 1)/crm/public/leads.html
@@ -19,6 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -39,6 +39,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -20,6 +20,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -19,6 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -18,9 +18,10 @@
         <a href="/schedule" class="btn">Schedule</a>
       <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
-      <a href="/library" class="btn">Library</a>
+        <a href="/letters" class="btn">Letter</a>
+        <a href="/settings" class="btn">Settings</a>
+        <a href="/tradelines" class="btn">Tradelines</a>
+        <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -19,6 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
@@ -35,9 +36,6 @@
         <div id="calTitle" class="font-semibold"></div>
         <button id="nextMonth" class="btn">&gt;</button>
       </div>
-      <div class="flex justify-end mb-2">
-        <button id="googleBtn" class="btn">Connect Google</button>
-      </div>
       <div class="grid grid-cols-7 text-center font-medium mb-1">
         <div>Sun</div><div>Mon</div><div>Tue</div><div>Wed</div><div>Thu</div><div>Fri</div><div>Sat</div>
       </div>
@@ -47,7 +45,6 @@
 </main>
 <script src="/common.js"></script>
 <script src="/hotkeys.js"></script>
-<script async defer src="https://apis.google.com/js/api.js"></script>
 <script src="/schedule.js"></script>
 
 </body>

--- a/metro2 (copy 1)/crm/public/schedule.js
+++ b/metro2 (copy 1)/crm/public/schedule.js
@@ -5,86 +5,52 @@ document.addEventListener('DOMContentLoaded', () => {
   const listEl = document.getElementById('appointmentList');
   const prevBtn = document.getElementById('prevMonth');
   const nextBtn = document.getElementById('nextMonth');
-  const googleBtn = document.getElementById('googleBtn');
-  const events = JSON.parse(localStorage.getItem('appointments') || '[]');
-  const save = () => localStorage.setItem('appointments', JSON.stringify(events));
+
   let current = new Date();
+  let events = [];
 
-  const CLIENT_ID = window.GOOGLE_CLIENT_ID || 'YOUR_GOOGLE_CLIENT_ID';
-  const API_KEY = window.GOOGLE_API_KEY || 'YOUR_GOOGLE_API_KEY';
-  const SCOPES = 'https://www.googleapis.com/auth/calendar.events';
-  let gReady = false;
+  async function loadEvents() {
+    try {
+      const resp = await fetch('/api/calendar/events');
+      const data = await resp.json();
+      events = (data.events || []).map(ev => ({
+        id: ev.id,
+        date: (ev.start?.date || ev.start?.dateTime || '').split('T')[0],
+        text: ev.summary || ''
+      }));
+    } catch (e) {
+      console.error('Failed to load events', e);
+      events = [];
+    }
+  }
 
-  function initGoogle() {
-    if (!googleBtn || !window.gapi) return setTimeout(initGoogle, 100);
-    gapi.load('client:auth2', async () => {
-      await gapi.client.init({
-        apiKey: API_KEY,
-        clientId: CLIENT_ID,
-        discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'],
-        scope: SCOPES,
+  async function addEvent(dateStr, text) {
+    try {
+      await fetch('/api/calendar/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          summary: text,
+          start: { date: dateStr },
+          end: { date: dateStr }
+        })
       });
-      gReady = true;
-      googleBtn.addEventListener('click', handleAuthClick);
-      const auth = gapi.auth2.getAuthInstance();
-      auth.isSignedIn.listen(updateSigninStatus);
-      updateSigninStatus(auth.isSignedIn.get());
-    });
-  }
-  initGoogle();
-
-  function handleAuthClick() {
-    const auth = gapi.auth2.getAuthInstance();
-    if (auth.isSignedIn.get()) auth.signOut();
-    else auth.signIn();
+      await loadEvents();
+      render();
+    } catch (e) {
+      console.error('Failed to create event', e);
+    }
   }
 
-  function updateSigninStatus(isSignedIn) {
-    if (!googleBtn) return;
-    googleBtn.textContent = isSignedIn ? 'Sign out Google' : 'Connect Google';
-    if (isSignedIn) loadGoogleEvents();
-  }
-
-  async function loadGoogleEvents() {
-    if (!gReady) return;
-    const timeMin = new Date(current.getFullYear(), current.getMonth(), 1).toISOString();
-    const timeMax = new Date(current.getFullYear(), current.getMonth() + 1, 0, 23, 59, 59).toISOString();
-    const resp = await gapi.client.calendar.events.list({
-      calendarId: 'primary', timeMin, timeMax,
-      showDeleted: false, singleEvents: true, orderBy: 'startTime'
-    });
-    resp.result.items.forEach(item => {
-      const start = item.start.date || item.start.dateTime;
-      const dateStr = start.split('T')[0];
-      if (!events.some(e => e.date === dateStr && e.text === item.summary)) {
-        events.push({ date: dateStr, text: item.summary });
-      }
-    });
-    save();
-    render();
-  }
-
-  async function addGoogleEvent(dateStr, text) {
-    if (!gReady) return;
-    const auth = gapi.auth2.getAuthInstance();
-    if (!auth.isSignedIn.get()) return;
-    await gapi.client.calendar.events.insert({
-      calendarId: 'primary',
-      resource: {
-        summary: text,
-        start: { date: dateStr },
-        end: { date: dateStr }
-      }
-    });
-  }
-
-  function changeMonth(delta) {
-    current.setMonth(current.getMonth() + delta);
-    render();
-    if (gReady && gapi.auth2.getAuthInstance().isSignedIn.get()) loadGoogleEvents();
+  function renderList() {
+    if (!listEl) return;
+    const upcoming = events.slice().sort((a, b) => a.date.localeCompare(b.date));
+    listEl.innerHTML = '<h2 class="text-xl font-bold mb-2">Upcoming</h2>' +
+      upcoming.map(e => `<div class="mb-1">${e.date}: ${e.text}</div>`).join('');
   }
 
   function render() {
+    if (!calEl || !titleEl) return;
     calEl.innerHTML = '';
     const year = current.getFullYear();
     const month = current.getMonth();
@@ -108,27 +74,19 @@ document.addEventListener('DOMContentLoaded', () => {
       cell.appendChild(list);
       cell.addEventListener('click', async () => {
         const text = prompt(`Appointment details for ${dateStr}:`);
-        if (text) {
-          events.push({ date: dateStr, text });
-          save();
-          await addGoogleEvent(dateStr, text);
-          render();
-        }
+        if (text) await addEvent(dateStr, text);
       });
       calEl.appendChild(cell);
     }
     renderList();
   }
 
-  function renderList() {
-    if (!listEl) return;
-    const upcoming = events.slice().sort((a, b) => a.date.localeCompare(b.date));
-    listEl.innerHTML = '<h2 class="text-xl font-bold mb-2">Upcoming</h2>' +
-      upcoming.map(e => `<div class="mb-1">${e.date}: ${e.text}</div>`).join('');
-  }
+  prevBtn.addEventListener('click', () => { current.setMonth(current.getMonth() - 1); render(); });
+  nextBtn.addEventListener('click', () => { current.setMonth(current.getMonth() + 1); render(); });
 
-  prevBtn.addEventListener('click', () => changeMonth(-1));
-  nextBtn.addEventListener('click', () => changeMonth(1));
-
-  render();
+  (async function init() {
+    await loadEvents();
+    render();
+  })();
 });
+

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -19,6 +19,7 @@
       <a href="/billing" class="btn">Billing</a>
       <a href="/letters" class="btn">Letter</a>
       <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
       <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
@@ -30,7 +31,6 @@
 
   <div class="glass card space-y-2">
     <div class="font-medium">API Keys</div>
-    <input id="openaiKey" class="w-full border rounded px-2 py-1 text-sm" placeholder="OpenAI API Key" />
     <input id="hibpKey" class="w-full border rounded px-2 py-1 text-sm" placeholder="HIBP API Key" />
     <input id="rssFeedUrl" class="w-full border rounded px-2 py-1 text-sm" placeholder="RSS Feed URL" />
     <input id="gcalToken" class="w-full border rounded px-2 py-1 text-sm" placeholder="Google Calendar Token" />

--- a/metro2 (copy 1)/crm/public/settings.js
+++ b/metro2 (copy 1)/crm/public/settings.js
@@ -1,6 +1,5 @@
 /* public/settings.js */
 document.addEventListener('DOMContentLoaded', () => {
-  const openaiEl = document.getElementById('openaiKey');
   const hibpEl = document.getElementById('hibpKey');
   const rssEl = document.getElementById('rssFeedUrl');
   const gcalTokenEl = document.getElementById('gcalToken');
@@ -13,7 +12,6 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const resp = await fetch('/api/settings');
       const data = await resp.json();
-      if (openaiEl) openaiEl.value = data.settings?.openaiApiKey || '';
       if (hibpEl) hibpEl.value = data.settings?.hibpApiKey || '';
       if (rssEl) rssEl.value = data.settings?.rssFeedUrl || '';
       if (gcalTokenEl) gcalTokenEl.value = data.settings?.googleCalendarToken || '';
@@ -27,7 +25,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (saveBtn) {
     saveBtn.addEventListener('click', async () => {
       const body = {
-        openaiApiKey: openaiEl.value.trim(),
         hibpApiKey: hibpEl.value.trim(),
         rssFeedUrl: rssEl.value.trim(),
         googleCalendarToken: gcalTokenEl.value.trim(),

--- a/metro2 (copy 1)/crm/public/tradelines.html
+++ b/metro2 (copy 1)/crm/public/tradelines.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Tradelines</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+<header class="p-4">
+  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
+    <div class="text-xl font-semibold">Metro 2 CRM</div>
+    <div class="flex items-center gap-2">
+      <a href="/dashboard" class="btn">Dashboard</a>
+      <a href="/clients" class="btn">Clients</a>
+      <a href="/leads" class="btn">Leads</a>
+      <a href="/schedule" class="btn">Schedule</a>
+      <a id="navCompany" href="/my-company" class="btn">My Company</a>
+      <a href="/billing" class="btn">Billing</a>
+      <a href="/letters" class="btn">Letter</a>
+      <a href="/settings" class="btn">Settings</a>
+      <a href="/tradelines" class="btn">Tradelines</a>
+      <a href="/library" class="btn">Library</a>
+      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
+      <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
+    </div>
+  </div>
+</header>
+<main class="max-w-7xl mx-auto px-4 py-6">
+  <h1 class="text-4xl font-bold text-center mb-6">📊 Browse Tradelines</h1>
+
+  <div class="flex flex-wrap justify-between items-center mb-4 gap-4">
+    <input type="text" id="search" placeholder="Search by bank..." class="flex-1 min-w-[200px] px-4 py-2 rounded border shadow-sm focus:ring-2 focus:ring-blue-500">
+    <select id="sort" class="flex-1 min-w-[150px] px-4 py-2 rounded border shadow-sm focus:ring-2 focus:ring-blue-500">
+      <option value="">Sort by</option>
+      <option value="price-asc">Price ↑</option>
+      <option value="price-desc">Price ↓</option>
+      <option value="limit-asc">Limit ↑</option>
+      <option value="limit-desc">Limit ↓</option>
+      <option value="age-asc">Age ↑</option>
+      <option value="age-desc">Age ↓</option>
+    </select>
+  </div>
+
+  <div id="bank-list" class="mb-4 text-sm text-gray-600 italic"></div>
+  <div id="tradeline-container" class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"></div>
+
+  <div class="flex justify-center mt-6">
+    <button id="prev" class="px-4 py-2 mx-1 bg-gray-300 hover:bg-gray-400 transition rounded">Prev</button>
+    <button id="next" class="px-4 py-2 mx-1 bg-gray-300 hover:bg-gray-400 transition rounded">Next</button>
+  </div>
+</main>
+
+<a href="#" id="mobile-buy" class="fixed bottom-5 right-5 bg-blue-600 text-white text-sm px-4 py-2 rounded-full shadow-lg block md:hidden hidden z-50">Buy Now</a>
+
+<script src="/common.js"></script>
+<script src="/hotkeys.js"></script>
+<script src="/tradelines.js"></script>
+</body>
+</html>
+

--- a/metro2 (copy 1)/crm/public/tradelines.js
+++ b/metro2 (copy 1)/crm/public/tradelines.js
@@ -1,0 +1,89 @@
+/* public/tradelines.js */
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('tradeline-container');
+  const searchInput = document.getElementById('search');
+  const sortSelect = document.getElementById('sort');
+  const mobileBuy = document.getElementById('mobile-buy');
+  const bankList = document.getElementById('bank-list');
+
+  let tradelines = [];
+  try {
+    const resp = await fetch('/api/tradelines');
+    const data = await resp.json();
+    tradelines = data.tradelines || [];
+  } catch (e) {
+    console.error('Failed to load tradelines', e);
+  }
+
+  let currentPage = 1;
+  const perPage = 10;
+  let filteredData = tradelines;
+
+  function renderBankList(data) {
+    const banks = [...new Set(data.map(t => t.bank))].sort();
+    bankList.textContent = banks.length ? `Available Banks: ${banks.join(', ')}` : '';
+  }
+
+  function renderTradelines(data) {
+    container.innerHTML = '';
+    const paginated = data.slice((currentPage - 1) * perPage, currentPage * perPage);
+
+    if (paginated.length === 0) {
+      container.innerHTML = `<div class="col-span-full text-center text-gray-500 text-lg py-10">🔍 No tradelines found. Try a different search or filter.</div>`;
+      mobileBuy.classList.add('hidden');
+      return;
+    }
+
+    paginated.forEach(t => {
+      const el = document.createElement('div');
+      el.className = 'bg-white shadow-md rounded-xl p-4 hover:shadow-lg transition transform hover:scale-[1.01] duration-200';
+      el.innerHTML = `
+        <h2 class="text-xl font-semibold">${t.bank}</h2>
+        <p class="text-sm text-gray-600 mb-2">${t.age} | $${t.limit} limit</p>
+        <p class="text-lg font-bold text-green-600">$${t.price}</p>
+        <p class="text-xs text-gray-400">Statement: ${t.statement_date}</p>
+        <p class="text-xs text-gray-400">Reports to: ${t.reporting}</p>
+        <a href="${t.buy_link}" class="inline-block mt-3 bg-blue-500 text-white text-sm px-4 py-2 rounded hover:bg-blue-600 transition">Buy Now</a>
+      `;
+      container.appendChild(el);
+    });
+
+    mobileBuy.href = paginated[0].buy_link || '#';
+    mobileBuy.classList.remove('hidden');
+  }
+
+  function filterAndSort() {
+    filteredData = tradelines.filter(t => t.bank.toLowerCase().includes(searchInput.value.toLowerCase()));
+    const sortBy = sortSelect.value;
+
+    if (sortBy === 'price-asc') filteredData.sort((a, b) => a.price - b.price);
+    if (sortBy === 'price-desc') filteredData.sort((a, b) => b.price - a.price);
+    if (sortBy === 'limit-asc') filteredData.sort((a, b) => a.limit - b.limit);
+    if (sortBy === 'limit-desc') filteredData.sort((a, b) => b.limit - a.limit);
+    if (sortBy === 'age-asc') filteredData.sort((a, b) => (a.age || '').localeCompare(b.age || ''));
+    if (sortBy === 'age-desc') filteredData.sort((a, b) => (b.age || '').localeCompare(a.age || ''));
+
+    renderBankList(filteredData);
+    renderTradelines(filteredData);
+  }
+
+  document.getElementById('prev').addEventListener('click', () => {
+    if (currentPage > 1) {
+      currentPage--;
+      renderTradelines(filteredData);
+    }
+  });
+
+  document.getElementById('next').addEventListener('click', () => {
+    if ((currentPage * perPage) < filteredData.length) {
+      currentPage++;
+      renderTradelines(filteredData);
+    }
+  });
+
+  searchInput.addEventListener('input', () => { currentPage = 1; filterAndSort(); });
+  sortSelect.addEventListener('change', () => { currentPage = 1; filterAndSort(); });
+
+  filterAndSort();
+});
+

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -13,8 +13,7 @@ import os from "os";
 import archiver from "archiver";
 import puppeteer from "puppeteer";
 import nodeFetch from "node-fetch";
-
-import { PassThrough } from "stream";
+import cheerio from "cheerio";
 
 import { logInfo, logError, logWarn } from "./logger.js";
 
@@ -71,7 +70,6 @@ const __dirname = path.dirname(__filename);
 const SETTINGS_PATH = path.join(__dirname, "settings.json");
 function loadSettings(){
   return readJson(SETTINGS_PATH, {
-    openaiApiKey: "",
     hibpApiKey: "",
     rssFeedUrl: "https://hnrss.org/frontpage",
     googleCalendarToken: "",
@@ -150,206 +148,27 @@ process.on("warning", warn => {
   logWarn("NODE_WARNING", warn.message, { stack: warn.stack });
 });
 
-// Scheduler that respects OpenAI rate-limit headers
-class RateLimitScheduler {
-  constructor() {
-    this.limitRequests = Infinity;
-    this.limitTokens = Infinity;
-    this.remainingRequests = Infinity;
-    this.remainingTokens = Infinity;
-    this.resetRequests = 0;
-    this.resetTokens = 0;
-    this.avgTokens = 1000; // initial guess
-    this.count = 0;
-    this.concurrency = 1;
-    this.intervalMs = 0;
-    this.active = 0;
-    this.queue = [];
-    this.slotTimes = [0];
-    this.globalReset = 0;
-  }
-
-  get nextAllowed(){
-    return Math.max(Math.min(...this.slotTimes), this.globalReset);
-  }
-
-  updateFromHeaders(h) {
-    const toNum = v => (v === null ? NaN : Number(v));
-    const lr = toNum(h.get("x-ratelimit-limit-requests"));
-    const lt = toNum(h.get("x-ratelimit-limit-tokens"));
-    const rr = toNum(h.get("x-ratelimit-remaining-requests"));
-    const rt = toNum(h.get("x-ratelimit-remaining-tokens"));
-    const rrs = toNum(h.get("x-ratelimit-reset-requests"));
-    const rts = toNum(h.get("x-ratelimit-reset-tokens"));
-    if (!isNaN(lr)) this.limitRequests = lr;
-    if (!isNaN(lt)) this.limitTokens = lt;
-    if (!isNaN(rr)) this.remainingRequests = rr;
-    if (!isNaN(rt)) this.remainingTokens = rt;
-    if (!isNaN(rrs)) this.resetRequests = Date.now() + rrs * 1000;
-    if (!isNaN(rts)) this.resetTokens = Date.now() + rts * 1000;
-
-    this.intervalMs = isFinite(this.limitRequests) ? 60000 / this.limitRequests : 0;
-    const safeConcurrency = Math.min(
-      this.limitRequests,
-      Math.floor(this.limitTokens / Math.max(this.avgTokens, 1))
-    );
-    this.concurrency = Math.max(1, safeConcurrency);
-    while (this.slotTimes.length < this.concurrency) this.slotTimes.push(0);
-    if (this.slotTimes.length > this.concurrency) this.slotTimes.length = this.concurrency;
-
-    if (this.remainingRequests <= 0 || this.remainingTokens <= 0) {
-      this.globalReset = Math.max(this.resetRequests, this.resetTokens);
-    } else {
-      this.globalReset = 0;
+// Basic resource monitoring to catch memory or CPU spikes
+const MAX_RSS_MB = Number(process.env.MAX_RSS_MB || 512);
+const RESOURCE_CHECK_MS = Number(process.env.RESOURCE_CHECK_MS || 60_000);
+let lastCpu = process.cpuUsage();
+setInterval(() => {
+  try {
+    const { rss } = process.memoryUsage();
+    if (rss > MAX_RSS_MB * 1024 * 1024) {
+      logWarn("HIGH_MEMORY_USAGE", "Memory usage high", { rss });
     }
-  }
-
-  updateUsage(tokens) {
-    if (typeof tokens === "number" && tokens > 0) {
-      this.count++;
-      this.avgTokens = (this.avgTokens * (this.count - 1) + tokens) / this.count;
-      const safeConcurrency = Math.min(
-        this.limitRequests,
-        Math.floor(this.limitTokens / Math.max(this.avgTokens, 1))
-      );
-      this.concurrency = Math.max(1, safeConcurrency);
-    while (this.slotTimes.length < this.concurrency) this.slotTimes.push(0);
-    if (this.slotTimes.length > this.concurrency) this.slotTimes.length = this.concurrency;
+    const cpu = process.cpuUsage(lastCpu);
+    lastCpu = process.cpuUsage();
+    const cpuMs = (cpu.user + cpu.system) / 1000;
+    if (cpuMs > 1000) {
+      logWarn("HIGH_CPU_USAGE", "CPU usage high", { cpuMs });
     }
+  } catch (e) {
+    logWarn("RESOURCE_MONITOR_FAILED", e.message);
   }
+}, RESOURCE_CHECK_MS);
 
-  async schedule(fn) {
-    return new Promise((resolve, reject) => {
-      this.queue.push({ fn, resolve, reject });
-      this._dequeue();
-    });
-  }
-
-  _dequeue() {
-    if (this.active >= this.concurrency) return;
-    if (!this.queue.length) return;
-
-    const now = Date.now();
-    const nextSlot = Math.min(...this.slotTimes);
-    const nextAllowed = Math.max(nextSlot, this.globalReset);
-    const wait = Math.max(0, nextAllowed - now);
-    if (wait > 0) {
-      setTimeout(() => this._dequeue(), wait);
-      return;
-    }
-
-    const idx = this.slotTimes.indexOf(nextSlot);
-    const task = this.queue.shift();
-    this.active++;
-    this.slotTimes[idx] = now + this.intervalMs;
-
-    Promise.resolve()
-      .then(task.fn)
-      .then(res => {
-        this.active--;
-        task.resolve(res);
-        this._dequeue();
-      })
-      .catch(err => {
-        this.active--;
-        task.reject(err);
-        this._dequeue();
-      });
-
-    if (this.active < this.concurrency && this.queue.length) {
-      this._dequeue();
-    }
-  }
-}
-
-const openAIScheduler = new RateLimitScheduler();
-
-async function fetchWithRetries(url, options, maxRetries = 5, scheduler, onResponse) {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const resp = scheduler
-        ? await scheduler.schedule(() => fetchFn(url, options))
-        : await fetchFn(url, options);
-
-      if (onResponse) {
-        try { onResponse(resp); } catch {}
-      }
-
-
-      if (resp.ok) return resp;
-
-      const status = resp.status;
-      if ((status === 429 || status >= 500) && attempt < maxRetries) {
-        const ra = Number(resp.headers.get("retry-after"));
-        let wait = ra ? ra * 1000 : Math.pow(2, attempt) * 1000;
-        if (scheduler) {
-          const extra = scheduler.nextAllowed - Date.now();
-          if (extra > wait) wait = extra;
-        }
-        const jitter = Math.random() * 1000;
-        await new Promise(r => setTimeout(r, wait + jitter));
-
-        continue;
-      }
-
-      const errText = await resp.text().catch(() => "");
-      throw new Error(`HTTP ${status}: ${errText}`);
-    } catch (err) {
-      if (attempt >= maxRetries) throw err;
-      let wait = Math.pow(2, attempt) * 1000;
-      if (scheduler) {
-        const extra = scheduler.nextAllowed - Date.now();
-        if (extra > wait) wait = extra;
-      }
-      const jitter = Math.random() * 1000;
-      await new Promise(r => setTimeout(r, wait + jitter));
-
-    }
-  }
-  throw new Error("Failed after retries");
-}
-
-async function rewordWithAI(text, tone) {
-  const key = loadSettings().openaiApiKey || process.env.OPENAI_API_KEY;
-  if (!key || !text) return text;
-
-  const payload = {
-    model: "gpt-4.1-mini",
-    messages: [
-      { role: "system", content: "You reword credit dispute statements." },
-      {
-        role: "user",
-        content: `Tone: ${tone}\nReword the following text. Do not use the \"—\" character.\nText: ${text}`,
-      },
-    ],
-  };
-
-    try {
-      const resp = await fetchWithRetries(
-        "https://api.openai.com/v1/chat/completions",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${key}`,
-          },
-          body: JSON.stringify(payload),
-        },
-        5,
-        openAIScheduler,
-        r => openAIScheduler.updateFromHeaders(r.headers)
-      );
-
-      const data = await resp.json().catch(() => ({}));
-      openAIScheduler.updateUsage(data.usage?.total_tokens);
-      const out = data.choices?.[0]?.message?.content?.trim() || text;
-      return out.replace(/—/g, "-");
-    } catch (e) {
-      logError("AI_REWORD_FAILED", "OpenAI API error", e);
-      return text;
-    }
-
-}
 
 // periodically surface due letter reminders
 processAllReminders();
@@ -372,6 +191,7 @@ app.get(["/letters", "/letters/:jobId"], (_req, res) =>
   res.sendFile(path.join(PUBLIC_DIR, "letters.html"))
 );
 app.get("/library", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "library.html")));
+app.get("/tradelines", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "tradelines.html")));
 app.get("/quiz", (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "quiz.html")));
 app.get("/settings", (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "settings.html")));
 app.get("/portal/:id", (req, res) => {
@@ -389,13 +209,12 @@ app.get("/api/settings", (_req, res) => {
 
 app.post("/api/settings", (req, res) => {
   const {
-    openaiApiKey = "",
     hibpApiKey = "",
     rssFeedUrl = "",
     googleCalendarToken = "",
     googleCalendarId = "",
   } = req.body || {};
-  saveSettings({ openaiApiKey, hibpApiKey, rssFeedUrl, googleCalendarToken, googleCalendarId });
+  saveSettings({ hibpApiKey, rssFeedUrl, googleCalendarToken, googleCalendarId });
 
   res.json({ ok: true });
 });
@@ -431,6 +250,15 @@ app.delete("/api/calendar/events/:id", async (req, res) => {
   try {
     await deleteCalendarEvent(req.params.id);
     res.json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+app.get("/api/tradelines", async (_req, res) => {
+  try {
+    const tradelines = await scrapeTradelines();
+    res.json({ ok: true, tradelines });
   } catch (e) {
     res.status(500).json({ ok: false, error: e.message });
   }
@@ -988,6 +816,42 @@ async function hibpLookup(email) {
   }
 }
 
+async function scrapeTradelines() {
+  const resp = await fetchFn('https://tradelinesupply.com/pricing/');
+  const html = await resp.text();
+  const $ = cheerio.load(html);
+  const items = [];
+  $('tr').each((_, row) => {
+    const productTd = $(row).find('td.product_data');
+    const priceTd = $(row).find('td.product_price');
+    if (!productTd.length || !priceTd.length) return;
+    const bankName = (productTd.data('bankname') || '').toString().trim();
+    const creditLimitRaw = (productTd.data('creditlimit') || '').toString().replace(/[$,]/g, '');
+    const creditLimit = parseInt(creditLimitRaw, 10) || 0;
+    const dateOpened = (productTd.data('dateopened') || '').toString().trim();
+    const purchaseBy = (productTd.data('purchasebydate') || '').toString().trim();
+    const reportingPeriod = (productTd.data('reportingperiod') || '').toString().trim();
+    const priceText = priceTd.text().trim();
+    const match = /\$\s?(\d+(?:,\d{3})*(?:\.\d{2})?)/.exec(priceText);
+    if (!match) return;
+    const basePrice = parseFloat(match[1].replace(/,/g, ''));
+    let finalPrice;
+    if (basePrice < 500) finalPrice = basePrice + 100;
+    else if (basePrice <= 1000) finalPrice = basePrice + 200;
+    else finalPrice = basePrice + 300;
+    items.push({
+      buy_link: `/buy?bank=${encodeURIComponent(bankName)}&price=${finalPrice}`,
+      bank: bankName,
+      price: Math.round(finalPrice * 100) / 100,
+      limit: creditLimit,
+      age: dateOpened,
+      statement_date: purchaseBy,
+      reporting: reportingPeriod
+    });
+  });
+  return items;
+}
+
 function escapeHtml(str) {
   return String(str || "").replace(/[&<>"']/g, c => ({
     "&": "&amp;",
@@ -1205,20 +1069,6 @@ app.post("/api/generate", async (req,res)=>{
       breaches: consumer.breaches || []
     };
 
-    for (const sel of selections || []) {
-      if (sel.aiTone) {
-        const tl = reportWrap.data?.tradelines?.[sel.tradelineIndex];
-        if (tl && Array.isArray(sel.violationIdxs)) {
-          for (const vidx of sel.violationIdxs) {
-            const v = tl.violations?.[vidx];
-            if (v) {
-              v.title = await rewordWithAI(v.title || "", sel.aiTone);
-              if (v.detail) v.detail = await rewordWithAI(v.detail, sel.aiTone);
-            }
-          }
-        }
-      }
-    }
 
     const letters = generateLetters({ report: reportWrap.data, selections, consumer: consumerForLetter, requestType });
     if (personalInfo) {

--- a/metro2 (copy 1)/crm/settings.json
+++ b/metro2 (copy 1)/crm/settings.json
@@ -1,5 +1,4 @@
 {
-  "openaiApiKey": "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",
   "hibpApiKey": "63a05b3069ff4e6ba75ceb1112885749",
   "rssFeedUrl": "https://hnrss.org/frontpage",
   "googleCalendarToken": "",


### PR DESCRIPTION
## Summary
- drop OpenAI rewording and related settings while leaving AI/OCR UI controls
- sync schedule with dashboard by storing events through the calendar API
- add tradelines scraper, API, and navigation page to browse offers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1ec58a7e08323b4f3d56bb7936b01