### PR TITLE
Add tradelines list to client portal navigation

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -35,9 +35,8 @@
       <a href="#educationSection" class="btn">Education</a>
       <a href="#documentSection" class="btn">Docs</a>
       <a href="#mailSection" class="btn">Mail</a>
+      <a href="#tradelines" class="btn">Tradelines</a>
       <a href="#uploads" class="btn">Uploads</a>
-
-      
     </nav>
     <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You’ve planted the seed — secured cards are your first step to building credit.">
       <span class="text-xl">🔒</span>
@@ -164,6 +163,20 @@
   </div>
   <div id="mailWaiting" class="space-y-2"></div>
   <div id="mailMailed" class="space-y-2 hidden"></div>
+</div>
+<div id="tradelinesSection" class="max-w-3xl mx-auto p-4 hidden">
+  <h2 class="text-xl font-bold mb-2">Tradelines</h2>
+  <input id="tradelineSearch" type="text" class="input w-full mb-2" placeholder="Search by bank..." />
+  <select id="tradelineSort" class="input w-full mb-2">
+    <option value="">Sort by</option>
+    <option value="price-asc">Price ↑</option>
+    <option value="price-desc">Price ↓</option>
+    <option value="limit-asc">Limit ↑</option>
+    <option value="limit-desc">Limit ↓</option>
+    <option value="age-asc">Age ↑</option>
+    <option value="age-desc">Age ↓</option>
+  </select>
+  <div id="tradelineList" class="space-y-2 max-h-96 overflow-y-auto"></div>
 </div>
 <script src="/client-portal.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -203,6 +203,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const mailMailed = document.getElementById('mailMailed');
   const mailTabWaiting = document.getElementById('mailTabWaiting');
   const mailTabMailed = document.getElementById('mailTabMailed');
+  const tradelinesSection = document.getElementById('tradelinesSection');
+  const tradelineList = document.getElementById('tradelineList');
+  const tradelineSearch = document.getElementById('tradelineSearch');
+  const tradelineSort = document.getElementById('tradelineSort');
+  let allTradelines = [];
   function loadDocs(){
     if (!(docEl && consumerId)) return;
     fetch(`/api/consumers/${consumerId}/state`)
@@ -291,6 +296,53 @@ document.addEventListener('DOMContentLoaded', () => {
       if(mailWaiting) mailWaiting.classList.add('hidden');
     });
   }
+
+  function renderTradelines(data){
+    if(!tradelineList) return;
+    if(!data.length){
+      tradelineList.innerHTML = '<div class="muted text-sm">No tradelines found.</div>';
+      return;
+    }
+    tradelineList.innerHTML = data.map(t=>`
+      <div class="flex items-center justify-between p-2 border rounded">
+        <div>
+          <div class="font-medium">${t.bank}</div>
+          <div class="text-xs muted">${t.age} | $${t.limit} limit</div>
+        </div>
+        <div class="text-right">
+          <div class="font-semibold">$${t.price}</div>
+          <a href="${t.buy_link}" class="btn text-xs px-2 py-1">Buy</a>
+        </div>
+      </div>`).join('');
+  }
+
+  function filterTradelines(){
+    let data = allTradelines.filter(t=>t.bank.toLowerCase().includes((tradelineSearch?.value||'').toLowerCase()));
+    const sort = tradelineSort?.value;
+    if(sort==='price-asc') data.sort((a,b)=>a.price-b.price);
+    if(sort==='price-desc') data.sort((a,b)=>b.price-a.price);
+    if(sort==='limit-asc') data.sort((a,b)=>a.limit-b.limit);
+    if(sort==='limit-desc') data.sort((a,b)=>b.limit-a.limit);
+    if(sort==='age-asc') data.sort((a,b)=>(a.age||'').localeCompare(b.age||''));
+    if(sort==='age-desc') data.sort((a,b)=>(b.age||'').localeCompare(a.age||''));
+    renderTradelines(data);
+  }
+
+  async function loadTradelines(){
+    if(!tradelineList) return;
+    if(allTradelines.length){ filterTradelines(); return; }
+    try{
+      const resp = await fetch('/api/tradelines');
+      const data = await resp.json();
+      allTradelines = data.tradelines || [];
+      filterTradelines();
+    }catch(e){
+      tradelineList.innerHTML = '<div class="muted text-sm">Failed to load tradelines.</div>';
+    }
+  }
+
+  if(tradelineSearch) tradelineSearch.addEventListener('input', filterTradelines);
+  if(tradelineSort) tradelineSort.addEventListener('change', filterTradelines);
 
   const goalBtn = document.getElementById('btnGoal');
   if(goalBtn){
@@ -382,6 +434,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const uploadSection = document.getElementById('uploadSection');
   const educationSection = document.getElementById('educationSection');
   const documentSection = document.getElementById('documentSection');
+  
   function showSection(hash){
     if (portalMain) portalMain.classList.add('hidden');
     if (uploadSection) uploadSection.classList.add('hidden');
@@ -389,6 +442,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (educationSection) educationSection.classList.add('hidden');
     if (documentSection) documentSection.classList.add('hidden');
     if (mailSection) mailSection.classList.add('hidden');
+    if (tradelinesSection) tradelinesSection.classList.add('hidden');
 
     if (hash === '#uploads' && uploadSection) {
       uploadSection.classList.remove('hidden');
@@ -403,6 +457,9 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (hash === '#mailSection' && mailSection) {
       mailSection.classList.remove('hidden');
       loadMail();
+    } else if (hash === '#tradelines' && tradelinesSection) {
+      tradelinesSection.classList.remove('hidden');
+      loadTradelines();
     } else if (portalMain) {
       portalMain.classList.remove('hidden');
     }


### PR DESCRIPTION
## Summary
- Add Tradelines link to client portal navigation
- Display tradelines in a scrollable list with host-style filtering and sorting
- Handle section switching to load tradelines on demand

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check crm/public/client-portal.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2e73f6fc8832393c81105ae646a4a