### PR TITLE
Add tradelines list to client portal navigation

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -35,9 +35,8 @@
       <a href="#educationSection" class="btn">Education</a>
       <a href="#documentSection" class="btn">Docs</a>
       <a href="#mailSection" class="btn">Mail</a>
+      <a href="#tradelines" class="btn">Tradelines</a>
       <a href="#uploads" class="btn">Uploads</a>
-
-      
     </nav>
     <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You’ve planted the seed — secured cards are your first step to building credit.">
       <span class="text-xl">🔒</span>
@@ -138,7 +137,7 @@
 </div>
 <div id="messageSection" class="max-w-3xl mx-auto p-4 hidden">
   <h2 class="text-xl font-bold mb-2">Messages</h2>
-  <div id="messageList" class="space-y-2 mb-2 text-sm"></div>
+  <div id="messageList" class="space-y-2 mb-2 text-sm flex flex-col"></div>
   <form id="messageForm" class="flex gap-2">
     <input id="messageInput" class="input flex-1" placeholder="Type message..." />
     <button class="btn" type="submit">Send</button>
@@ -164,6 +163,20 @@
   </div>
   <div id="mailWaiting" class="space-y-2"></div>
   <div id="mailMailed" class="space-y-2 hidden"></div>
+</div>
+<div id="tradelinesSection" class="max-w-3xl mx-auto p-4 hidden">
+  <h2 class="text-xl font-bold mb-2">Tradelines</h2>
+  <input id="tradelineSearch" type="text" class="input w-full mb-2" placeholder="Search by bank..." />
+  <select id="tradelineSort" class="input w-full mb-2">
+    <option value="">Sort by</option>
+    <option value="price-asc">Price ↑</option>
+    <option value="price-desc">Price ↓</option>
+    <option value="limit-asc">Limit ↑</option>
+    <option value="limit-desc">Limit ↓</option>
+    <option value="age-asc">Age ↑</option>
+    <option value="age-desc">Age ↓</option>
+  </select>
+  <div id="tradelineList" class="space-y-2 max-h-96 overflow-y-auto"></div>
 </div>
 <script src="/client-portal.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -35,6 +35,7 @@ body {
   transition: background .2s;
 }
 .btn:hover { background: var(--accent-hover); }
+.input { background: rgba(255,255,255,0.8); border: 1px solid var(--glass-brd); border-radius: 10px; padding: 8px; }
 .muted { color: var(--muted); }
 
 .text-accent { color: var(--accent); }
@@ -180,14 +181,12 @@ body.voice-active #voiceNotes{display:block;}
 }
 
 /* Messaging */
-.msg-host {
-  background: var(--accent-bg);
-  color: #fff;
-}
-.msg-client {
-  background: var(--green-bg);
-  color: #fff;
-}
+.message { padding:8px 12px; border-radius:12px; max-width:80%; box-shadow:0 1px 2px rgba(0,0,0,.05); }
+.msg-host { background: var(--accent-bg); color:#fff; align-self:flex-start; }
+.msg-client { background: var(--green-bg); color:#fff; align-self:flex-end; }
+
+/* Tradelines */
+.tradeline-item { background: rgba(255,255,255,0.85); border:1px solid var(--glass-brd); border-radius:12px; }
 
 .tl-card.selected {
   box-shadow: 0 0 0 2px var(--green);


### PR DESCRIPTION
## Summary
- Add Tradelines link to client portal navigation
- Display tradelines in a scrollable list with host-style filtering and sorting
- Handle section switching to load tradelines on demand
- Make tradeline list items more readable with solid background styling
- Improve message bubbles and input styling for messages section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check public/client-portal.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2e73f6fc8832393c81105ae646a4a