### PR TITLE
Track team member names in messages

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -397,9 +397,10 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(data => {
         const msgs = data.messages || [];
         if (messageBanner) {
-          const hostMsg = msgs.find(m => m.payload?.from === 'host');
+          const hostMsg = msgs.find(m => m.payload?.from && m.payload.from !== 'client');
           if (hostMsg) {
-            messageBanner.textContent = hostMsg.payload?.text || '';
+            const prefix = hostMsg.payload?.from ? hostMsg.payload.from + ': ' : '';
+            messageBanner.textContent = prefix + (hostMsg.payload?.text || '');
             messageBanner.classList.remove('hidden');
           } else {
             messageBanner.classList.add('hidden');
@@ -409,9 +410,12 @@ document.addEventListener('DOMContentLoaded', () => {
           messageList.innerHTML = '<div class="muted">No messages.</div>';
         } else {
           messageList.innerHTML = msgs.map(m => {
-            const from = m.payload?.from === 'host' ? 'msg-host' : 'msg-client';
+            const fromUser = m.payload?.from;
+            const isClient = fromUser === 'client';
+            const cls = isClient ? 'msg-client' : 'msg-host';
+            const name = isClient ? 'You' : fromUser || 'Host';
             const when = new Date(m.at).toLocaleString();
-            return `<div class="message ${from}"><div class="text-xs muted">${when}</div><div>${esc(m.payload?.text||'')}</div></div>`;
+            return `<div class="message ${cls}"><div class="text-xs muted">${esc(name)} • ${when}</div><div>${esc(m.payload?.text||'')}</div></div>`;
           }).join('');
         }
       })

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -102,7 +102,10 @@ document.addEventListener('DOMContentLoaded', () => {
         msgList.textContent = 'No messages.';
         return;
       }
-      msgList.innerHTML = msgs.map(m=>`<div><span class="font-medium">${escapeHtml(m.consumer?.name || '')} - ${m.payload?.from==='host'?'You':'Client'}:</span> ${escapeHtml(m.payload?.text || '')}</div>`).join('');
+      msgList.innerHTML = msgs.map(m=>{
+        const sender = m.payload?.from === 'client' ? 'Client' : m.payload?.from || 'Host';
+        return `<div><span class="font-medium">${escapeHtml(m.consumer?.name || '')} - ${escapeHtml(sender)}:</span> ${escapeHtml(m.payload?.text || '')}</div>`;
+      }).join('');
     }catch(e){
       console.error('Failed to load messages', e);
       msgList.textContent = 'Failed to load messages.';

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -1082,9 +1082,12 @@ async function loadMessages(){
   const msgs = resp.messages || [];
   if(!msgs.length){ $("#msgList").innerHTML = `<div class="muted">No messages.</div>`; return; }
   $("#msgList").innerHTML = msgs.map(m=>{
-    const from = m.payload?.from === 'host' ? 'msg-host' : 'msg-client';
+    const fromUser = m.payload?.from;
+    const isClient = fromUser === 'client';
+    const cls = isClient ? 'msg-client' : 'msg-host';
+    const label = isClient ? 'Client' : escapeHtml(fromUser || 'Host');
     const when = new Date(m.at).toLocaleString();
-    return `<div class="${from} p-2 rounded"><div class="text-xs muted">${when}</div><div>${escapeHtml(m.payload?.text||'')}</div></div>`;
+    return `<div class="${cls} p-2 rounded"><div class="text-xs muted">${label} • ${when}</div><div>${escapeHtml(m.payload?.text||'')}</div></div>`;
   }).join('');
 }
 
@@ -1092,7 +1095,7 @@ $("#btnSendMsg").addEventListener("click", async ()=>{
   if(!currentConsumerId) return showErr("Select a consumer first.");
   const txt = $("#msgInput").value.trim();
   if(!txt) return;
-  const res = await api(`/api/messages/${currentConsumerId}`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ text: txt, from:'host' }) });
+  const res = await api(`/api/messages/${currentConsumerId}`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ text: txt }) });
   if(!res?.ok) return showErr(res.error || "Failed to send message.");
   $("#msgInput").value = "";
   await loadMessages();

--- a/metro2 (copy 1)/crm/public/my-company.js
+++ b/metro2 (copy 1)/crm/public/my-company.js
@@ -45,8 +45,11 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       const data = await res.json();
       members = data.users || [];
+      const teamData = members.map(m => ({ name: m.username, role: m.role, email: m.email }));
+      localStorage.setItem('teamMembers', JSON.stringify(teamData));
     } catch {
       members = [];
+      localStorage.removeItem('teamMembers');
     }
     renderMembers();
   }

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -748,10 +748,16 @@ app.get("/api/messages/:consumerId", (req,res)=>{
   res.json({ ok:true, messages: msgs });
 });
 
-app.post("/api/messages/:consumerId", (req,res)=>{
+app.post("/api/messages/:consumerId", optionalAuth, (req,res)=>{
   const text = req.body.text || "";
-  const from = req.body.from || "host";
-  addEvent(req.params.consumerId, "message", { from, text });
+  let from = req.body.from || "host";
+  const payload = { from, text };
+  if (req.user) {
+    from = req.user.username;
+    payload.from = from;
+    payload.userId = req.user.id;
+  }
+  addEvent(req.params.consumerId, "message", payload);
   res.json({ ok:true });
 });
 


### PR DESCRIPTION
## Summary
- Associate authenticated user info with posted messages on the server.
- Show sender names for messages in dashboard, client portal, and client view.
- Persist team members locally for portal display.

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js && echo 'server ok'`
- `node --check public/index.js && echo 'index ok'`
- `node --check public/dashboard.js && echo 'dashboard ok'`
- `node --check public/my-company.js && echo 'my-company ok'`
- `node --check public/client-portal.js && echo 'client-portal ok'`


------
https://chatgpt.com/codex/tasks/task_e_68b2f3be2e7883238830c2620ca8f4e9