### PR TITLE
Track team member names in messages

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -397,9 +397,10 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(data => {
         const msgs = data.messages || [];
         if (messageBanner) {
-          const hostMsg = msgs.find(m => m.payload?.from === 'host');
+          const hostMsg = msgs.find(m => m.payload?.from && m.payload.from !== 'client');
           if (hostMsg) {
-            messageBanner.textContent = hostMsg.payload?.text || '';
+            const prefix = hostMsg.payload?.from ? hostMsg.payload.from + ': ' : '';
+            messageBanner.textContent = prefix + (hostMsg.payload?.text || '');
             messageBanner.classList.remove('hidden');
           } else {
             messageBanner.classList.add('hidden');
@@ -409,9 +410,12 @@ document.addEventListener('DOMContentLoaded', () => {
           messageList.innerHTML = '<div class="muted">No messages.</div>';
         } else {
           messageList.innerHTML = msgs.map(m => {
-            const from = m.payload?.from === 'host' ? 'msg-host' : 'msg-client';
+            const fromUser = m.payload?.from;
+            const isClient = fromUser === 'client';
+            const cls = isClient ? 'msg-client' : 'msg-host';
+            const name = isClient ? 'You' : fromUser || 'Host';
             const when = new Date(m.at).toLocaleString();
-            return `<div class="message ${from}"><div class="text-xs muted">${when}</div><div>${esc(m.payload?.text||'')}</div></div>`;
+            return `<div class="message ${cls}"><div class="text-xs muted">${esc(name)} • ${when}</div><div>${esc(m.payload?.text||'')}</div></div>`;
           }).join('');
         }
       })

--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -58,6 +58,29 @@ function initPalette(){
   applyTheme(saved);
 }
 
+async function limitNavForMembers(){
+  const auth = localStorage.getItem('auth');
+  if(!auth) return;
+  try{
+    const res = await fetch('/api/me',{ headers:{ Authorization:'Basic '+auth } });
+    if(!res.ok) return;
+    const data = await res.json();
+    if(!data.user || data.user.role !== 'member') return;
+    const nav = document.querySelector('header .flex.items-center.gap-2');
+    if(!nav) return;
+    const allowed = new Set(['/dashboard','/schedule','/leads','/billing','/clients']);
+    [...nav.children].forEach(el=>{
+      if(el.tagName === 'A'){
+        const href = el.getAttribute('href');
+        if(allowed.has(href)) return;
+        el.remove();
+      } else if(el.id === 'btnHelp' || el.id === 'btnInvite' || el.id === 'tierBadge'){
+        el.remove();
+      }
+    });
+  }catch{}
+}
+
 const deletionTiers = [
   { threshold: 150, name: 'Credit Legend', icon: '👑', class: 'bg-gradient-to-r from-purple-400 to-pink-500 text-white', message: 'The ultimate, rare achievement.' },
   { threshold: 125, name: 'Credit Hero', icon: '🦸', class: 'bg-red-100 text-red-700', message: 'You’re now the hero of your credit story.' },
@@ -172,6 +195,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
   initVoiceNotes();
   ensureTierBadge();
   renderDeletionTier();
+  limitNavForMembers();
 });
 
 window.openHelp = openHelp;

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -102,7 +102,10 @@ document.addEventListener('DOMContentLoaded', () => {
         msgList.textContent = 'No messages.';
         return;
       }
-      msgList.innerHTML = msgs.map(m=>`<div><span class="font-medium">${escapeHtml(m.consumer?.name || '')} - ${m.payload?.from==='host'?'You':'Client'}:</span> ${escapeHtml(m.payload?.text || '')}</div>`).join('');
+      msgList.innerHTML = msgs.map(m=>{
+        const sender = m.payload?.from === 'client' ? 'Client' : m.payload?.from || 'Host';
+        return `<div><span class="font-medium">${escapeHtml(m.consumer?.name || '')} - ${escapeHtml(sender)}:</span> ${escapeHtml(m.payload?.text || '')}</div>`;
+      }).join('');
     }catch(e){
       console.error('Failed to load messages', e);
       msgList.textContent = 'Failed to load messages.';

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -1082,9 +1082,12 @@ async function loadMessages(){
   const msgs = resp.messages || [];
   if(!msgs.length){ $("#msgList").innerHTML = `<div class="muted">No messages.</div>`; return; }
   $("#msgList").innerHTML = msgs.map(m=>{
-    const from = m.payload?.from === 'host' ? 'msg-host' : 'msg-client';
+    const fromUser = m.payload?.from;
+    const isClient = fromUser === 'client';
+    const cls = isClient ? 'msg-client' : 'msg-host';
+    const label = isClient ? 'Client' : escapeHtml(fromUser || 'Host');
     const when = new Date(m.at).toLocaleString();
-    return `<div class="${from} p-2 rounded"><div class="text-xs muted">${when}</div><div>${escapeHtml(m.payload?.text||'')}</div></div>`;
+    return `<div class="${cls} p-2 rounded"><div class="text-xs muted">${label} • ${when}</div><div>${escapeHtml(m.payload?.text||'')}</div></div>`;
   }).join('');
 }
 
@@ -1092,7 +1095,7 @@ $("#btnSendMsg").addEventListener("click", async ()=>{
   if(!currentConsumerId) return showErr("Select a consumer first.");
   const txt = $("#msgInput").value.trim();
   if(!txt) return;
-  const res = await api(`/api/messages/${currentConsumerId}`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ text: txt, from:'host' }) });
+  const res = await api(`/api/messages/${currentConsumerId}`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ text: txt }) });
   if(!res?.ok) return showErr(res.error || "Failed to send message.");
   $("#msgInput").value = "";
   await loadMessages();

--- a/metro2 (copy 1)/crm/public/my-company.js
+++ b/metro2 (copy 1)/crm/public/my-company.js
@@ -45,8 +45,11 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       const data = await res.json();
       members = data.users || [];
+      const teamData = members.map(m => ({ name: m.username, role: m.role, email: m.email }));
+      localStorage.setItem('teamMembers', JSON.stringify(teamData));
     } catch {
       members = [];
+      localStorage.removeItem('teamMembers');
     }
     renderMembers();
   }

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -192,6 +192,11 @@ function requirePermission(perm){
   };
 }
 
+function forbidMember(req,res,next){
+  if(req.user && req.user.role === "member") return res.status(403).send("Forbidden");
+  next();
+}
+
 
 // Basic resource monitoring to catch memory or CPU spikes
 const MAX_RSS_MB = Number(process.env.MAX_RSS_MB || 512);
@@ -228,20 +233,20 @@ setInterval(() => {
 // ---------- Static UI ----------
 const PUBLIC_DIR = path.join(__dirname, "public");
 app.use(express.static(PUBLIC_DIR));
-app.get("/", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "index.html")));
+app.get("/", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "index.html")));
 app.get("/dashboard", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "dashboard.html")));
 app.get("/clients", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "index.html")));
 app.get("/leads", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "leads.html")));
 app.get("/schedule", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "schedule.html")));
-app.get("/my-company", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "my-company.html")));
+app.get("/my-company", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "my-company.html")));
 app.get("/billing", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "billing.html")));
-app.get(["/letters", "/letters/:jobId"], (_req, res) =>
+app.get(["/letters", "/letters/:jobId"], optionalAuth, forbidMember, (_req, res) =>
   res.sendFile(path.join(PUBLIC_DIR, "letters.html"))
 );
-app.get("/library", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "library.html")));
-app.get("/tradelines", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "tradelines.html")));
-app.get("/quiz", (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "quiz.html")));
-app.get("/settings", (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "settings.html")));
+app.get("/library", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "library.html")));
+app.get("/tradelines", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "tradelines.html")));
+app.get("/quiz", optionalAuth, forbidMember, (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "quiz.html")));
+app.get("/settings", optionalAuth, forbidMember, (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "settings.html")));
 app.get("/portal/:id", (req, res) => {
   const db = loadDB();
   const consumer = db.consumers.find(c => c.id === req.params.id);
@@ -653,6 +658,10 @@ app.get("/api/users", authenticate, requireRole("admin"), (_req,res)=>{
   res.json({ ok:true, users: db.users.map(u=>({ id:u.id, username:u.username, role:u.role, permissions: u.permissions || [] })) });
 });
 
+app.get("/api/me", authenticate, (req,res)=>{
+  res.json({ ok:true, user: { id: req.user.id, username: req.user.username, role: req.user.role, permissions: req.user.permissions || [] } });
+});
+
 // =================== Contacts ===================
 app.get("/api/contacts", authenticate, requirePermission("contacts"), (_req,res)=>{
 
@@ -748,10 +757,16 @@ app.get("/api/messages/:consumerId", (req,res)=>{
   res.json({ ok:true, messages: msgs });
 });
 
-app.post("/api/messages/:consumerId", (req,res)=>{
+app.post("/api/messages/:consumerId", optionalAuth, (req,res)=>{
   const text = req.body.text || "";
-  const from = req.body.from || "host";
-  addEvent(req.params.consumerId, "message", { from, text });
+  let from = req.body.from || "host";
+  const payload = { from, text };
+  if (req.user) {
+    from = req.user.username;
+    payload.from = from;
+    payload.userId = req.user.id;
+  }
+  addEvent(req.params.consumerId, "message", payload);
   res.json({ ok:true });
 });
 


### PR DESCRIPTION
## Summary
- Associate authenticated user info with posted messages on the server.
- Show sender names for messages in dashboard, client portal, and client view.
- Persist team members locally for portal display.
- Restrict team members to dashboard, schedule, leads, billing, and clients pages only.

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`
- `node --check public/common.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2f3be2e7883238830c2620ca8f4e9