### PR TITLE
feat: move company links to settings dropdown

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -15,12 +15,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -25,12 +25,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
       <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You've started your journey.">

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -76,12 +76,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/leads.html
+++ b/metro2 (copy 1)/crm/public/leads.html
@@ -15,12 +15,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -35,12 +35,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -20,12 +20,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -15,12 +15,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -16,12 +16,16 @@
         <a href="/clients" class="btn">Clients</a>
         <a href="/leads" class="btn">Leads</a>
         <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-        <a href="/letters" class="btn">Letter</a>
+      <div class="relative group">
         <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
         <a href="/tradelines" class="btn">Tradelines</a>
-        <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -15,12 +15,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -15,12 +15,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>

--- a/metro2 (copy 1)/crm/public/tradelines.html
+++ b/metro2 (copy 1)/crm/public/tradelines.html
@@ -15,12 +15,16 @@
       <a href="/clients" class="btn">Clients</a>
       <a href="/leads" class="btn">Leads</a>
       <a href="/schedule" class="btn">Schedule</a>
-      <a id="navCompany" href="/my-company" class="btn">My Company</a>
       <a href="/billing" class="btn">Billing</a>
-      <a href="/letters" class="btn">Letter</a>
-      <a href="/settings" class="btn">Settings</a>
+      <div class="relative group">
+        <a href="/settings" class="btn">Settings</a>
+        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
+          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+          <a href="/letters" class="btn text-sm">Letter</a>
+          <a href="/library" class="btn text-sm">Library</a>
+        </div>
+      </div>
       <a href="/tradelines" class="btn">Tradelines</a>
-      <a href="/library" class="btn">Library</a>
       <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
       <button id="btnInvite" class="btn" style="background: var(--green-bg);">Invite +</button>
     </div>


### PR DESCRIPTION
## Summary
- Move My Company, Letter, and Library links into a hover-based Settings dropdown across all pages
- Position dropdown below navigation so it no longer covers other elements

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2f4db69a88323981b428a28ac776a