### PR TITLE
Fix host-team message overlap and state marker clustering

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -33,6 +33,17 @@ function renderProductTier(){
   el.title = tier.message;
 }
 
+function escapeHtml(s){
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  };
+  return String(s||'').replace(/[&<>"']/g, c => map[c]);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const idMatch = location.pathname.match(/\/portal\/(.+)$/);
 
@@ -415,7 +426,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const cls = isClient ? 'msg-client' : 'msg-host';
             const name = isClient ? 'You' : fromUser || 'Host';
             const when = new Date(m.at).toLocaleString();
-
+            return `<div class="message ${cls}"><div class="text-xs muted">${name} • ${when}</div><div>${escapeHtml(m.payload?.text || '')}</div></div>`;
           }).join('');
         }
       })

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -50,13 +50,19 @@ function renderClientMap(consumers){
     });
   setTimeout(()=>map.invalidateSize(),0);
 
-  consumers.forEach(c=>{
+  const grouped = consumers.reduce((acc,c)=>{
     const code = getStateCode(c.state);
+    if(!code) return acc;
+    (acc[code] ||= []).push(c.name || '');
+    return acc;
+  },{});
+
+  Object.entries(grouped).forEach(([code,names])=>{
     const coords = stateCenters[code];
     if(coords){
       L.circleMarker(coords,{ radius:6, color:'#059669', fillColor:'#10b981', fillOpacity:0.7 })
         .addTo(map)
-        .bindPopup(c.name || '');
+        .bindPopup(names.join('<br>'));
     }
   });
 }

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -137,7 +137,7 @@
           <div class="font-semibold">Messages</div>
           <button id="btnSendMsg" class="btn text-sm">Send</button>
         </div>
-        <div id="msgList" class="space-y-2 text-sm max-h-48 overflow-y-auto"></div>
+        <div id="msgList" class="space-y-2 text-sm max-h-48 overflow-y-auto flex flex-col"></div>
         <textarea id="msgInput" class="w-full border rounded p-2 text-sm" rows="2" placeholder="Type message..."></textarea>
       </div>
       <div class="glass card">

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -1087,7 +1087,7 @@ async function loadMessages(){
     const cls = isClient ? 'msg-client' : 'msg-host';
     const label = isClient ? 'Client' : escapeHtml(fromUser || 'Host');
     const when = new Date(m.at).toLocaleString();
-    return `<div class="${cls} p-2 rounded"><div class="text-xs muted">${label} • ${when}</div><div>${escapeHtml(m.payload?.text||'')}</div></div>`;
+    return `<div class="message ${cls}"><div class="text-xs muted">${label} • ${when}</div><div>${escapeHtml(m.payload?.text||'')}</div></div>`;
   }).join('');
 }
 


### PR DESCRIPTION
## Summary
- make dashboard message list a flex column and style messages consistently
- sanitize and render client portal messages with explicit HTML escaping
- group clients by state so map markers don't overlap

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b2f9273a348323b5608c94be014857