### PR TITLE
fix: ensure nav dropdown above content

### DIFF
--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -7,7 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
   <style>
-    #templatePanel{position:fixed;top:100px;left:50%;transform:translateX(-50%);z-index:40;width:90vw;max-width:1100px;}
+    #templatePanel{position:fixed;top:100px;left:50%;transform:translateX(-50%);width:90vw;max-width:1100px;}
     .drag-bubble{width:20px;height:20px;border-radius:50%;background:#d1d5db;position:absolute;top:-10px;right:-10px;cursor:grab;box-shadow:0 2px 4px rgba(0,0,0,0.2);}
   </style>
 </head>

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -232,7 +232,12 @@ body.voice-active #voiceNotes{display:block;}
 .tl-card.selected { box-shadow: 0 0 0 2px var(--green); }
 
 /* Ensure navigation dropdowns appear above other panels */
-header .group > div {
+header {
+  position: relative;
+  z-index: 200;
+}
+
+header .group > div.absolute {
   z-index: 100 !important;
 }
 


### PR DESCRIPTION
## Summary
- give header a stacking context so navigation overlays page panels
- scope menu z-index to absolute dropdowns
- drop template panel z-index to prevent overlap

## Testing
- `npm test` *(fails: Missing script "test")*
- `node check-dropdown.mjs` *(dashboard and library dropdowns z-index 100, cards z-index auto)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fd69f88083238e71ba80ab843f76