### PR TITLE
Separate host and team navigation wrappers

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -23,7 +23,7 @@
   </style>
 </head>
 <body>
-<header class="p-4">
+<header id="team-nav" class="p-4">
   <div class="max-w-3xl mx-auto flex items-center justify-between">
     <div class="flex items-center gap-2">
       <div id="mascot" class="w-12 h-12"></div>

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -68,7 +68,7 @@
   </style>
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/leads.html
+++ b/metro2 (copy 1)/crm/public/leads.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -27,7 +27,7 @@
   </style>
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-  <header class="p-4">
+  <header id="host-nav" class="p-4">
     <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
       <div class="text-xl font-semibold">Metro 2 CRM</div>
       <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -196,6 +196,16 @@ body.voice-active #voiceNotes{display:block;}
   accent-color: var(--green);
 }
 
+#host-nav,#team-nav{position:fixed;left:0;right:0;}
+#host-nav{top:0;z-index:50;}
+#team-nav{top:0;z-index:40;}
+#host-nav + #team-nav{top:60px;}
+body{padding-top:0;}
+body:has(#host-nav){padding-top:60px;}
+body:has(#team-nav){padding-top:60px;}
+body:has(#host-nav + #team-nav){padding-top:120px;}
+
+
 /* Violation severity styling */
 .violation-item {
   border-left: 4px solid transparent;

--- a/metro2 (copy 1)/crm/public/tradelines.html
+++ b/metro2 (copy 1)/crm/public/tradelines.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-<header class="p-4">
+<header id="host-nav" class="p-4">
   <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
     <div class="text-xl font-semibold">Metro 2 CRM</div>
     <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Add `host-nav` ID to CRM page headers and `team-nav` to client portal to uniquely identify each navigation bar.
- Style host and team navigation wrappers independently to keep bars fixed and avoid layout jumps.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2fd758a7c83238f4e54f272e1e4dd