### PR TITLE
Add transparency slider for glass UI

### DIFF
--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -88,6 +88,12 @@ body {
   border: 2px solid #fff;
   cursor: pointer;
 }
+#themePalette .alpha-slider{
+  -webkit-appearance:none;
+  width:100px;
+  transform:rotate(-90deg);
+}
+#themePalette.collapsed .alpha-slider{display:none;}
 #themePalette .mic {
   width:32px;
   height:32px;


### PR DESCRIPTION
## Summary
- add slider to theme palette to control glass background transparency
- update styles for new slider

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b314c83fd08323a1e63472d7195db9