### PR TITLE
Use new team member creation API

### DIFF
--- a/metro2 (copy 1)/crm/public/my-company.js
+++ b/metro2 (copy 1)/crm/public/my-company.js
@@ -76,27 +76,33 @@ document.addEventListener('DOMContentLoaded', () => {
       const uEl = document.getElementById('tmUser');
       const pEl = document.getElementById('tmPass');
       if (!uEl.value.trim() || !auth) return;
-      const perms = [];
-      if (document.getElementById('permContacts').checked) perms.push('contacts');
-      if (document.getElementById('permTasks').checked) perms.push('tasks');
-      if (document.getElementById('permReports').checked) perms.push('reports');
-      await fetch('/api/users', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Basic ' + auth
-        },
-        body: JSON.stringify({
-          username: uEl.value.trim(),
-          password: pEl.value,
-          role: 'member',
-          permissions: perms
-        })
-      });
-      // Generate shareable link that preloads credentials via ?auth param
-      const link = `${location.origin}/dashboard?auth=${btoa(`${uEl.value.trim()}:${pEl.value}`)}`;
-      // Offer the link for copying/sharing
-      prompt('Share this link with the new team member:', link);
+      const body = { username: uEl.value.trim() };
+      if (pEl.value) body.password = pEl.value;
+      let res;
+      try {
+        res = await fetch('/api/team-members', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Basic ' + auth
+          },
+          body: JSON.stringify(body)
+        });
+      } catch {
+        alert('Network error while creating team member');
+        return;
+      }
+      if (res.status === 401 || res.status === 403) {
+        alert('You are not authorized to add team members');
+        return;
+      }
+      if (!res.ok) {
+        alert('Failed to create team member');
+        return;
+      }
+      const { member } = await res.json();
+      const link = `${location.origin}/team/${member.token}`;
+      prompt(`Share this link with the new team member:\n${link}\nInitial password: ${member.password}`, link);
 
       uEl.value = '';
       pEl.value = '';


### PR DESCRIPTION
## Summary
- Switch team member creation to `/api/team-members` endpoint
- Share invite link using returned token and include initial password in prompt
- Handle network and authorization failures when adding team members

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b31623bd188323a99687ba4c3dad06