### PR TITLE
Limit personal info letters to mismatched fields

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -1348,8 +1348,13 @@ app.post("/api/generate", async (req,res)=>{
 
 
     const letters = generateLetters({ report: reportWrap.data, selections, consumer: consumerForLetter, requestType });
-    if (personalInfo) {
-      letters.push(...generatePersonalInfoLetters({ consumer: consumerForLetter }));
+    if (Array.isArray(personalInfo) && personalInfo.length) {
+      letters.push(
+        ...generatePersonalInfoLetters({
+          consumer: consumerForLetter,
+          mismatchedFields: personalInfo,
+        })
+      );
     }
     if (Array.isArray(inquiries) && inquiries.length) {
       letters.push(...generateInquiryLetters({ consumer: consumerForLetter, inquiries }));


### PR DESCRIPTION
## Summary
- Support mismatch filtering when generating personal information letters
- Pass personal info mismatch list from API endpoint to letter generator

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3501efcbc8323b53911e363323cb8