### PR TITLE
Fix sequence save to support multiple entries

### DIFF
--- a/metro2 (copy 1)/crm/public/library.js
+++ b/metro2 (copy 1)/crm/public/library.js
@@ -171,10 +171,10 @@ function newSequence(){
 async function saveSequence(){
   const selected = Array.from(document.querySelectorAll('#seqTemplates input[type="checkbox"]:checked')).map(cb => cb.value);
   const payload = {
-    id: currentSequenceId,
     name: document.getElementById('seqName').value,
     templates: selected
   };
+  if (currentSequenceId != null) payload.id = currentSequenceId;
   const res = await fetch('/api/sequences', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- allow saving multiple sequences by only including an ID when editing an existing sequence
- handle zero-valued sequence IDs when saving sequences

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b352eca7688323a05adfa7143a3a43