### PR TITLE
feat: make navigation bar sticky

### DIFF
--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -204,14 +204,11 @@ body.voice-active #voiceNotes{display:block;}
   accent-color: var(--green);
 }
 
-#host-nav,#team-nav{position:fixed;left:0;right:0;}
+#host-nav,#team-nav{position:sticky;left:0;right:0;}
 #host-nav{top:0;z-index:50;}
 #team-nav{top:0;z-index:40;}
 #host-nav + #team-nav{top:60px;}
 body{padding-top:0;}
-body:has(#host-nav){padding-top:60px;}
-body:has(#team-nav){padding-top:60px;}
-body:has(#host-nav + #team-nav){padding-top:120px;}
 
 
 /* Violation severity styling */


### PR DESCRIPTION
## Summary
- stick host and team navigation bars using CSS `position: sticky`
- remove body padding offsets for the fixed nav approach

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b353e6224483239d7250a9c6de97d1