### PR TITLE
Move transparency slider next to color palette

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -58,8 +58,10 @@ function initPalette(){
     .join('');
   wrap.innerHTML = `
     <button class="toggle">▶</button>
-    <div class="palette-bubbles">${bubbles}</div>
-    <input id="glassAlpha" class="alpha-slider" type="range" min="0" max="0.5" step="0.05" />
+    <div class="palette-controls">
+      <div class="palette-bubbles">${bubbles}</div>
+      <input id="glassAlpha" class="alpha-slider" type="range" min="0" max="0.5" step="0.05" />
+    </div>
     <button id="voiceMic" class="mic">🎤</button>`;
   document.body.appendChild(wrap);
   const toggle = wrap.querySelector('.toggle');

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -76,7 +76,12 @@ body {
   color: #fff;
   cursor: pointer;
 }
-#themePalette.collapsed .palette-bubbles { display: none; }
+#themePalette.collapsed .palette-controls { display: none; }
+#themePalette .palette-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 #themePalette .palette-bubbles {
   display: flex;
   flex-direction: column;
@@ -94,7 +99,6 @@ body {
   width:100px;
   transform:rotate(-90deg);
 }
-#themePalette.collapsed .alpha-slider{display:none;}
 #themePalette .mic {
   width:32px;
   height:32px;


### PR DESCRIPTION
## Summary
- Position transparency slider beside color palette to prevent overlap
- Group palette colors and slider in new `.palette-controls` container

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3546da88083239f3d66bb65c75230