### PR TITLE
Move theme palette to left and fix collapse

### DIFF
--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -59,7 +59,7 @@ body {
 #themePalette {
   position: fixed;
   top: 50%;
-  right: 8px;
+  left: 8px;
   transform: translateY(-50%);
   display: flex;
   flex-direction: column;
@@ -76,8 +76,8 @@ body {
   color: #fff;
   cursor: pointer;
 }
-#themePalette.collapsed .palette-controls { display: none; }
-#themePalette .palette-controls {
+#themePalette .palette-controls { display: none; }
+#themePalette:not(.collapsed) .palette-controls {
   display: flex;
   align-items: center;
   gap: 8px;


### PR DESCRIPTION
## Summary
- Position the theme palette on the left side of the screen
- Ensure palette controls hide when collapsed for proper toggle behavior

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3562a8ccc832390b670d819b194ce