### PR TITLE
Move transparency slider next to color palette

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -58,8 +58,10 @@ function initPalette(){
     .join('');
   wrap.innerHTML = `
     <button class="toggle">▶</button>
-    <div class="palette-bubbles">${bubbles}</div>
-    <input id="glassAlpha" class="alpha-slider" type="range" min="0" max="0.5" step="0.05" />
+    <div class="palette-controls">
+      <div class="palette-bubbles">${bubbles}</div>
+      <input id="glassAlpha" class="alpha-slider" type="range" min="0" max="0.5" step="0.05" />
+    </div>
     <button id="voiceMic" class="mic">🎤</button>`;
   document.body.appendChild(wrap);
   const toggle = wrap.querySelector('.toggle');

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -320,7 +320,7 @@
   </template>
 
 <!-- New Consumer Modal -->
-<div id="newModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)]">
+<div id="newModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)] z-[999]">
   <form id="newForm" class="glass card w-[min(560px,92vw)] space-y-3">
     <div class="flex items-center justify-between">
       <div class="font-semibold">New Consumer</div>
@@ -351,7 +351,7 @@
 </div>
 
 <!-- Edit Consumer Modal -->
-<div id="editModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)]">
+<div id="editModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)] z-[999]">
   <form id="editForm" class="glass card w-[min(560px,92vw)] space-y-3">
     <div class="flex items-center justify-between">
       <div class="font-semibold">Edit Consumer</div>

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -76,7 +76,12 @@ body {
   color: #fff;
   cursor: pointer;
 }
-#themePalette.collapsed .palette-bubbles { display: none; }
+#themePalette.collapsed .palette-controls { display: none; }
+#themePalette .palette-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 #themePalette .palette-bubbles {
   display: flex;
   flex-direction: column;
@@ -94,7 +99,6 @@ body {
   width:100px;
   transform:rotate(-90deg);
 }
-#themePalette.collapsed .alpha-slider{display:none;}
 #themePalette .mic {
   width:32px;
   height:32px;


### PR DESCRIPTION
## Summary
- Position transparency slider beside color palette to prevent overlap
- Group palette colors and slider in new `.palette-controls` container
- Raise new and edit consumer modals above the interface so they overlay all other elements

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3546da88083239f3d66bb65c75230