### PR TITLE
Remove analyzer directory and update quiz

### DIFF
--- a/metro2 (copy 1)/analyzer/package-lock.json
+++ b/metro2 (copy 1)/analyzer/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "analyzer",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/metro2 (copy 1)/crm/public/quiz.js
+++ b/metro2 (copy 1)/crm/public/quiz.js
@@ -11,7 +11,7 @@ const QUESTIONS = [
   },
   {
     q: "What does R do on the CRM page?",
-    a: ["Removes focused card or current report", "Refreshes page", "Runs analyzer", "Renames consumer"],
+    a: ["Removes focused card or current report", "Refreshes page", "Records note", "Renames consumer"],
     correct: 0,
   },
   {


### PR DESCRIPTION
## Summary
- delete unused `analyzer` directory
- update quiz options to remove analyzer reference

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b366fa5f008323affddf725920fa89