### PR TITLE
Fix 'Report not found' warning for new clients

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -139,13 +139,13 @@ function currentPageItems(){
   return items.slice(start, start+PAGE_SIZE);
 }
 
-async function loadConsumers(){
+async function loadConsumers(restore = true){
   clearErr();
   const data = await api("/api/consumers");
   if (!data || !data.consumers) { showErr("Could not load consumers."); return; }
   DB = data;
   renderConsumers();
-  restoreSelectedConsumer();
+  if (restore) restoreSelectedConsumer();
 }
 function renderConsumers(){
   const wrap = $("#consumerList");
@@ -843,7 +843,7 @@ $("#newForm").addEventListener("submit", async (e)=>{
   });
   if(!res?.ok) return showErr(res?.error || "Failed to create consumer.");
   closeNew();
-  await loadConsumers();
+  await loadConsumers(false);
   await selectConsumer(res.consumer.id);
 });
 
@@ -887,7 +887,7 @@ $("#editForm").addEventListener("submit", async (e)=>{
   });
   if(!res?.ok) return showErr(res?.error || "Failed to save.");
   closeEdit();
-  await loadConsumers();
+  await loadConsumers(false);
   const c = DB.consumers.find(x=>x.id===currentConsumerId);
   $("#selConsumer").textContent = c ? c.name : "—";
 });


### PR DESCRIPTION
## Summary
- add optional restore flag to consumer loading helper
- skip restoring previous selection after creating or editing a client to avoid fetching missing reports

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b36c88d834832395a36387d39cae2e