### PR TITLE
feat: add jwt auth and password reset

### DIFF
--- a/metro2 (copy 1)/crm/package-lock.json
+++ b/metro2 (copy 1)/crm/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "archiver": "^6.0.2",
+        "bcryptjs": "^2.4.3",
         "cheerio": "^1.1.2",
         "express": "^4.21.2",
+        "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "nanoid": "^5.1.5",
         "node-fetch": "^3.3.2",
@@ -299,6 +301,12 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -343,6 +351,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -740,6 +754,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1452,6 +1475,55 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -1503,6 +1575,48 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/metro2 (copy 1)/crm/package.json
+++ b/metro2 (copy 1)/crm/package.json
@@ -13,10 +13,12 @@
     "archiver": "^6.0.2",
     "cheerio": "^1.1.2",
     "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
     "nanoid": "^5.1.5",
     "node-fetch": "^3.3.2",
     "nodemailer": "^6.9.12",
+    "bcryptjs": "^2.4.3",
     "puppeteer": "^24.17.0",
     "stripe": "^18.5.0"
   }

--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -1,8 +1,19 @@
 /* public/common.js */
-// Allow ?auth=BASE64 credentials links to set local auth state
-const _authParam = new URLSearchParams(location.search).get('auth');
+// Allow ?auth=BASE64 or ?token=JWT links to set local auth state
+const params = new URLSearchParams(location.search);
+const _authParam = params.get('auth');
 if (_authParam) {
   localStorage.setItem('auth', _authParam);
+}
+const _tokenParam = params.get('token');
+if (_tokenParam) {
+  localStorage.setItem('token', _tokenParam);
+}
+
+// redirect to login if not authenticated
+if (location.pathname !== '/login.html') {
+  const hasAuth = localStorage.getItem('token') || localStorage.getItem('auth');
+  if (!hasAuth) location.href = '/login.html';
 }
 const THEMES = {
   blue:   { accent: '#007AFF', hover: '#005bb5', bg: 'rgba(0,122,255,0.12)', glassBg: 'rgba(0,122,255,0.15)', glassBrd: 'rgba(0,122,255,0.3)' },
@@ -89,11 +100,19 @@ function initPalette(){
   }
 }
 
-async function limitNavForMembers(){
+function authHeader(){
+  const token = localStorage.getItem('token');
+  if(token) return { Authorization: 'Bearer '+token };
   const auth = localStorage.getItem('auth');
-  if(!auth) return;
+  if(auth) return { Authorization: 'Basic '+auth };
+  return {};
+}
+
+async function limitNavForMembers(){
+  const headers = authHeader();
+  if(Object.keys(headers).length === 0) return;
   try{
-    const res = await fetch('/api/me',{ headers:{ Authorization:'Basic '+auth } });
+    const res = await fetch('/api/me',{ headers });
     if(!res.ok) return;
     const data = await res.json();
     const role = (data.user?.role || '').toLowerCase();

--- a/metro2 (copy 1)/crm/public/login.html
+++ b/metro2 (copy 1)/crm/public/login.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Login - Metro 2 CRM</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="theme-color" content="#AF52DE" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body class="min-h-screen flex items-center justify-center bg-gray-100">
+  <div class="glass card w-full max-w-sm space-y-4">
+    <h1 class="text-xl font-semibold text-center">Sign in</h1>
+    <div id="err" class="hidden p-2 text-sm text-red-700 bg-red-50 border border-red-200 rounded"></div>
+    <input id="username" type="text" placeholder="Username" class="w-full border rounded px-3 py-2" />
+    <input id="password" type="password" placeholder="Password" class="w-full border rounded px-3 py-2" />
+    <button id="btnLogin" class="btn w-full">Login</button>
+    <button id="btnRegister" class="btn w-full" style="background:var(--green-bg)">Register</button>
+    <button id="btnReset" class="btn w-full" style="background:var(--accent-bg)">Reset Password</button>
+  </div>
+  <script src="/common.js"></script>
+  <script src="/login.js"></script>
+</body>
+</html>

--- a/metro2 (copy 1)/crm/public/login.js
+++ b/metro2 (copy 1)/crm/public/login.js
@@ -1,0 +1,61 @@
+/* public/login.js */
+async function handleAuth(endpoint){
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value;
+  if(!username || !password){
+    showError('Username and password required');
+    return;
+  }
+  try{
+    const res = await fetch(endpoint,{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ username, password })
+    });
+    const data = await res.json();
+    if(!res.ok || !data.ok){
+      throw new Error(data.error || 'Request failed');
+    }
+    if(data.token){
+      localStorage.setItem('token', data.token);
+      // legacy basic auth support
+      localStorage.setItem('auth', btoa(`${username}:${password}`));
+      location.href = '/index.html';
+    }
+  }catch(err){
+    showError(err.message);
+  }
+}
+
+function showError(msg){
+  const el = document.getElementById('err');
+  el.textContent = msg;
+  el.classList.remove('hidden');
+}
+
+document.getElementById('btnLogin').addEventListener('click', ()=>handleAuth('/api/login'));
+document.getElementById('btnRegister').addEventListener('click', ()=>handleAuth('/api/register'));
+
+// simple password reset flow using prompts
+ document.getElementById('btnReset').addEventListener('click', async ()=>{
+  const username = prompt('Enter username for reset:');
+  if(!username) return;
+  try{
+    const res = await fetch('/api/request-password-reset',{
+      method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({username})
+    });
+    const data = await res.json();
+    if(!res.ok || !data.ok){ throw new Error(data.error || 'Request failed'); }
+    const token = data.token;
+    const newPass = prompt('Enter new password:');
+    if(!newPass) return;
+    const res2 = await fetch('/api/reset-password',{
+      method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({username, token, password:newPass})
+    });
+    const data2 = await res2.json();
+    if(!res2.ok || !data2.ok){ throw new Error(data2.error || 'Reset failed'); }
+    showError('Password reset. Please login with new password.');
+  }catch(err){
+    showError(err.message);
+  }
+});


### PR DESCRIPTION
## Summary
- add login page for sign-in, registration, and password reset
- store JWT and basic creds in browser and redirect after auth
- update common utilities for token-aware requests and login redirects

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b496d19f3c83238ec8bde3a20be692