### PR TITLE
feat: show login by default and add logout

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -11,9 +11,25 @@ if (_tokenParam) {
 }
 
 // redirect to login if not authenticated
-if (location.pathname !== '/login.html') {
+if (location.pathname !== '/' && location.pathname !== '/login.html') {
   const hasAuth = localStorage.getItem('token') || localStorage.getItem('auth');
   if (!hasAuth) location.href = '/login.html';
+}
+
+// append a logout button to the nav if present
+const navContainer = document.querySelector('header .flex.items-center.gap-2');
+if (navContainer) {
+  const btnLogout = document.createElement('button');
+  btnLogout.id = 'btnLogout';
+  btnLogout.className = 'btn';
+  btnLogout.textContent = 'Logout';
+  btnLogout.addEventListener('click', () => {
+    // clear all locally stored state when logging out to avoid
+    // carrying data between different user sessions
+    localStorage.clear();
+    location.href = '/login.html';
+  });
+  navContainer.appendChild(btnLogout);
 }
 const THEMES = {
   blue:   { accent: '#007AFF', hover: '#005bb5', bg: 'rgba(0,122,255,0.12)', glassBg: 'rgba(0,122,255,0.15)', glassBrd: 'rgba(0,122,255,0.3)' },

--- a/metro2 (copy 1)/crm/public/login.js
+++ b/metro2 (copy 1)/crm/public/login.js
@@ -16,12 +16,15 @@ async function handleAuth(endpoint){
     if(!res.ok || !data.ok){
       throw new Error(data.error || 'Request failed');
     }
-    if(data.token){
-      localStorage.setItem('token', data.token);
-      // legacy basic auth support
-      localStorage.setItem('auth', btoa(`${username}:${password}`));
-      location.href = '/index.html';
-    }
+      if(data.token){
+        // start a fresh local state for the newly authenticated user
+        // so previous user data doesn't leak between accounts
+        localStorage.clear();
+        localStorage.setItem('token', data.token);
+        // legacy basic auth support
+        localStorage.setItem('auth', btoa(`${username}:${password}`));
+        location.href = '/clients';
+      }
   }catch(err){
     showError(err.message);
   }

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -264,8 +264,10 @@ const TEAM_TEMPLATE = (()=>{
     return fs.readFileSync(path.join(PUBLIC_DIR, "team-member-template.html"), "utf-8");
   }catch{return "";}
 })();
-app.use(express.static(PUBLIC_DIR));
-app.get("/", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "index.html")));
+  // Disable default index to avoid auto-serving the app without auth
+  app.use(express.static(PUBLIC_DIR, { index: false }));
+  // Serve login by default so users aren't dropped straight into the app
+  app.get("/", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "login.html")));
 app.get("/dashboard", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "dashboard.html")));
 app.get("/clients", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "index.html")));
 app.get("/leads", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "leads.html")));


### PR DESCRIPTION
## Summary
- Serve login page at root and disable default index serving
- Redirect to clients after authentication and add logout control to navigation
- Protect login redirect logic for root path
- Clear stored state on login and logout so different users don't share data

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b49ca675808323ae3da5bc9edeb619