### PR TITLE
Add HTML credit report parser and PDF utility

### DIFF
--- a/metro2 (copy 1)/crm/creditAuditTool.js
+++ b/metro2 (copy 1)/crm/creditAuditTool.js
@@ -245,7 +245,7 @@ async function detectChromium(){
 }
 
 // CLI usage
-if(fileURLToPath(import.meta.url) === path.resolve(process.argv[1])){
+ if(fileURLToPath(import.meta.url) === path.resolve(process.argv[1] || '')){
   const raw = await fetchCreditReport();
   const normalized = normalizeReport(raw);
   const html = renderHtml(normalized);

--- a/metro2 (copy 1)/crm/creditReportPdf.js
+++ b/metro2 (copy 1)/crm/creditReportPdf.js
@@ -1,0 +1,25 @@
+import { JSDOM } from 'jsdom';
+import { parseCreditReportHTML } from './parser.js';
+import { normalizeReport, renderHtml } from './creditAuditTool.js';
+import { htmlToPdfBuffer } from './pdfUtils.js';
+
+/**
+ * Convert a raw credit report HTML string into a PDF buffer.
+ * The parser extracts tradeline data, normalizes it for the audit tool,
+ * renders a bureau comparison HTML report, and finally converts that to a PDF.
+ *
+ * @param {string} html - raw credit report HTML content
+ * @param {Array|null} selections - optional subset selection for normalizeReport
+ * @param {string} consumerName - name used when rendering the report
+ * @returns {Promise<Buffer>} PDF buffer of the rendered report
+ */
+export async function creditReportHtmlToPdf(html, selections = null, consumerName = 'Consumer') {
+  if (!html || typeof html !== 'string') throw new Error('HTML string required');
+  const dom = new JSDOM(html);
+  const parsed = parseCreditReportHTML(dom.window.document);
+  const normalized = normalizeReport(parsed, selections);
+  const reportHtml = renderHtml(normalized, consumerName);
+  return await htmlToPdfBuffer(reportHtml);
+}
+
+export default creditReportHtmlToPdf;

--- a/metro2 (copy 1)/crm/package-lock.json
+++ b/metro2 (copy 1)/crm/package-lock.json
@@ -12,6 +12,7 @@
         "bcryptjs": "^2.4.3",
         "cheerio": "^1.1.2",
         "express": "^4.21.2",
+        "jsdom": "^24.1.3",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "nanoid": "^5.1.5",
@@ -20,6 +21,25 @@
         "puppeteer": "^24.17.0",
         "stripe": "^18.5.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -40,6 +60,116 @@
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -213,6 +343,12 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/b4a": {
@@ -498,6 +634,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/compress-commons": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.3.tgz",
@@ -641,12 +789,44 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -656,6 +836,12 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/degenerator": {
       "version": "5.0.1",
@@ -668,6 +854,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -863,6 +1058,21 @@
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1075,6 +1285,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -1256,6 +1482,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1265,6 +1506,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/htmlparser2": {
@@ -1448,6 +1701,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1468,6 +1727,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -1856,6 +2155,12 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
+      "integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2111,6 +2416,18 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -2118,6 +2435,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/puppeteer": {
@@ -2191,6 +2517,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2243,6 +2575,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2250,6 +2588,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -2274,6 +2618,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -2554,6 +2910,12 @@
         }
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tar-fs": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
@@ -2591,6 +2953,33 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -2634,12 +3023,31 @@
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "optional": true
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -2663,6 +3071,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -2670,6 +3090,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -2698,6 +3127,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -2742,6 +3184,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/metro2 (copy 1)/crm/package.json
+++ b/metro2 (copy 1)/crm/package.json
@@ -11,14 +11,15 @@
   },
   "dependencies": {
     "archiver": "^6.0.2",
+    "bcryptjs": "^2.4.3",
     "cheerio": "^1.1.2",
     "express": "^4.21.2",
+    "jsdom": "^24.1.3",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
     "nanoid": "^5.1.5",
     "node-fetch": "^3.3.2",
     "nodemailer": "^6.9.12",
-    "bcryptjs": "^2.4.3",
     "puppeteer": "^24.17.0",
     "stripe": "^18.5.0"
   }

--- a/metro2 (copy 1)/crm/parser.js
+++ b/metro2 (copy 1)/crm/parser.js
@@ -1,0 +1,376 @@
+// parser.js
+//
+// Usage (browser):
+//   const { tradelines } = parseCreditReportHTML(document);
+//   // or: parseCreditReportHTML(new DOMParser().parseFromString(html, "text/html"));
+//
+// Usage (Node + jsdom):
+//   import { JSDOM } from "jsdom";
+//   const dom = new JSDOM(html);
+//   const { tradelines } = parseCreditReportHTML(dom.window.document);
+
+function parseCreditReportHTML(doc) {
+  const results = { tradelines: [] };
+
+  // The report can have multiple tradeline blocks. Each block looks like the one you pasted.
+  // We select by the table class used for the comparison area and walk up to a container.
+  const tlTables = Array.from(
+    doc.querySelectorAll("table.rpt_content_table.rpt_content_header.rpt_table4column")
+  );
+
+  // If no tables found, bail early.
+  if (!tlTables.length) return results;
+
+  for (const table of tlTables) {
+    const container = table.closest("td.ng-binding, ng-include, body") || table.parentElement;
+
+    const tl = {
+      meta: { creditor: null },
+      per_bureau: {
+        TransUnion: {},
+        Experian: {},
+        Equifax: {},
+      },
+      // optional: violations can be filled later by your engine
+      violations: [],
+      // include parsed history
+      history: { TransUnion: [], Experian: [], Equifax: [] },
+      history_summary: {}, // quick counts per bureau
+    };
+
+    // ---- A) Creditor (header above the table) ----
+    const creditorEl = container.querySelector("div.sub_header");
+    tl.meta.creditor = text(creditorEl) || "Unknown";
+
+    // ---- B) Bureau order from the header row ----
+    const trs = rows(table);
+    const headerThs = trs.length ? Array.from(trs[0].querySelectorAll("th")).slice(1) : [];
+    const bureauOrder = headerThs.map((th) => normalizeBureau(text(th))).filter(Boolean);
+
+    // Map "column index" -> bureau key
+    // Example: ["TransUnion","Experian","Equifax"]
+    // We will use this to place each <td.info> into tl.per_bureau[bureau]
+    // starting from col 0 = first bureau after label.
+    // Note: if some bureaus are hidden (ng-show=false), header text should still reflect order.
+    // Fallback to ALL if header missing (conservative).
+    const ALL = ["TransUnion", "Experian", "Equifax"];
+    const bureaus = bureauOrder.length ? bureauOrder : ALL;
+
+    // ---- C) Row label → field(s) rules ----
+    // Each key is the *visual* left label from the HTML.
+    // The value declares which field(s) to populate and how to render (single or combined).
+    const rowRules = [
+      // exact label, fields (single)
+      rule("Account #", ["account_number"]),
+      rule("Account Type", ["account_type"]),
+      rule("Account Type - Detail", ["account_type_detail"]),
+      rule("Bureau Code", ["bureau_code"]),
+      rule("Account Status", ["account_status"]),
+      rule("Payment Status", ["payment_status"]),
+      rule("Monthly Payment", ["monthly_payment"]),
+      rule("Balance", ["balance"]),
+      rule("Credit Limit", ["credit_limit"]),
+      rule("High Credit", ["high_credit"]),
+      rule("Past Due", ["past_due"]),
+      rule("Date Opened", ["date_opened"]),
+      rule("Last Reported", ["last_reported"]),
+      rule("Date Last Payment", ["date_last_payment"]),
+      rule("Date Last Active", ["date_last_active"]),
+      rule("No. of Months (terms)", ["months_terms"]),
+
+      // combined rows present in some templates
+      rule("Account Status / Payment Status", ["account_status", "payment_status"], "combined"),
+      rule("Balance / Past Due", ["balance", "past_due"], "combined"),
+      rule("Credit Limit / High Credit", ["credit_limit", "high_credit"], "combined"),
+      rule("Dates", ["date_opened", "last_reported", "date_last_payment"], "combined"),
+
+      // comments (special handling)
+      rule("Comments", ["comments"], "comments"),
+    ];
+
+    // ---- D) Walk data rows ----
+    for (let i = 1; i < trs.length; i++) {
+      const tr = trs[i];
+      const label = text(tr.querySelector("td.label")).replace(/:\s*$/, "");
+
+      const ruleDef = matchRule(rowRules, label);
+      if (!ruleDef) continue;
+
+      const infoTds = Array.from(tr.querySelectorAll("td.info"));
+      // normalize over bureau count; if fewer tds, pad with nulls
+      while (infoTds.length < bureaus.length) infoTds.push(null);
+
+      infoTds.forEach((td, idx) => {
+        const bureau = bureaus[idx];
+        if (!bureau) return;
+
+        // prepare pb record
+        const pb = tl.per_bureau[bureau] || (tl.per_bureau[bureau] = {});
+        if (!td) return;
+
+        if (ruleDef.kind === "comments") {
+          const remarks = extractComments(td);
+          if (remarks.length) {
+            // store array and also a joined string for convenience
+            pb.comments = remarks;
+            pb.comments_raw = remarks.slice(); // original lines
+          } else if (!pb.comments) {
+            pb.comments = []; // keep array semantics
+          }
+          return;
+        }
+
+        if (ruleDef.kind === "combined") {
+          // Combined cell value holds multiple parts separated by "/","|" etc. But the HTML we parse
+          // is already split per the provided rows. For safety, we still split by separators if present.
+          const val = cellText(td);
+
+          // Try to split into as many parts as fields length.
+          const parts = smartSplit(val, ruleDef.fields.length);
+          ruleDef.fields.forEach((field, j) => {
+            const raw = (parts[j] || "").trim();
+            setField(pb, field, raw);
+          });
+        } else {
+          // single-field row
+          const raw = cellText(td);
+          setField(pb, ruleDef.fields[0], raw);
+        }
+      });
+    }
+
+    // ---- E) Payment history table ----
+    const histTable = container.querySelector("table.addr_hsrty");
+    if (histTable) {
+      const hist = parseHistoryTable(histTable);
+      tl.history = hist.byBureau;
+      tl.history_summary = hist.summary;
+    }
+
+    // Push this tradeline
+    results.tradelines.push(tl);
+  }
+
+  return results;
+
+  // ---------- helpers ----------
+
+  function rows(table) {
+    const bodyRows = table.querySelectorAll("tbody > tr");
+    return bodyRows.length ? Array.from(bodyRows) : Array.from(table.querySelectorAll("tr"));
+  }
+
+  function text(el) {
+    return (el && (el.textContent || "").replace(/\s+/g, " ").trim()) || "";
+  }
+
+  function cellText(td) {
+    if (!td) return "";
+    // Comments can contain multiple divs; for non-comments row,
+    // we still gather all strings to be resilient.
+    const parts = [];
+    td.querySelectorAll("*").forEach((n) => {
+      if (n.childElementCount === 0) {
+        const s = (n.textContent || "").trim();
+        if (s) parts.push(s);
+      }
+    });
+    if (!parts.length) {
+      const base = (td.textContent || "").trim();
+      if (base) parts.push(base);
+    }
+    const joined = parts.join(" ").replace(/\s+/g, " ").trim();
+    return joined;
+  }
+
+  function normalizeBureau(s) {
+    const t = (s || "").toLowerCase();
+    if (t.includes("transunion")) return "TransUnion";
+    if (t.includes("experian")) return "Experian";
+    if (t.includes("equifax")) return "Equifax";
+    return null;
+  }
+
+  function rule(label, fields, kind = "single") {
+    return { label, fields, kind };
+  }
+
+  function matchRule(rules, label) {
+    // exact first
+    let r = rules.find((x) => x.label === label);
+    if (r) return r;
+
+    // loose fallbacks (in case the source uses minor variants/spaces)
+    const L = label.toLowerCase().replace(/\s+/g, " ").trim();
+    return rules.find((x) => x.label.toLowerCase().replace(/\s+/g, " ").trim() === L) || null;
+  }
+
+  function extractComments(td) {
+    // multiple remarks are in <div> children; fallback to td text if empty
+    const divs = Array.from(td.querySelectorAll("div"));
+    const lines = divs.map((d) => text(d)).filter(Boolean);
+    if (lines.length) return uniq(lines);
+
+    const raw = cellText(td);
+    if (!raw) return [];
+    // If combined with \u00a0 we split on two+ spaces or " • " etc.
+    return uniq(
+      raw
+        .split(/\s{2,}|•|\u00A0{2,}/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+    );
+  }
+
+  function uniq(arr) {
+    return Array.from(new Set(arr));
+  }
+
+  function setField(pb, field, raw) {
+    const normalized = normalizeFieldValue(field, raw);
+    pb[`${field}_raw`] = raw || "";
+    pb[field] = normalized;
+  }
+
+  function normalizeFieldValue(field, raw) {
+    const v = (raw || "").trim();
+    if (!v) return "";
+
+    // money fields
+    if (["balance", "credit_limit", "high_credit", "past_due", "monthly_payment"].includes(field)) {
+      const num = parseMoneyToNumber(v);
+      // keep formatted like "$1,234.00" if we could parse; else keep as-is
+      return isFinite(num) ? formatMoney(num) : v;
+    }
+
+    // dates -> keep "MM/DD/YYYY" if already in that form; otherwise try to coerce
+    if (
+      ["date_opened", "last_reported", "date_last_payment", "date_last_active"].includes(field)
+    ) {
+      const d = coerceDateMDY(v);
+      return d || v;
+    }
+
+    // months_terms -> numeric if possible
+    if (field === "months_terms") {
+      const n = parseInt(v.replace(/[^\d-]/g, ""), 10);
+      return Number.isFinite(n) ? String(n) : v;
+    }
+
+    // Everything else: return as-is
+    return v;
+  }
+
+  function parseMoneyToNumber(s) {
+    // accepts "$202.00", "202", "0", "$0.00"
+    const m = (s || "").replace(/[^0-9.-]/g, "");
+    const n = parseFloat(m);
+    return Number.isFinite(n) ? n : NaN;
+  }
+
+  function formatMoney(n) {
+    // always 2 decimals, US style with commas
+    try {
+      return n.toLocaleString(undefined, { style: "currency", currency: "USD", minimumFractionDigits: 2 });
+    } catch {
+      // simple fallback
+      const fixed = n.toFixed(2);
+      return `$${fixed}`;
+    }
+  }
+
+  function coerceDateMDY(s) {
+    // if already looks like MM/DD/YYYY, return it
+    if (/^\d{2}\/\d{2}\/\d{4}$/.test(s)) return s;
+
+    // try to parse and output as MM/DD/YYYY
+    const d = new Date(s);
+    if (isNaN(+d)) return "";
+
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    const yyyy = d.getFullYear();
+    return `${mm}/${dd}/${yyyy}`;
+    // (If you need to keep original, it's in *_raw)
+  }
+
+  // smart split for combined cells like "X / Y" or "Opened: A | Last Reported: B | Last Payment: C"
+  function smartSplit(val, expectedParts) {
+    if (!val) return Array(expectedParts).fill("");
+
+    // Try pipe with labels first
+    // "Opened: 05/01/2025 | Last Reported: 08/19/2025 | Last Payment: 07/03/2025"
+    let byPipe = val.split("|").map((s) => s.trim());
+    if (byPipe.length >= expectedParts) {
+      return byPipe.map((part) => part.replace(/^[A-Za-z ]+:\s*/, ""));
+    }
+
+    // Then try slash
+    let bySlash = val.split("/").map((s) => s.trim());
+    if (bySlash.length >= expectedParts) return bySlash;
+
+    // Fallback: return the whole value in the first field
+    const arr = Array(expectedParts).fill("");
+    arr[0] = val.trim();
+    return arr;
+  }
+
+  // ---- Payment history parsing ----
+  function parseHistoryTable(hTable) {
+    const trs = rows(hTable);
+    if (trs.length < 2) return { byBureau: {}, summary: {} };
+
+    // Months row = first row (labels)
+    const months = Array.from(trs[0].querySelectorAll("td.info")).map((td) => {
+      const lg = td.querySelector("span.lg-view");
+      return text(lg) || text(td);
+    });
+
+    // Years row = second row (two-digit years)
+    const years = Array.from(trs[1].querySelectorAll("td.info")).map((td) => text(td));
+    const labels = months.map((m, i) => `${m} ’${years[i] || ""}`.trim());
+
+    const byBureau = {
+      TransUnion: [],
+      Experian: [],
+      Equifax: [],
+    };
+    const summary = {};
+
+    // Subsequent rows: per-bureau statuses
+    for (let i = 2; i < trs.length; i++) {
+      const tr = trs[i];
+      const labelTd = tr.querySelector("td.label");
+      if (!labelTd) continue;
+      const bureau = normalizeBureau(text(labelTd));
+      if (!bureau) continue;
+
+      const cells = Array.from(tr.querySelectorAll("td.info"));
+      const statuses = cells.map((td, idx) => {
+        const cls = (td.getAttribute("class") || "").split(/\s+/).find((c) => c.startsWith("hstry-")) || null;
+        const txt = text(td) || null;
+        return {
+          col: labels[idx] || `col_${idx}`,
+          status_class: cls,   // e.g. hstry-ok, hstry-unknown
+          status_text: txt,    // often "OK" or ""
+        };
+      });
+
+      byBureau[bureau] = statuses;
+
+      // quick counts
+      const counts = {
+        ok: statuses.filter((s) => s.status_class === "hstry-ok" || s.status_text === "OK").length,
+        unknown: statuses.filter((s) => s.status_class === "hstry-unknown").length,
+        late: statuses.filter((s) => /hstry-(late|derog|neg)/.test(s.status_class || "")).length,
+        total: statuses.length,
+      };
+      summary[bureau] = counts;
+    }
+
+    return { byBureau, summary };
+  }
+}
+
+export { parseCreditReportHTML };
+


### PR DESCRIPTION
## Summary
- add utility to convert parsed credit report HTML into PDF buffers
- update parser usage examples to ESM and harden credit audit CLI guard
- include jsdom dependency for DOM parsing

## Testing
- `node -e "import('./metro2 (copy 1)/crm/parser.js').then(m=>console.log('parser keys', Object.keys(m))).catch(e=>console.error(e))"`
- `node -e "import('./metro2 (copy 1)/crm/creditReportPdf.js').then(m=>console.log('pdf keys', Object.keys(m))).catch(e=>console.error(e))"`
- `node - <<'NODE'\nimport { creditReportHtmlToPdf } from './metro2 (copy 1)/crm/creditReportPdf.js';\nconst html = `<html><body><table class=\"rpt_content_table rpt_content_header rpt_table4column\"><tbody><tr><th></th><th>TransUnion</th><th>Experian</th><th>Equifax</th></tr><tr><td class=\"label\">Account #</td><td class=\"info\">123</td><td class=\"info\">123</td><td class=\"info\">123</td></tr></tbody></table></body></html>`;\ncreditReportHtmlToPdf(html).then(buf => console.log('pdf bytes', buf.length)).catch(err => console.error('error', err.message));\nNODE`
- `cd "metro2 (copy 1)/crm" && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b571e3aa508323aa48625d664d190f