### PR TITLE
refactor: centralize chromium detection and launch

### DIFF
--- a/metro2 (copy 1)/crm/creditAuditTool.js
+++ b/metro2 (copy 1)/crm/creditAuditTool.js
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import puppeteer from 'puppeteer';
+import { detectChromium, launchBrowser } from './pdfUtils.js';
 
 // ----- Data Source -----
 // Simulate pulling credit-report JSON from internal API/scrape
@@ -215,8 +215,7 @@ export async function savePdf(html){
   try{
     const execPath = await detectChromium();
     console.log("Launching Chromium for PDF generation", execPath || "(default)");
-    browser = await puppeteer.launch({
-      headless:true,
+    browser = await launchBrowser({
       args:["--no-sandbox","--disable-setuid-sandbox","--disable-dev-shm-usage"],
       executablePath: execPath || undefined
     });
@@ -234,14 +233,6 @@ export async function savePdf(html){
   } finally {
     if (browser) await browser.close();
   }
-}
-
-async function detectChromium(){
-  if(process.env.PUPPETEER_EXECUTABLE_PATH) return process.env.PUPPETEER_EXECUTABLE_PATH;
-  for(const p of ['/usr/bin/chromium','/usr/bin/chromium-browser','/snap/bin/chromium','/usr/bin/google-chrome','/usr/bin/google-chrome-stable']){
-    try{ await fs.access(p); return p; }catch{}
-  }
-  return null;
 }
 
 // CLI usage

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -6,12 +6,11 @@ import { fileURLToPath } from "url";
 import { createRequire } from "module";
 import multer from "multer";
 import { nanoid } from "nanoid";
-import { spawn, spawnSync } from "child_process";
-import { htmlToPdfBuffer } from "./pdfUtils.js";
+import { spawn } from "child_process";
+import { htmlToPdfBuffer, launchBrowser } from "./pdfUtils.js";
 import crypto from "crypto";
 import os from "os";
 import archiver from "archiver";
-import puppeteer from "puppeteer";
 import nodeFetch from "node-fetch";
 import * as cheerio from "cheerio";
 import jwt from "jsonwebtoken";
@@ -91,34 +90,6 @@ function loadSettings(){
 
 function saveSettings(data){ writeJson(SETTINGS_PATH, data); }
 
-async function detectChromium(){
-  if(process.env.PUPPETEER_EXECUTABLE_PATH) return process.env.PUPPETEER_EXECUTABLE_PATH;
-  const candidates = [
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser',
-    '/snap/bin/chromium',
-    '/usr/bin/google-chrome',
-    '/usr/bin/google-chrome-stable'
-  ];
-  for(const p of candidates){
-    try{
-      await fs.promises.access(p, fs.constants.X_OK);
-      const check = spawnSync(p, ['--version'], { stdio:'ignore' });
-      if(check.status === 0) return p;
-    }catch{}
-  }
-  return null;
-}
-
-async function launchBrowser(){
-  const execPath = await detectChromium();
-  const opts = {
-    headless:true,
-    args:['--no-sandbox','--disable-setuid-sandbox','--disable-dev-shm-usage','--disable-gpu','--no-zygote','--single-process']
-  };
-  if(execPath) opts.executablePath = execPath;
-  return puppeteer.launch(opts);
-}
 
 const require = createRequire(import.meta.url);
 let nodemailer = null;


### PR DESCRIPTION
## Summary
- extract Chromium detection to shared pdfUtils with new launchBrowser helper
- replace duplicate browser setup in server and creditAuditTool with shared utility

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5b14e93d083238834674893f6c8d3