### PR TITLE
Skip empty tradeline cards

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -544,6 +544,18 @@ function renderTradelines(tradelines){
   const visible = [];
   tradelines.forEach((tl, idx)=>{
     if (hiddenTradelines.has(idx)) return;
+
+    // Skip tradelines with no bureau data. Some parsed reports include
+    // placeholder entries that contain an empty `per_bureau` object and no
+    // useful information, which resulted in blank cards being rendered in
+    // the UI. These cards only showed a generic violation like "Missing Date
+    // of First Delinquency" and provided no actionable data. By filtering out
+    // these empty entries up front, only meaningful tradelines are displayed
+    // to the user.
+    const hasBureauData = Object.values(tl.per_bureau || {})
+      .some(b => b && Object.keys(b).length);
+    if (!hasBureauData) return;
+
     const tags = deriveTags(tl);
     if (!passesFilter(tags)) return;
     visible.push({ tl, idx, tags });


### PR DESCRIPTION
## Summary
- Ignore tradelines that lack bureau data so blank cards aren't rendered

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5b5c5c7ec8323a5dcf6ae60b98aa5