### PR TITLE
Fix tradeline container selection for history parsing

### DIFF
--- a/metro2 (copy 1)/crm/parser.js
+++ b/metro2 (copy 1)/crm/parser.js
@@ -20,7 +20,11 @@ function parseCreditReportHTML(doc) {
   if (!tlTables.length) return results;
 
   for (const table of tlTables) {
-    const container = table.closest("td.ng-binding, ng-include, body") || table.parentElement;
+    let container = table.closest("td.ng-binding");
+    if (!container) {
+      const ngInclude = table.closest("ng-include");
+      container = (ngInclude && ngInclude.parentElement) || table.parentElement;
+    }
 
     const tl = {
       meta: { creditor: null },


### PR DESCRIPTION
## Summary
- ensure parser walks out of `ng-include` to capture associated history table

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b70e12c7608323a2837140a9d4eed6