### PR TITLE
Filter tradelines lacking account numbers

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -552,7 +552,7 @@ function renderTradelines(tradelines){
     const pb = tl.per_bureau || {};
     const hasBureauData = ["TransUnion","Experian","Equifax"]
       .some(b => Object.keys(pb[b] || {}).length);
-    const hasAcct = Object.keys(tl.meta?.account_numbers || {}).length > 0;
+    const hasAcct = Object.values(tl.meta?.account_numbers || {}).some(v => v);
     const hasVios = (tl.violations || []).length > 0;
     if (!hasBureauData && !hasAcct && !hasVios) return;
 


### PR DESCRIPTION
## Summary
- ignore tradelines whose account numbers are all empty strings

## Testing
- `npm test` *(fails: Missing script 'test')*
- `node -e` snippet to ensure tradelines with empty account numbers are skipped

------
https://chatgpt.com/codex/tasks/task_e_68bad6e77f6c832384833afb476f4b0d