### PR TITLE
feat: expand hotkey modes

### DIFF
--- a/metro2 (copy 1)/crm/public/hotkeys.js
+++ b/metro2 (copy 1)/crm/public/hotkeys.js
@@ -14,4 +14,7 @@ document.addEventListener('keydown', (e) => {
   if (k === 'e') { e.preventDefault(); click('btnEditConsumer'); }
   if (k === 'g') { e.preventDefault(); click('btnGenerate'); }
   if (k === 'r') { e.preventDefault(); document.querySelector('.tl-remove')?.click(); }
+  if (k === 'd') { e.preventDefault(); window.__crm_helpers?.setMode?.('breach'); }
+  if (k === 's') { e.preventDefault(); window.__crm_helpers?.setMode?.('assault'); }
+  if (k === 'i') { e.preventDefault(); window.__crm_helpers?.setMode?.('identity'); }
 });


### PR DESCRIPTION
## Summary
- add `d`, `s`, and `i` hotkeys to toggle breach, assault, and identity modes
- ensure hotkeys respect typing guard and prevent default behavior

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68badd850d4483239c6be94d80e863de