### PR TITLE
Add analytics tracking and CTA A/B testing

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.js
+++ b/metro2 (copy 1)/crm/public/billing.js
@@ -32,6 +32,7 @@ async function loadInvoices(){
     if(btn){
       btn.addEventListener('click', async ()=>{
         await api(`/api/invoices/${inv.id}`, { method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify({paid:true}) });
+        trackEvent('purchase', { amount: inv.amount });
         loadInvoices();
       });
     }

--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -17,6 +17,33 @@ function formatCurrency(val) {
   return isNaN(num) ? '—' : `$${num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
+// Lightweight analytics helper exposed globally
+function trackEvent(name, props = {}) {
+  if (window.plausible) {
+    window.plausible(name, { props });
+  } else {
+    console.debug('trackEvent', name, props);
+  }
+}
+window.trackEvent = trackEvent;
+
+document.addEventListener('DOMContentLoaded', () => {
+  trackEvent('page_view', { path: location.pathname });
+  initAbTest();
+});
+
+function initAbTest() {
+  const btn = document.getElementById('btnInvite');
+  if (!btn) return;
+  let variant = localStorage.getItem('cta_variant');
+  if (!variant) {
+    variant = Math.random() < 0.5 ? 'invite_plus' : 'add_team_member';
+    localStorage.setItem('cta_variant', variant);
+  }
+  btn.textContent = variant === 'invite_plus' ? 'Invite +' : 'Add Team Member';
+  trackEvent('ab_exposure', { experiment: 'cta_copy', variant });
+}
+
 // Allow ?auth=BASE64 or ?token=JWT links to set local auth state
 // (runs early so tokens in query strings are captured immediately)
 //

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="theme-color" content="#AF52DE" />
   <script src="https://cdn.tailwindcss.com"></script>
+  <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
   <link rel="stylesheet" href="/style.css" />
   <style>
     :root{

--- a/metro2 (copy 1)/crm/public/leads.js
+++ b/metro2 (copy 1)/crm/public/leads.js
@@ -73,6 +73,7 @@ document.getElementById('saveLead').addEventListener('click', async()=>{
     headers:{'Content-Type':'application/json'},
     body: JSON.stringify(lead)
   });
+  trackEvent('lead_submission', { source: lead.source || 'unknown' });
   document.getElementById('leadName').value='';
   document.getElementById('leadEmail').value='';
   document.getElementById('leadPhone').value='';

--- a/metro2 (copy 1)/crm/public/letters.js
+++ b/metro2 (copy 1)/crm/public/letters.js
@@ -120,6 +120,7 @@ async function printLetter(L){
   try {
     ifr.contentWindow.focus();
     ifr.contentWindow.print();
+    trackEvent('letter_generated', { jobId: JOB_ID, index: L.index });
   } finally {
     setTimeout(()=> document.body.removeChild(ifr), 1000);
   }
@@ -153,6 +154,7 @@ $("#btnDownloadAll").addEventListener("click", async ()=>{
     a.click();
     a.remove();
     setTimeout(()=> URL.revokeObjectURL(url), 1000);
+    trackEvent('letters_download_all', { jobId: JOB_ID, count: LETTERS.length });
   } catch(e){ showErr(e.message || String(e)); }
   finally {
     btn.disabled = false;


### PR DESCRIPTION
## Summary
- integrate Plausible analytics and global `trackEvent` helper
- record page views, leads, purchases, letters, and CTA variant exposure

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68badd08d4e48323af81d134fdbf3f3b