### PR TITLE
Ensure card mode retains bureau selections

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -1235,7 +1235,20 @@ function toggleCardMode(card, modeKey){
 
   // remove other mode classes before toggling desired one
   MODES.forEach(m => { if (m.cardClass !== info.cardClass) card.classList.remove(m.cardClass); });
-  card.classList.toggle(info.cardClass);
+  const added = card.classList.toggle(info.cardClass);
+
+  if (added) {
+    const bureaus = Array.from(card.querySelectorAll('input.bureau'));
+    if (bureaus.length) {
+      if (!bureaus.some(cb => cb.checked)) {
+        // default to first available bureau
+        bureaus[0].checked = true;
+      }
+    } else {
+      console.warn('No bureaus available to select for card');
+    }
+  }
+
   updateCardBadges(card);
   updateSelectionStateFromCard(card);
 }


### PR DESCRIPTION
## Summary
- Auto-select the first bureau checkbox when toggling a card mode
- Warn if no bureau checkboxes exist for the card
- Refresh selection state after applying mode changes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68badd91a4b083238a354ae75f6eff08