### PR TITLE
Expose hotkey mode switcher and track usage

### DIFF
--- a/metro2 (copy 1)/crm/public/hotkeys.js
+++ b/metro2 (copy 1)/crm/public/hotkeys.js
@@ -14,7 +14,7 @@ document.addEventListener('keydown', (e) => {
   if (k === 'e') { e.preventDefault(); click('btnEditConsumer'); }
   if (k === 'g') { e.preventDefault(); click('btnGenerate'); }
   if (k === 'r') { e.preventDefault(); document.querySelector('.tl-remove')?.click(); }
-  if (k === 'd') { e.preventDefault(); window.__crm_helpers?.setMode?.('breach'); }
-  if (k === 's') { e.preventDefault(); window.__crm_helpers?.setMode?.('assault'); }
-  if (k === 'i') { e.preventDefault(); window.__crm_helpers?.setMode?.('identity'); }
+  if (k === 'd') { e.preventDefault(); trackEvent?.('hotkey_mode', { key: 'd', mode: 'breach' }); window.__crm_helpers?.setMode?.('breach'); }
+  if (k === 's') { e.preventDefault(); trackEvent?.('hotkey_mode', { key: 's', mode: 'assault' }); window.__crm_helpers?.setMode?.('assault'); }
+  if (k === 'i') { e.preventDefault(); trackEvent?.('hotkey_mode', { key: 'i', mode: 'identity' }); window.__crm_helpers?.setMode?.('identity'); }
 });

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -1308,7 +1308,8 @@ window.__crm_helpers = {
   attachCardHandlers,
   focusCardRef: ()=> lastFocusedCard,
   toggleWholeCardSelection,
-  clearMode: ()=>{ activeMode=null; updateModeButtons(); }
+  clearMode: ()=>{ activeMode=null; updateModeButtons(); },
+  setMode,
 };
 
 const tlList = $("#tlList");


### PR DESCRIPTION
## Summary
- export `setMode` so hotkeys can toggle special mode badges on tradeline cards
- log an analytic event whenever `i`, `d`, or `s` hotkeys are used

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baf083a09c8323a13c9e72b800668b