### PR TITLE
fix(parser): handle 'Date of Last Payment' label variant

### DIFF
--- a/metro2 (copy 1)/crm/parser.js
+++ b/metro2 (copy 1)/crm/parser.js
@@ -80,7 +80,7 @@ function parseCreditReportHTML(doc) {
       rule("Past Due", ["past_due"]),
       rule("Date Opened", ["date_opened"]),
       rule("Last Reported", ["last_reported"]),
-      rule("Date Last Payment", ["date_last_payment"]),
+      rule(/Date(?: of)? Last Payment/i, ["date_last_payment"]),
       rule("Date Last Active", ["date_last_active"]),
       rule("No. of Months (terms)", ["months_terms"]),
 
@@ -234,13 +234,23 @@ function parseCreditReportHTML(doc) {
   }
 
   function matchRule(rules, label) {
-    // exact first
-    let r = rules.find((x) => x.label === label);
+    // exact string match first
+    let r = rules.find((x) => typeof x.label === "string" && x.label === label);
     if (r) return r;
 
-    // loose fallbacks (in case the source uses minor variants/spaces)
+    // regex match
+    r = rules.find((x) => x.label instanceof RegExp && x.label.test(label));
+    if (r) return r;
+
+    // loose fallbacks for string labels (trim spaces, case-insensitive)
     const L = label.toLowerCase().replace(/\s+/g, " ").trim();
-    return rules.find((x) => x.label.toLowerCase().replace(/\s+/g, " ").trim() === L) || null;
+    return (
+      rules.find(
+        (x) =>
+          typeof x.label === "string" &&
+          x.label.toLowerCase().replace(/\s+/g, " ").trim() === L
+      ) || null
+    );
   }
 
   function extractComments(td) {

--- a/metro2 (copy 1)/crm/tests/parserDateLastPayment.test.js
+++ b/metro2 (copy 1)/crm/tests/parserDateLastPayment.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { parseCreditReportHTML } from '../parser.js';
+
+test('parses Date of Last Payment label', () => {
+  const html = `
+    <table class="rpt_content_table rpt_content_header rpt_table4column">
+      <tbody>
+        <tr><th></th><th>TransUnion</th></tr>
+        <tr>
+          <td class="label">Date of Last Payment:</td>
+          <td class="info">01/02/2023</td>
+        </tr>
+      </tbody>
+    </table>
+  `;
+  const dom = new JSDOM(html);
+  const { tradelines } = parseCreditReportHTML(dom.window.document);
+  assert.equal(tradelines[0].per_bureau.TransUnion.date_last_payment, '01/02/2023');
+});


### PR DESCRIPTION
## Summary
- expand parser rule to match "Date of Last Payment" label variant
- add regression test covering new label parsing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baefd0f0e48323a9d5787f39a0e5b9