### PR TITLE
fix: avoid duplicate card badge

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -1295,14 +1295,6 @@ function updateCardBadges(card){
       wrap.appendChild(s);
     }
   });
-
-  const mode = MODES.find(m => card.classList.contains(m.cardClass));
-  if (mode){
-    const s = document.createElement("span");
-    s.className = `chip chip-mini chip-${mode.key}`;
-    s.textContent = mode.chip;
-    wrap.appendChild(s);
-  }
 }
 window.__crm_helpers = {
   attachCardHandlers,


### PR DESCRIPTION
## Summary
- prevent double rendering of special mode chips in `updateCardBadges`

## Testing
- `npm test --prefix 'metro2 (copy 1)/crm'`


------
https://chatgpt.com/codex/tasks/task_e_68baf46514dc83238de5a7b0fd87fbe7