### PR TITLE
refactor: collapse hotkey mode handlers

### DIFF
--- a/metro2 (copy 1)/crm/public/hotkeys.js
+++ b/metro2 (copy 1)/crm/public/hotkeys.js
@@ -14,7 +14,7 @@ document.addEventListener('keydown', (e) => {
   if (k === 'e') { e.preventDefault(); click('btnEditConsumer'); }
   if (k === 'g') { e.preventDefault(); click('btnGenerate'); }
   if (k === 'r') { e.preventDefault(); document.querySelector('.tl-remove')?.click(); }
-  if (k === 'd') { e.preventDefault(); trackEvent?.('hotkey_mode', { key: 'd', mode: 'breach' }); window.__crm_helpers?.setMode?.('breach'); }
-  if (k === 's') { e.preventDefault(); trackEvent?.('hotkey_mode', { key: 's', mode: 'assault' }); window.__crm_helpers?.setMode?.('assault'); }
-  if (k === 'i') { e.preventDefault(); trackEvent?.('hotkey_mode', { key: 'i', mode: 'identity' }); window.__crm_helpers?.setMode?.('identity'); }
+  if (k === 'd') window.__crm_helpers?.setMode?.('breach');
+  if (k === 's') window.__crm_helpers?.setMode?.('assault');
+  if (k === 'i') window.__crm_helpers?.setMode?.('identity');
 });


### PR DESCRIPTION
## Summary
- simplify breach, assault, and identity hotkeys to a single setMode call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baf4614ed48323a27c76e08429e99b