### PR TITLE
feat: load Metro 2 violations with severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# CRM Metro-2
+
+Minimal CRM for generating Metro-2 dispute letters.
+
+## Prerequisites
+- Node.js 18+
+- Python 3 (for postinstall)
+
+## Setup
+```bash
+cd "metro2 (copy 1)/crm"
+npm install
+```
+
+## Environment
+- `PORT` (optional, defaults to 3000)
+
+## Run
+```bash
+npm start
+```
+
+## Test
+```bash
+npm test
+```
+
+## Deploy
+Container-friendly; run `npm start` in production environment.

--- a/metro2 (copy 1)/crm/metro2Violations.json
+++ b/metro2 (copy 1)/crm/metro2Violations.json
@@ -1,0 +1,20 @@
+{
+  "PST_DUE_CURR": {
+    "violation": "Past-due reported while account marked 'current'",
+    "fcraSection": "605(a)",
+    "severity": 5,
+    "snippets": {
+      "en": "Per FCRA §605(a), reporting a past-due amount on an account shown as current is inaccurate and must be corrected.",
+      "es": "Según la FCRA §605(a), reportar un monto vencido en una cuenta marcada como al día es inexacto y debe corregirse."
+    }
+  },
+  "LATE_NO_PAST_DUE": {
+    "violation": "Late status but no past-due balance",
+    "fcraSection": "607(b)",
+    "severity": 4,
+    "snippets": {
+      "en": "Per FCRA §607(b), data must reflect maximum possible accuracy. A late status with no past-due balance fails this standard.",
+      "es": "Según la FCRA §607(b), los datos deben reflejar la máxima exactitud posible. Un estado de atraso sin saldo vencido no cumple con este estándar."
+    }
+  }
+}

--- a/metro2 (copy 1)/crm/tests/violationMapping.test.js
+++ b/metro2 (copy 1)/crm/tests/violationMapping.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { filterViolationsBySeverity } from '../letterEngine.js';
+
+test('filterViolationsBySeverity prioritizes high severity and loads snippets', () => {
+  const input = [
+    { code: 'LATE_NO_PAST_DUE' },
+    { code: 'PST_DUE_CURR' }
+  ];
+  const filtered = filterViolationsBySeverity(input, 4, 'en');
+  assert.equal(filtered.length, 2);
+  assert.equal(filtered[0].code, 'PST_DUE_CURR');
+  const spanish = filterViolationsBySeverity([{ code: 'PST_DUE_CURR' }], 1, 'es');
+  assert.ok(spanish[0].detail.includes('Según la FCRA'));
+});


### PR DESCRIPTION
## Summary
- load Metro 2 violation metadata from `metro2Violations.json`
- map violation codes to FCRA sections and inject bilingual snippets with severity tags
- expose severity filter helper and unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bafb8b3e44832392887f1089d69eb8