### PR TITLE
docs: add Metro-2 violation cheat sheet

### DIFF
--- a/metro2 (copy 1)/crm/README.md
+++ b/metro2 (copy 1)/crm/README.md
@@ -1,5 +1,43 @@
 # Metro2 CRM
 
+## Metro-2 Violation Cheat Sheet
+
+Use `metro2Violations.json` as a quick reference for common Metro-2 and FCRA conflicts. The file drives both the audit engine that flags report issues and the letter generator that cites the correct statutes.
+
+### Sample entry
+
+```json
+{
+  "code": "STATUS_PAST_DUE",
+  "title": "Past-due balance reported as current",
+  "detail": "Account shows 'Pays as agreed' but Past Due > $0",
+  "severity": "high",
+  "fcra": "15 U.S.C. §1681s-2(a)(1)(A)"
+}
+```
+
+### Extending the dataset
+
+1. Append new objects to `metro2Violations.json` with `code`, `title`, `detail`, `severity`, and `fcra` fields.
+2. Keep descriptions factual and align each rule with FCRA accuracy requirements—avoid implying guaranteed deletions or timeframes.
+3. Run `npm test` to validate changes and maintain compliance.
+
+## Quick Start
+
+1. **Run audit** – parse `data/report.json` and create a shareable report.
+
+   ```bash
+   npm run audit
+   ```
+
+2. **View high-severity violations** – open the generated PDF under `public/reports/` and focus on entries tagged `"severity": "high"`.
+
+3. **Generate letters referencing FCRA sections** – start the server and use the dashboard's **Generate Letters** action.
+
+   ```bash
+   npm start
+   ```
+
 ## Tests
 
 Install dependencies and run the test suite:


### PR DESCRIPTION
## Summary
- add Metro-2 Violation Cheat Sheet to README with sample entry and dataset guidance
- document quick audit workflow from audit to letter generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bafb8eeaac8323ba4674bfb039e6b8