### PR TITLE
feat: enrich tradeline data for letters

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -1,6 +1,7 @@
 // letterEngine.js
 
 import { PLAYBOOKS } from './playbook.js';
+import { enrichTradeline } from './pullTradelineData.js';
 import fs from 'fs';
 
 // Load Metro 2 violation definitions
@@ -810,6 +811,9 @@ function generateLetters({ report, selections, consumer, requestType = "correct"
         ];
       }
     }
+
+    // Ensure each tradeline has complete data before letter creation
+    enrichTradeline(tl);
 
     const isSpecial = SPECIAL_ONE_BUREAU.has(sel.specialMode);
     const comparisonBureaus = isSpecial ? [sel.bureaus[0]] : ALL_BUREAUS;

--- a/metro2 (copy 1)/crm/pullTradelineData.js
+++ b/metro2 (copy 1)/crm/pullTradelineData.js
@@ -1,0 +1,57 @@
+import { JSDOM } from 'jsdom';
+import parseCreditReportHTML from './parser.js';
+
+const ALL_BUREAUS = ['TransUnion', 'Experian', 'Equifax'];
+const ENRICH_FIELDS = [
+  'account_number',
+  'account_type',
+  'account_status',
+  'payment_status',
+  'monthly_payment',
+  'balance',
+  'credit_limit',
+  'high_credit',
+  'past_due',
+  'date_opened',
+  'last_reported',
+  'date_last_payment',
+  'comments'
+];
+
+function enrichTradeline(tl, override = {}) {
+  for (const bureau of ALL_BUREAUS) {
+    const pb = (tl.per_bureau[bureau] ||= {});
+    for (const field of ENRICH_FIELDS) {
+      if (pb[field] == null || pb[field] === '') {
+        if (override[field] != null) {
+          pb[field] = override[field];
+          continue;
+        }
+        for (const b2 of ALL_BUREAUS) {
+          const v = tl.per_bureau?.[b2]?.[field];
+          if (v != null && v !== '') {
+            pb[field] = v;
+            break;
+          }
+        }
+      }
+    }
+  }
+  return tl;
+}
+
+async function pullTradelineData({ apiUrl, fetchImpl = fetch, overrides = {} }) {
+  const res = await fetchImpl(apiUrl);
+  if (!res.ok) throw new Error(`Failed to fetch report: ${res.status}`);
+  const html = await res.text();
+  const dom = new JSDOM(html);
+  const report = parseCreditReportHTML(dom.window.document);
+  for (const tl of report.tradelines || []) {
+    const ov = overrides[tl.meta?.creditor] || {};
+    enrichTradeline(tl, ov);
+  }
+  return report;
+}
+
+export { pullTradelineData, enrichTradeline };
+export default pullTradelineData;

--- a/metro2 (copy 1)/crm/tests/pullTradelineData.test.js
+++ b/metro2 (copy 1)/crm/tests/pullTradelineData.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { pullTradelineData } from '../pullTradelineData.js';
+
+const SAMPLE_HTML = `<html><body><td class="ng-binding"><div class="sub_header">Test Creditor</div><table class="rpt_content_table rpt_content_header rpt_table4column"><tr><th></th><th>TransUnion</th><th>Experian</th><th>Equifax</th></tr><tr><td class="label">Account #:</td><td class="info">1234</td><td class="info">1234</td><td class="info">1234</td></tr></table></td></body></html>`;
+
+test('pullTradelineData parses and enriches tradelines', async () => {
+  const fakeFetch = async () => ({ ok: true, text: async () => SAMPLE_HTML });
+  const overrides = { 'Test Creditor': { date_opened: '01/01/2020' } };
+  const report = await pullTradelineData({ apiUrl: 'http://example.com', fetchImpl: fakeFetch, overrides });
+  const tl = report.tradelines[0];
+  assert.equal(tl.meta.creditor, 'Test Creditor');
+  assert.equal(tl.per_bureau.TransUnion.account_number, '1234');
+  assert.equal(tl.per_bureau.Experian.date_opened, '01/01/2020');
+  assert.equal(tl.per_bureau.Equifax.date_opened, '01/01/2020');
+});


### PR DESCRIPTION
## Summary
- fetch and normalize credit report data with enrichment layer
- ensure letters build from enriched tradelines
- add smoke test for tradeline data pull

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bafeff3bc883239a07026e3ae02d86