### PR TITLE
docs: install chromium deps for puppeteer

### DIFF
--- a/metro2 (copy 1)/crm/README.md
+++ b/metro2 (copy 1)/crm/README.md
@@ -22,6 +22,16 @@ Use `metro2Violations.json` as a quick reference for common Metro-2 and FCRA con
 2. Keep descriptions factual and align each rule with FCRA accuracy requirements—avoid implying guaranteed deletions or timeframes.
 3. Run `npm test` to validate changes and maintain compliance.
 
+## Chromium dependencies
+
+Puppeteer needs system libraries (`libnss3`, `libnspr4`) to render PDFs. On Debian/Ubuntu run:
+
+```bash
+npm run setup:chrome
+```
+
+Without them, letter generation will fail with errors like `libnspr4.so: cannot open shared object file`.
+
 ## Quick Start
 
 1. **Run audit** – parse `data/report.json` and create a shareable report.

--- a/metro2 (copy 1)/crm/install-chrome-deps.sh
+++ b/metro2 (copy 1)/crm/install-chrome-deps.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+# Installs libraries required by Chromium for Puppeteer.
+# Currently supports Debian/Ubuntu systems with apt-get.
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "apt-get not found. Please install libnss3 and libnspr4 using your package manager."
+  exit 0
+fi
+
+if [ "$EUID" -ne 0 ]; then
+  echo "This script requires root privileges. Re-run with sudo." >&2
+  exit 1
+fi
+
+apt-get update
+apt-get install -y libnss3 libnspr4

--- a/metro2 (copy 1)/crm/package.json
+++ b/metro2 (copy 1)/crm/package.json
@@ -9,8 +9,8 @@
     "dev": "node server.js",
     "audit": "node creditAuditTool.js",
     "postinstall": "python3 -m pip install --user -r requirements.txt",
-    "test": "node --test tests/*.test.js"
-
+    "test": "node --test tests/*.test.js",
+    "setup:chrome": "bash install-chrome-deps.sh"
   },
   "dependencies": {
     "archiver": "^6.0.2",

--- a/metro2 (copy 1)/crm/pdfUtils.js
+++ b/metro2 (copy 1)/crm/pdfUtils.js
@@ -21,7 +21,6 @@ function stripAngularMarkup(markup){
       const classes = `${pre} ${post}`.trim().replace(/\s+/g,' ');
       return classes ? `class="${classes}"` : '';
     });
-}
 
 export async function detectChromium(){
   if(process.env.PUPPETEER_EXECUTABLE_PATH) return process.env.PUPPETEER_EXECUTABLE_PATH;
@@ -66,7 +65,7 @@ export async function htmlToPdfBuffer(html){
       browser = await launchBrowser();
     }catch(err){
       throw new Error(
-        `Chromium failed to launch. Install system deps (e.g. libatk1.0-0, libx11) or set PUPPETEER_EXECUTABLE_PATH.\nOriginal error: ${err.message}`
+        `Chromium failed to launch. Install system deps (libnss3, libnspr4) via 'npm run setup:chrome' or set PUPPETEER_EXECUTABLE_PATH.\nOriginal error: ${err.message}`
       );
     }
     const page = await browser.newPage();


### PR DESCRIPTION
## Summary
- add setup script to install libnss3 and libnspr4 for headless Chromium
- document dependency step and new npm script in README
- clarify pdf generation error message to reference setup script

## Testing
- `npm test` *(fails: Promise resolution is still pending but the event loop has already resolved)*
- `npm run setup:chrome`


------
https://chatgpt.com/codex/tasks/task_e_68bb0c0a368883238669c41cbcd2907d