### PR TITLE
Add global OCR flag for generated letters

### DIFF
--- a/metro2 (copy 1)/crm/pdfUtils.js
+++ b/metro2 (copy 1)/crm/pdfUtils.js
@@ -21,6 +21,7 @@ function stripAngularMarkup(markup){
       const classes = `${pre} ${post}`.trim().replace(/\s+/g,' ');
       return classes ? `class="${classes}"` : '';
     });
+}
 
 export async function detectChromium(){
   if(process.env.PUPPETEER_EXECUTABLE_PATH) return process.env.PUPPETEER_EXECUTABLE_PATH;

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -862,7 +862,15 @@ $("#btnGenerate").addEventListener("click", async ()=>{
     const resp = await fetch("/api/generate", {
       method: "POST",
       headers: { "Content-Type":"application/json" },
-      body: JSON.stringify({ consumerId: currentConsumerId, reportId: currentReportId, selections, requestType, personalInfo: includePI, collectors: colSelections })
+      body: JSON.stringify({
+        consumerId: currentConsumerId,
+        reportId: currentReportId,
+        selections,
+        requestType,
+        personalInfo: includePI,
+        collectors: colSelections,
+        useOcr: ocrCb?.checked || false,
+      })
 
     });
     if(!resp.ok){

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -1507,7 +1507,16 @@ function loadJobFromDisk(jobId){
 app.post("/api/generate", authenticate, requirePermission("letters"), async (req,res)=>{
 
   try{
-    const { consumerId, reportId, selections, requestType, personalInfo, inquiries, collectors } = req.body;
+    const {
+      consumerId,
+      reportId,
+      selections,
+      requestType,
+      personalInfo,
+      inquiries,
+      collectors,
+      useOcr,
+    } = req.body;
 
     const db = loadDB();
     const consumer = db.consumers.find(c=>c.id===consumerId);
@@ -1545,8 +1554,11 @@ app.post("/api/generate", authenticate, requirePermission("letters"), async (req
     }
 
     for (const L of letters) {
+      L.useOcr = !!useOcr;
+    }
+    for (const L of letters) {
       const sel = (selections || []).find(s => s.tradelineIndex === L.tradelineIndex);
-      if (sel?.useOcr) L.useOcr = true;
+      if (sel && sel.useOcr !== undefined) L.useOcr = !!sel.useOcr;
     }
 
     console.log(`Generated ${letters.length} letters for consumer ${consumer.id}`);

--- a/metro2 (copy 1)/crm/tests/collectSelections.test.js
+++ b/metro2 (copy 1)/crm/tests/collectSelections.test.js
@@ -72,3 +72,9 @@ await test('collectSelections captures creditor info and skips incomplete specia
   assert.deepEqual(s.accountNumbers, { TransUnion:'TU123', Experian:'EX456', Equifax:'EQ789' });
   assert.ok(warnings.length === 1);
 });
+
+ocrEl.checked = true;
+const selectionsOcr = collectSelections();
+await test('checking #cbUseOcr marks selections for OCR', () => {
+  assert.ok(selectionsOcr.every(s => s.useOcr));
+});


### PR DESCRIPTION
## Summary
- include `useOcr` field in generate request payload
- default letters' `useOcr` to request flag on the server with per-selection override
- verify OCR flagging through new tests

## Testing
- `npm test`
- `npx jest` *(fails: Jest cannot parse ES modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0dfff2d88323810ab9dbee1c3131