### PR TITLE
feat: add credit score widget

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -57,23 +57,20 @@
 
   </div>
 
-  <div class="glass card">
+  <div id="creditScoreWidget" class="glass card">
     <div class="font-medium mb-2">Credit Score</div>
-    <div class="relative grid place-items-center">
-      <svg id="scoreRing" viewBox="0 0 140 140" class="w-32 h-32 -rotate-90">
-        <circle cx="70" cy="70" r="54" stroke="#e5e7eb" stroke-width="12" fill="none"></circle>
-        <circle id="scoreProgress" cx="70" cy="70" r="54" stroke="url(#g)" stroke-width="12" stroke-linecap="round" fill="none" stroke-dasharray="339.292" stroke-dashoffset="339.292"></circle>
-        <defs>
-          <linearGradient id="g" x1="0" x2="1">
-            <stop offset="0%" stop-color="#10b981" />
-            <stop offset="100%" stop-color="#06b6d4" />
-          </linearGradient>
-        </defs>
-      </svg>
-      <div id="scoreValue" class="absolute text-2xl font-bold flex gap-2">
-        <span id="scoreTU" class="text-blue-500">0</span>
-        <span id="scoreEX" class="text-purple-500">0</span>
-        <span id="scoreEQ" class="text-red-500">0</span>
+    <div class="relative grid grid-cols-3 gap-4 text-center">
+      <div>
+        <div class="text-xs text-gray-500">TransUnion</div>
+        <div class="tu text-2xl font-bold">0</div>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500">Experian</div>
+        <div class="ex text-2xl font-bold">0</div>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500">Equifax</div>
+        <div class="eq text-2xl font-bold">0</div>
       </div>
       <div id="scoreConfetti" class="pointer-events-none absolute inset-0"></div>
     </div>

--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -34,40 +34,35 @@ function renderProductTier(){
 }
 
 function renderScore(){
-  const scoreVal = document.getElementById('scoreValue');
-  const scoreTU = document.getElementById('scoreTU');
-  const scoreEX = document.getElementById('scoreEX');
-  const scoreEQ = document.getElementById('scoreEQ');
-  const scoreProg = document.getElementById('scoreProgress');
+  const widget = document.getElementById('creditScoreWidget');
+  if (!widget) return;
+  const tuEl = widget.querySelector('.tu');
+  const exEl = widget.querySelector('.ex');
+  const eqEl = widget.querySelector('.eq');
   const scoreConfetti = document.getElementById('scoreConfetti');
-  if (scoreVal && scoreProg) {
-    const score = JSON.parse(localStorage.getItem('creditScore') || '{}');
-    const tu = Number(score.transunion || score.tu || score.current || 0);
-    const ex = Number(score.experian || score.exp || 0);
-    const eq = Number(score.equifax || score.eq || 0);
-    if (scoreTU) scoreTU.textContent = tu;
-    if (scoreEX) scoreEX.textContent = ex;
-    if (scoreEQ) scoreEQ.textContent = eq;
-    const scores = [tu, ex, eq].filter(n => n > 0);
-    const avg = scores.length ? scores.reduce((a,b)=>a+b,0) / scores.length : 0;
-    const pct = Math.min(1, avg / 850);
-    const circ = 339.292;
-    scoreProg.style.strokeDashoffset = circ * (1 - pct);
-    const start = Number(score.start || 0);
-    if (avg > start && scoreConfetti && window.lottie) {
-      lottie.loadAnimation({
-        container: scoreConfetti,
-        renderer: 'svg',
-        loop: false,
-        autoplay: true,
-        path: 'https://assets10.lottiefiles.com/packages/lf20_j1adxtyb.json'
-      });
-      setTimeout(() => { scoreConfetti.innerHTML = ''; }, 1500);
-      const ms = document.getElementById('milestones');
-      if (ms) ms.innerHTML = `<div class="news-item">🎉 Score increased by ${Math.round(avg - start)} points!</div>`;
-    }
-    renderProductTier();
+  const score = JSON.parse(localStorage.getItem('creditScore') || '{}');
+  const tu = Number(score.transunion || score.tu || score.current || 0);
+  const ex = Number(score.experian || score.exp || 0);
+  const eq = Number(score.equifax || score.eq || 0);
+  if (tuEl) tuEl.textContent = tu;
+  if (exEl) exEl.textContent = ex;
+  if (eqEl) eqEl.textContent = eq;
+  const scores = [tu, ex, eq].filter(n => n > 0);
+  const avg = scores.length ? scores.reduce((a,b)=>a+b,0) / scores.length : 0;
+  const start = Number(score.start || 0);
+  if (avg > start && scoreConfetti && window.lottie) {
+    lottie.loadAnimation({
+      container: scoreConfetti,
+      renderer: 'svg',
+      loop: false,
+      autoplay: true,
+      path: 'https://assets10.lottiefiles.com/packages/lf20_j1adxtyb.json'
+    });
+    setTimeout(() => { scoreConfetti.innerHTML = ''; }, 1500);
+    const ms = document.getElementById('milestones');
+    if (ms) ms.innerHTML = `<div class="news-item">🎉 Score increased by ${Math.round(avg - start)} points!</div>`;
   }
+  renderProductTier();
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- replace legacy score ring with credit score widget scaffold
- hydrate new widget spans from localStorage data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcbdbd4ee483238d7190ffa7758c8f