### PR TITLE
Handle malformed creditScore in client portal

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -25,7 +25,13 @@ function renderProductTier(){
   const el = document.getElementById('tierBadge');
   if(!el) return;
   const deletions = Number(localStorage.getItem('deletions') || 0);
-  const scoreData = JSON.parse(localStorage.getItem('creditScore') || '{"current":0}');
+  let scoreData;
+  try {
+    scoreData = JSON.parse(localStorage.getItem('creditScore') || '{"current":0}');
+    if (typeof scoreData === 'string') scoreData = JSON.parse(scoreData);
+  } catch {
+    scoreData = { current: 0 };
+  }
   const score = Number(scoreData.current || 0);
   const tier = getProductTier(deletions, score);
   el.className = `hidden sm:flex items-center gap-2 rounded-full px-4 py-2 shadow-sm animate-fadeInUp ${tier.class}`;


### PR DESCRIPTION
## Summary
- wrap `renderProductTier` score parsing in try/catch
- double-parse nested string values like `renderScore`
- keep portal running when `creditScore` is missing or malformed

## Testing
- `npm test`
- `node --input-type=module - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bcc5dd91f483239846a9e397776ce2