### PR TITLE
Add consumer tracker endpoint and client integration

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -130,12 +130,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const stepEl = document.getElementById('currentStep');
   if (consumerId && stepEl) {
-    const steps = JSON.parse(localStorage.getItem('trackerSteps') || '[]');
-    const data = JSON.parse(localStorage.getItem('trackerData') || '{}')[consumerId] || {};
-    const idx = steps.findIndex(s => !data[s]);
-    let current = 'Completed';
-    if (idx !== -1) current = steps[idx];
-    stepEl.textContent = current;
+    fetch(`/api/consumers/${consumerId}/tracker`)
+      .then(r => r.json())
+      .then(({ steps = [], completed = {} }) => {
+        const idx = steps.findIndex(s => !completed[s]);
+        stepEl.textContent = idx === -1 ? 'Completed' : steps[idx];
+      })
+      .catch(() => { stepEl.textContent = 'Unknown'; });
   }
 
   const feedEl = document.getElementById('newsFeed');

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -47,6 +47,7 @@ import {
   consumerUploadsDir,
   addReminder,
   processAllReminders,
+  listTracker,
 } from "./state.js";
 function injectStyle(html, css){
   if(/<head[^>]*>/i.test(html)){
@@ -2020,6 +2021,11 @@ app.get("/api/jobs/:jobId/letters/:idx.pdf", authenticate, requirePermission("le
 });
 
 // =================== Consumer STATE (events + files) ===================
+app.get("/api/consumers/:id/tracker", (req,res)=>{
+  const t = listTracker(req.params.id);
+  res.json(t);
+});
+
 app.get("/api/consumers/:id/state", (req,res)=>{
   const cstate = listConsumerState(req.params.id);
   res.json({ ok:true, state: cstate });


### PR DESCRIPTION
## Summary
- store tracker steps and per-consumer completion in server state
- expose GET `/api/consumers/:id/tracker` for client progress
- client portal now fetches tracker state from server instead of localStorage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bccd7b36088323b588662f3e1e7857