### PR TITLE
feat: add client login endpoint

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -772,6 +772,24 @@ app.post("/api/login", (req,res)=>{
   res.json({ ok:true, token: generateToken(user) });
 });
 
+app.post("/api/client/login", (req,res)=>{
+  const db = loadDB();
+  let client = null;
+  if(req.body.token){
+    client = db.consumers.find(c=>c.portalToken===req.body.token);
+  } else if(req.body.email){
+    client = db.consumers.find(c=>c.email===req.body.email);
+    if(!client || !client.password || !bcrypt.compareSync(req.body.password || "", client.password)){
+      return res.status(401).json({ ok:false, error:"Invalid credentials" });
+    }
+  } else {
+    return res.status(400).json({ ok:false, error:"Missing credentials" });
+  }
+  if(!client) return res.status(401).json({ ok:false, error:"Invalid credentials" });
+  const u = { id: client.id, username: client.email || client.name || "client", role: "client", permissions: [] };
+  res.json({ ok:true, token: generateToken(u) });
+});
+
 app.post("/api/request-password-reset", (req,res)=>{
   const db = loadUsersDB();
   const user = db.users.find(u=>u.username===req.body.username);

--- a/metro2 (copy 1)/crm/tests/clientLogin.test.js
+++ b/metro2 (copy 1)/crm/tests/clientLogin.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import bcrypt from 'bcryptjs';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DB_PATH = path.join(__dirname, '..', 'db.json');
+
+const original = fs.existsSync(DB_PATH) ? fs.readFileSync(DB_PATH) : null;
+const client = {
+  id: 'c1',
+  name: 'Test Client',
+  email: 'client@example.com',
+  password: bcrypt.hashSync('secret', 10),
+  portalToken: 'tok123',
+  reports: []
+};
+fs.writeFileSync(DB_PATH, JSON.stringify({ consumers: [client] }, null, 2));
+
+process.env.NODE_ENV = 'test';
+const { default: app } = await import('../server.js');
+
+test('client login via token issues client role', async () => {
+  const res = await request(app).post('/api/client/login').send({ token: 'tok123' });
+  assert.equal(res.body.ok, true);
+  const payload = jwt.decode(res.body.token);
+  assert.equal(payload.role, 'client');
+  assert.equal(payload.id, 'c1');
+});
+
+test('client login via email/password', async () => {
+  const res = await request(app).post('/api/client/login').send({ email: 'client@example.com', password: 'secret' });
+  assert.equal(res.body.ok, true);
+});
+
+test.after(() => {
+  if (original) fs.writeFileSync(DB_PATH, original);
+  else fs.unlinkSync(DB_PATH);
+});


### PR DESCRIPTION
## Summary
- support client auth via `/api/client/login` issuing JWTs with `role: "client"`
- reuse existing `generateToken` for consistent token structure
- cover client login flow with a basic integration test

## Testing
- `node --test tests/clientLogin.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bd85831cbc8323995f7963415549af