### PR TITLE
feat: parse credit inquiries

### DIFF
--- a/metro2 (copy 1)/crm/tests/parserInquiries.test.js
+++ b/metro2 (copy 1)/crm/tests/parserInquiries.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { parseCreditReportHTML } from '../parser.js';
+
+test('parses inquiries and summarizes counts', () => {
+  const html = `
+    <table>
+      <tr ng-repeat="inqPartition in data">
+        <td class="info">Capital One</td>
+        <td class="info">Bank</td>
+        <td class="info">01/05/2024</td>
+        <td class="info">TransUnion</td>
+      </tr>
+    </table>
+  `;
+  const dom = new JSDOM(html);
+  const { inquiries, inquiry_summary } = parseCreditReportHTML(dom.window.document);
+  assert.equal(inquiries.length, 1);
+  assert.equal(inquiries[0].creditor, 'Capital One');
+  assert.equal(inquiries[0].bureau, 'TransUnion');
+  assert.equal(inquiry_summary.byBureau.TransUnion, 1);
+  assert.equal(inquiry_summary.total, 1);
+});


### PR DESCRIPTION
## Summary
- extend `parseCreditReportHTML` to extract inquiry data and bureau counts
- add unit test for inquiry parsing

## Testing
- `NODE_ENV=test node --test tests/parserInquiries.test.js`
- `NODE_ENV=test npm test` *(fails: process hangs after login tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9f471c48832384e6010648cf8613