### PR TITLE
chore: update client portal template references

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -84,7 +84,7 @@ function restrictRoutes(role){
   const path = location.pathname;
   const ok = allowed.some(p=> path.startsWith(p));
   if(!ok){
-    location.href = role === 'client' ? '/client-portal.html' : '/dashboard';
+    location.href = role === 'client' ? '/client-portal-template.html' : '/dashboard';
   }
 }
 restrictRoutes(window.userRole);

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -7,7 +7,7 @@ const api = (u, o = {}) => fetch(u, o).then(r => r.json()).catch(e => ({ ok:fals
 
 const role = typeof window !== 'undefined' ? (window.userRole || 'host') : 'host';
 if (typeof window !== 'undefined' && role === 'client') {
-  window.location.href = '/client-portal.html';
+  window.location.href = '/client-portal-template.html';
 }
 if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
   document.addEventListener('DOMContentLoaded', () => {

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -262,6 +262,7 @@ app.get("/library", optionalAuth, forbidMember, (_req, res) => res.sendFile(path
 app.get("/tradelines", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "tradelines.html")));
 app.get("/quiz", optionalAuth, forbidMember, (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "quiz.html")));
 app.get("/settings", optionalAuth, forbidMember, (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "settings.html")));
+app.get("/client-portal.html", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "client-portal-template.html")));
 app.get("/team/:token", (req,res)=>{
   const token = path.basename(req.params.token);
   const file = path.join(PUBLIC_DIR, `team-${token}.html`);


### PR DESCRIPTION
## Summary
- replace remaining `client-portal.html` references with `client-portal-template.html`
- add Express route alias so `/client-portal.html` serves the new template

## Testing
- `npm test --prefix 'metro2 (copy 1)/crm'`
- `curl -I http://localhost:3000/client-portal-template.html`
- `curl -I http://localhost:3000/client-portal.html`


------
https://chatgpt.com/codex/tasks/task_e_68bda15acb8883239dddd5fe6f962734