### PR TITLE
Allow team members to view template

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -77,7 +77,7 @@ window.userRole = _payload.role || null;
 function restrictRoutes(role){
   const allowed = {
     host: null,
-    team: ['/dashboard','/clients','/leads','/schedule','/billing','/','/index.html','/login.html'],
+    team: ['/dashboard','/clients','/leads','/schedule','/billing','/','/index.html','/login.html','/team-member-template.html'],
     client: ['/client-portal','/portal','/login.html','/']
   }[role];
   if(!allowed) return;


### PR DESCRIPTION
## Summary
- allow team role to navigate to `/team-member-template.html` without redirect

## Testing
- `npm test` *(fails: hung after some tests, manual interruption)*
- `node testRestrict.cjs` *(manual check allowed href)*

------
https://chatgpt.com/codex/tasks/task_e_68bda1561f6083239ffa9493c7bc26f9