### PR TITLE
Prevent blue flash before theme loads

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -4,7 +4,33 @@
   <meta charset="utf-8">
   <title>Billing</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
 </head>
 <body>
 <header id="host-nav" class="p-4">

--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -5,7 +5,33 @@
   <title>Client Portal - {{name}}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
-    <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
     <style>
       @keyframes blob{0%,100%{transform:translate(0,0);}33%{transform:translate(15px,-10px);}66%{transform:translate(-10px,10px);}}
       .animate-blob{animation:blob 10s ease-in-out infinite;}

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -4,7 +4,33 @@
   <meta charset="utf-8">
   <title>Dashboard</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1j7k8fBRT1Q9ir3R8A4bMHt0gXu6p0UmmE8Zy+3E=" crossorigin="" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-oEnJPhGf6QjaxzX2LeLYI0m0CMvYZRyGmA4KQ1uYf3s=" crossorigin=""></script>
   <style>

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -7,7 +7,33 @@
   <meta name="theme-color" content="#AF52DE" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
   <style>
     :root{
       --glass-bg: rgba(255,255,255,0.4);

--- a/metro2 (copy 1)/crm/public/leads.html
+++ b/metro2 (copy 1)/crm/public/leads.html
@@ -4,7 +4,33 @@
   <meta charset="utf-8" />
   <title>Leads</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
 </head>
 <body>
 <header id="host-nav" class="p-4">

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -5,7 +5,33 @@
   <title>Generated Letters</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
   <style>
     :root {
       --green:#22c55e;

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -5,7 +5,33 @@
   <title>Library</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
   <style>
     /*
       The template panel previously used fixed positioning, which

--- a/metro2 (copy 1)/crm/public/login.html
+++ b/metro2 (copy 1)/crm/public/login.html
@@ -6,7 +6,33 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="theme-color" content="#AF52DE" />
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gray-100">
   <div class="glass card w-full max-w-sm space-y-4">

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -4,7 +4,33 @@
   <meta charset="utf-8">
   <title>My Company</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
 </head>
 <body>
 <header id="host-nav" class="p-4">

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -5,7 +5,33 @@
   <title>Hotkey Quiz</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
 </head>
 <body>
   <header id="host-nav" class="p-4">

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -4,7 +4,33 @@
   <meta charset="utf-8">
   <title>Schedule</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
 </head>
 <body>
 <header id="host-nav" class="p-4">

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -4,7 +4,33 @@
   <meta charset="utf-8">
   <title>Settings</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
 </head>
 <body>
 <header id="host-nav" class="p-4">

--- a/metro2 (copy 1)/crm/public/team-member-template.html
+++ b/metro2 (copy 1)/crm/public/team-member-template.html
@@ -4,7 +4,33 @@
   <meta charset="utf-8" />
   <title>Team Member {{name}}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
 </head>
 <body class="p-4">
   <div id="login">

--- a/metro2 (copy 1)/crm/public/tradelines.html
+++ b/metro2 (copy 1)/crm/public/tradelines.html
@@ -4,7 +4,33 @@
   <meta charset="utf-8">
   <title>Tradelines</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
+<script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+</script>
+<link rel="stylesheet" href="/style.css">
 </head>
 <body>
 <header id="host-nav" class="p-4">


### PR DESCRIPTION
## Summary
- preload saved theme variables before style.css to stop the blue nav flash
- hide document until theme applied for polished transitions

## Testing
- `npm test` (hangs after running tests; had to interrupt)


------
https://chatgpt.com/codex/tasks/task_e_68bda99dd0cc8323a9566a43a468ab3a