### PR TITLE
Fix team member role

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -852,7 +852,7 @@ app.post("/api/team-members", authenticate, requireRole("admin"), (req,res)=>{
     name: req.body.name || "",
     token,
     password,
-    role: "member",
+    role: "team",
     mustReset: true,
     permissions: []
   };


### PR DESCRIPTION
## Summary
- return role `team` for `/api/team-members`
- add regression tests for team JWT role and nav helpers

## Testing
- `node --test 'metro2 (copy 1)/crm/tests/teamRole.test.js'`


------
https://chatgpt.com/codex/tasks/task_e_68bdb78153b48323a5a3b53d41933882