### PR TITLE
feat: enforce role checks

### DIFF
--- a/metro2 (copy 1)/crm/README.md
+++ b/metro2 (copy 1)/crm/README.md
@@ -57,3 +57,8 @@ npm install
 npm test
 ```
 
+### Unauthorized access check
+
+The test suite includes assertions that a non-admin token receives `403 Forbidden` when accessing admin-only routes like `/api/users` and `/api/team-members`.
+
+

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -179,8 +179,13 @@ function optionalAuth(req,res,next){
   next();
 }
 
-function requireRole(_role){
-  return (_req, _res, next)=> next();
+function requireRole(role){
+  return (req, res, next) => {
+    if (req.user && req.user.role === role) {
+      return next();
+    }
+    res.status(403).send("Forbidden");
+  };
 }
 
 function hasPermission(user, perm){

--- a/metro2 (copy 1)/crm/tests/authorization.test.js
+++ b/metro2 (copy 1)/crm/tests/authorization.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import bcrypt from 'bcryptjs';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const USERS_DB_PATH = path.join(__dirname, '..', 'users-db.json');
+const original = fs.existsSync(USERS_DB_PATH) ? fs.readFileSync(USERS_DB_PATH) : null;
+
+const admin = { id: 'a1', username: 'admin', password: bcrypt.hashSync('secret', 10), role: 'admin', permissions: [] };
+const member = { id: 'm1', username: 'member', password: bcrypt.hashSync('secret', 10), role: 'member', permissions: [] };
+fs.writeFileSync(USERS_DB_PATH, JSON.stringify({ users: [admin, member] }, null, 2));
+
+process.env.NODE_ENV = 'test';
+const { default: app } = await import('../server.js');
+
+function token(user) {
+  return jwt.sign({ id: user.id, username: user.username, role: user.role, permissions: user.permissions }, 'dev-secret', { expiresIn: '1h' });
+}
+
+test('member cannot list users', async () => {
+  const res = await request(app)
+    .get('/api/users')
+    .set('Authorization', `Bearer ${token(member)}`);
+  assert.equal(res.status, 403);
+});
+
+test('member cannot create team member', async () => {
+  const res = await request(app)
+    .post('/api/team-members')
+    .set('Authorization', `Bearer ${token(member)}`)
+    .send({ username: 'newbie' });
+  assert.equal(res.status, 403);
+});
+
+test.after(() => {
+  if (original) fs.writeFileSync(USERS_DB_PATH, original);
+  else fs.unlinkSync(USERS_DB_PATH);
+});


### PR DESCRIPTION
## Summary
- enforce user role middleware for admin-only routes
- test admin endpoints reject non-admin tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7853e488323b0ed1f43c5acd20f