### PR TITLE
feat: add team member invite flow

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -80,6 +80,20 @@ function loadScores(){
   renderScore(score);
 }
 
+function renderTeamList(){
+  const teamList = document.getElementById('teamList');
+  if (!teamList) return;
+  const team = JSON.parse(localStorage.getItem('teamMembers') || '[]');
+  if (!team.length) {
+    teamList.textContent = 'No team members added.';
+  } else {
+    teamList.innerHTML = team.map(m => {
+      const role = m.role ? `<div class="text-xs muted">${m.role}${m.email? ' - ' + m.email : ''}</div>` : (m.email ? `<div class="text-xs muted">${m.email}</div>` : '');
+      return `<div class="news-item"><div class="font-medium">${m.name}</div>${role}</div>`;
+    }).join('');
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const idMatch = location.pathname.match(/\/portal\/(.+)$/);
 
@@ -120,18 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (cn) cn.textContent = company.name;
   }
 
-  const teamList = document.getElementById('teamList');
-  const team = JSON.parse(localStorage.getItem('teamMembers') || '[]');
-  if (teamList) {
-    if (!team.length) {
-      teamList.textContent = 'No team members added.';
-    } else {
-      teamList.innerHTML = team.map(m => {
-        const role = m.role ? `<div class="text-xs muted">${m.role}${m.email? ' - ' + m.email : ''}</div>` : (m.email ? `<div class="text-xs muted">${m.email}</div>` : '');
-        return `<div class="news-item"><div class="font-medium">${m.name}</div>${role}</div>`;
-      }).join('');
-    }
-  }
+  renderTeamList();
 
   const stepEl = document.getElementById('currentStep');
   if (consumerId && stepEl) {
@@ -176,11 +179,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   window.addEventListener('storage', e => {
     if (e.key === 'creditScore') loadScores();
+    if (e.key === 'teamMembers') renderTeamList();
   });
   const _setItem = localStorage.setItem;
   localStorage.setItem = function(key, value) {
     _setItem.apply(this, arguments);
     if (key === 'creditScore') loadScores();
+    if (key === 'teamMembers') renderTeamList();
   };
 
 

--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -30,6 +30,33 @@ window.trackEvent = trackEvent;
 document.addEventListener('DOMContentLoaded', () => {
   trackEvent('page_view', { path: location.pathname });
   initAbTest();
+  const btnInvite = document.getElementById('btnInvite');
+  if (btnInvite) {
+    btnInvite.addEventListener('click', async () => {
+      const email = prompt('Teammate email?');
+      if (!email) return;
+      const name = prompt('Teammate name?');
+      if (!name) return;
+      try {
+        const res = await fetch('/api/team-members', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...authHeader()
+          },
+          body: JSON.stringify({ username: email, name })
+        });
+        const data = await res.json();
+        if (!res.ok || !data.member) throw new Error(data.error || 'Request failed');
+        alert(`Token: ${data.member.token}\nTemp Password: ${data.member.password}`);
+        const team = JSON.parse(localStorage.getItem('teamMembers') || '[]');
+        team.push({ name, email, role: 'team' });
+        localStorage.setItem('teamMembers', JSON.stringify(team));
+      } catch (err) {
+        alert('Failed to invite member');
+      }
+    });
+  }
   applyRoleNav(window.userRole);
 });
 


### PR DESCRIPTION
## Summary
- allow inviting team members from any page via #btnInvite
- render updated team list in client portal when local storage changes

## Testing
- `npm test` *(hangs, partial output)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb77c5ff88323bb10a3ba2e7ec696