### PR TITLE
Fix credit score script in client portal

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -286,7 +286,7 @@ app.get("/portal/:id", (req, res) => {
   let html = tmpl.replace(/{{name}}/g, consumer.name);
   if (consumer.creditScore) {
     const scoreJson = JSON.stringify(consumer.creditScore);
-    const script = `\n<script>localStorage.setItem('creditScore', ${JSON.stringify(scoreJson)});</script>`;
+    const script = `\n<script>localStorage.setItem('creditScore', ${scoreJson});</script>`;
     html = html.replace('</body>', `${script}\n</body>`);
   }
   res.send(html);


### PR DESCRIPTION
## Summary
- properly insert credit score JSON into client portal localStorage

## Testing
- `npm test` *(fails: process terminated)*
- `curl -s http://localhost:3000/portal/RoVO6y0EKM | grep -n "creditScore"`


------
https://chatgpt.com/codex/tasks/task_e_68befc4b6c648323b9697976cc3b0e22