### PR TITLE
fix: escape message text with existing helper

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -468,7 +468,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const cls = isClient ? 'msg-client' : 'msg-host';
             const name = isClient ? 'You' : fromUser || 'Host';
             const when = new Date(m.at).toLocaleString();
-            return `<div class="message ${cls}"><div class="text-xs muted">${name} • ${when}</div><div>${escapeHtml(m.payload?.text || '')}</div></div>`;
+            return `<div class="message ${cls}"><div class="text-xs muted">${name} • ${when}</div><div>${esc(m.payload?.text || '')}</div></div>`;
           }).join('');
         }
       })


### PR DESCRIPTION
## Summary
- replace deprecated `escapeHtml` with `esc` helper in client portal messages

## Testing
- `npm test` *(fails: hangs after some tests)*

------
https://chatgpt.com/codex/tasks/task_e_68befc4f6db48323b5830d220bbfc077