### PR TITLE
Handle raw field fallbacks in audit and expose raw data for JSON

### DIFF
--- a/metro2 (copy 1)/crm/creditAuditTool.js
+++ b/metro2 (copy 1)/crm/creditAuditTool.js
@@ -129,22 +129,22 @@ export function renderHtml(report, consumerName = "Consumer"){
     const bureauData = acc.bureaus || {};
     const bureaus = Object.keys(bureauData);
     const fields = [
-      ["account_number", "Account #"],
-      ["account_type", "Account Type"],
-      ["payment_status", "Account Payment Status"],
-      ["balance_raw", "Balance"],
-      ["past_due_raw", "Past Due"],
-      ["high_credit_raw", "High Credit"],
-      ["date_opened_raw", "Date Opened"],
-      ["last_reported_raw", "Last Reported"],
-      ["date_last_payment_raw", "Date of Last Payment"],
-      ["comments", "Comments"],
+      ["account_number_raw", "account_number", "Account #"],
+      ["account_type_raw", "account_type", "Account Type"],
+      ["payment_status_raw", "payment_status", "Account Payment Status"],
+      ["balance_raw", "balance", "Balance"],
+      ["past_due_raw", "past_due", "Past Due"],
+      ["high_credit_raw", "high_credit", "High Credit"],
+      ["date_opened_raw", "date_opened", "Date Opened"],
+      ["last_reported_raw", "last_reported", "Last Reported"],
+      ["date_last_payment_raw", "date_last_payment", "Date of Last Payment"],
+      ["comments", "comments", "Comments"],
     ];
 
-    const rows = fields.map(([field, label]) => {
+    const rows = fields.map(([fieldRaw, field, label]) => {
       const rawValues = bureaus.map(b => {
         const info = acc.bureaus[b] || {};
-        return info[field] ?? "";
+        return info[fieldRaw] ?? info[field] ?? "";
       });
       const displayValues = rawValues.map(v => field === "payment_status" ? friendlyStatus(v) : v);
       const diff = new Set(displayValues.filter(v => v !== "")).size > 1 ? " diff" : "";

--- a/metro2 (copy 1)/crm/parser.js
+++ b/metro2 (copy 1)/crm/parser.js
@@ -265,7 +265,7 @@ function parseCreditReportHTML(doc) {
     pb.raw[field] = val;
     Object.defineProperty(pb, `${field}_raw`, {
       value: val,
-      enumerable: false,
+      enumerable: true,
       configurable: true,
       writable: true,
     });


### PR DESCRIPTION
## Summary
- Render audit table fields using raw values with normalized fallbacks
- Keep `_raw` properties enumerable so raw data survives JSON serialization

## Testing
- `npm test` *(fails: process hangs after running initial tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c1820d7e2483238fac1743ed618997