### PR TITLE
feat: show bureau tags on violations

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -460,11 +460,11 @@ export function mergeBureauViolations(vs){
   (vs||[]).forEach(v=>{
     const m = v.title?.match(/^(.*?)(?:\s*\((TransUnion|Experian|Equifax)\))?$/) || [];
     const base = (m[1] || v.title || "").trim();
-    const bureau = m[2];
+    const bureau = v.evidence?.bureau || m[2];
     const detailClean = (v.detail || "").replace(/\s*\((TransUnion|Experian|Equifax)\)$/,'').trim();
     const evKey = detailClean || JSON.stringify(v.evidence || {});
     const id = v.id || v.code || "";
-    const key = `${id}|${v.category||""}|${base}|${evKey}`;
+    const key = `${id}|${v.category||""}|${base}|${evKey}|${bureau||""}`;
     if(!map.has(key)) map.set(key,{category:v.category,title:base,bureaus:new Set(),details:new Set(),severity:v.severity||0});
     const entry = map.get(key);
     if(bureau) entry.bureaus.add(bureau);
@@ -473,9 +473,10 @@ export function mergeBureauViolations(vs){
   });
   return Array.from(map.values()).map(e=>({
     category:e.category,
-    title: e.bureaus.size ? `${e.title} (${Array.from(e.bureaus).join(', ')})` : e.title,
+    title: e.title,
     detail: Array.from(e.details).join(' '),
-    severity: e.severity
+    severity: e.severity,
+    bureaus: Array.from(e.bureaus)
   }));
 }
 
@@ -676,6 +677,7 @@ function renderTradelines(tradelines){
           <input type="checkbox" class="violation" value="${vidx + vStart}"/>
           <div>
             <div class="font-medium text-sm wrap-anywhere">${escapeHtml(v.category || "")} – ${escapeHtml(v.title || "")}${v.severity ? `<span class="severity-tag severity-${v.severity}">S${v.severity}</span>` : ""}</div>
+            ${v.bureaus && v.bureaus.length ? `<div class="text-xs mt-1">${v.bureaus.map(b=>'<span class="badge badge-bureau">'+escapeHtml(b)+'</span>').join(' ')}</div>` : ""}
             ${v.detail ? `<div class="text-sm text-gray-600 wrap-anywhere">${escapeHtml(v.detail)}</div>` : ""}
           </div>
         </label>`).join("");
@@ -816,7 +818,7 @@ function buildZoomHTML(tl){
   const per = tl.per_bureau || {};
   const vlist = mergeBureauViolations(tl.violations||[]).map(v=>`
     <li class="mb-2">
-      <div class="font-medium">${escapeHtml(v.category||"")} – ${escapeHtml(v.title||"")}</div>
+      <div class="font-medium">${escapeHtml(v.category||"")} – ${escapeHtml(v.title||"")}${v.bureaus && v.bureaus.length ? ' '+v.bureaus.map(b=>'<span class="badge badge-bureau">'+escapeHtml(b)+'</span>').join(' ') : ''}</div>
       ${v.detail? `<div class="text-gray-600">${escapeHtml(v.detail)}</div>` : ""}
     </li>`).join("") || "<div class='text-sm muted'>No violations detected.</div>";
 

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -188,6 +188,10 @@ body.voice-active #voiceNotes{display:block;}
   font-size: 12px;
   font-weight: 500;
 }
+.badge-bureau {
+  background: #E5E7EB;
+  color: #374151;
+}
 .badge-paid {
   background: #DEF7EC;
   color: #046C4E;

--- a/metro2 (copy 1)/crm/tests/violationMapping.test.js
+++ b/metro2 (copy 1)/crm/tests/violationMapping.test.js
@@ -12,7 +12,7 @@ test('filterViolationsBySeverity prioritizes high severity', () => {
   assert.equal(filtered[0].code, 'MISSING_DOFD');
 });
 
-test('mergeBureauViolations keeps distinct ids', async () => {
+test('mergeBureauViolations keeps violations separate per bureau', async () => {
   const stubEl = {};
   stubEl.addEventListener = () => {};
   stubEl.classList = { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} };
@@ -40,18 +40,21 @@ test('mergeBureauViolations keeps distinct ids', async () => {
     {
       id: 'A1',
       category: 'cat',
-      title: 'Same Title (TransUnion)',
-      detail: 'Same Detail (TransUnion)',
-      severity: 1
+      title: 'Same Title',
+      detail: 'Same Detail',
+      severity: 1,
+      evidence: { bureau: 'TransUnion' }
     },
     {
-      id: 'B2',
+      id: 'A1',
       category: 'cat',
-      title: 'Same Title (Experian)',
-      detail: 'Same Detail (Experian)',
-      severity: 1
+      title: 'Same Title',
+      detail: 'Same Detail',
+      severity: 1,
+      evidence: { bureau: 'Experian' }
     }
   ];
   const merged = mergeBureauViolations(input);
   assert.equal(merged.length, 2);
+  assert.deepEqual(merged.map(v=>v.bureaus), [['TransUnion'], ['Experian']]);
 });


### PR DESCRIPTION
## Summary
- include bureau identifier in mergeBureauViolations merge key
- render bureau tags next to violations and add badge styles
- test that violations remain separate for each bureau

## Testing
- `node --test tests/violationMapping.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c1bb3a52508323ad14fb3477da7995