### PR TITLE
feat: show bureau tags on violations

### DIFF
--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -188,6 +188,10 @@ body.voice-active #voiceNotes{display:block;}
   font-size: 12px;
   font-weight: 500;
 }
+.badge-bureau {
+  background: #E5E7EB;
+  color: #374151;
+}
 .badge-paid {
   background: #DEF7EC;
   color: #046C4E;

--- a/metro2 (copy 1)/crm/tests/violationMapping.test.js
+++ b/metro2 (copy 1)/crm/tests/violationMapping.test.js
@@ -12,7 +12,7 @@ test('filterViolationsBySeverity prioritizes high severity', () => {
   assert.equal(filtered[0].code, 'MISSING_DOFD');
 });
 
-test('mergeBureauViolations keeps distinct ids', async () => {
+test('mergeBureauViolations keeps violations separate per bureau', async () => {
   const stubEl = {};
   stubEl.addEventListener = () => {};
   stubEl.classList = { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} };
@@ -40,18 +40,52 @@ test('mergeBureauViolations keeps distinct ids', async () => {
     {
       id: 'A1',
       category: 'cat',
-      title: 'Same Title (TransUnion)',
-      detail: 'Same Detail (TransUnion)',
-      severity: 1
+      title: 'Same Title',
+      detail: 'Same Detail',
+      severity: 1,
+      evidence: { bureau: 'TransUnion' }
     },
     {
-      id: 'B2',
+      id: 'A1',
       category: 'cat',
-      title: 'Same Title (Experian)',
-      detail: 'Same Detail (Experian)',
-      severity: 1
+      title: 'Same Title',
+      detail: 'Same Detail',
+      severity: 1,
+      evidence: { bureau: 'Experian' }
     }
   ];
   const merged = mergeBureauViolations(input);
   assert.equal(merged.length, 2);
+  assert.deepEqual(merged.map(v=>v.bureaus), [['TransUnion'], ['Experian']]);
+});
+
+test('mergeBureauViolations splits violations with bureaus array', async () => {
+  const stubEl = {};
+  stubEl.addEventListener = () => {};
+  stubEl.classList = { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} };
+  stubEl.querySelector = () => stubEl;
+  stubEl.querySelectorAll = () => [];
+  stubEl.appendChild = () => {};
+  stubEl.innerHTML = '';
+  stubEl.textContent = '';
+  stubEl.style = {};
+  stubEl.dataset = {};
+  globalThis.document = {
+    querySelector: () => stubEl,
+    querySelectorAll: () => [],
+    getElementById: () => stubEl,
+    addEventListener: () => {},
+    createElement: () => stubEl,
+    body: { style: {} }
+  };
+  globalThis.window = {};
+  globalThis.MutationObserver = class { observe(){} disconnect(){} };
+  globalThis.localStorage = { getItem: () => null, setItem: () => {} };
+
+  const { mergeBureauViolations } = await import('../public/index.js');
+  const merged = mergeBureauViolations([
+    { id: 'A1', category: 'cat', title: 'Same Title', detail: 'Same Detail', bureaus: ['TransUnion','Experian'] }
+  ]);
+  assert.equal(merged.length, 2);
+  assert.deepEqual(merged.map(v=>v.bureaus), [['TransUnion'], ['Experian']]);
 });


### PR DESCRIPTION
## Summary
- include bureau identifier in mergeBureauViolations merge key
- render bureau tags next to violations and add badge styles
- test that violations remain separate for each bureau
- split violations that arrive with `bureaus` arrays so each bureau renders independently

## Testing
- `node --test tests/violationMapping.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1bb3a52508323ad14fb3477da7995