### PR TITLE
fix: consolidate cross-bureau violations

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -461,13 +461,16 @@ export function mergeBureauViolations(vs){
     const m = v.title?.match(/\((TransUnion|Experian|Equifax)\)/) || [];
     const base = (v.title || "").replace(/\s*\((TransUnion|Experian|Equifax)\)/g, "").trim();
     const detailClean = (v.detail || "").replace(/\s*\((TransUnion|Experian|Equifax)\)/g, "").trim();
-    const evKey = detailClean || JSON.stringify(v.evidence || {});
+    const evCopy = v.evidence ? JSON.parse(JSON.stringify(v.evidence)) : {};
+    delete evCopy.bureau;
+    const evKey = detailClean || JSON.stringify(evCopy);
     const id = v.id || v.code || "";
     const bureaus = v.bureaus || [v.evidence?.bureau || v.bureau || m[1]].filter(Boolean);
     const list = bureaus.length ? bureaus : [""];
+    const explicitBureaus = Array.isArray(v.bureaus);
 
     list.forEach(bureau => {
-      const key = `${id}|${v.category||""}|${base}|${evKey}|${bureau}`;
+      const key = `${id}|${v.category||""}|${base}|${evKey}${explicitBureaus ? `|${bureau}` : ''}`;
       if(!map.has(key)) map.set(key,{category:v.category,title:base,bureaus:new Set(),details:new Set(),severity:v.severity||0});
       const entry = map.get(key);
       if(bureau) entry.bureaus.add(bureau);

--- a/metro2 (copy 1)/crm/tests/violationMapping.test.js
+++ b/metro2 (copy 1)/crm/tests/violationMapping.test.js
@@ -12,7 +12,7 @@ test('filterViolationsBySeverity prioritizes high severity', () => {
   assert.equal(filtered[0].code, 'MISSING_DOFD');
 });
 
-test('mergeBureauViolations keeps violations separate per bureau', async () => {
+test('mergeBureauViolations consolidates violations differing only by bureau', async () => {
   const stubEl = {};
   stubEl.addEventListener = () => {};
   stubEl.classList = { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} };
@@ -55,8 +55,8 @@ test('mergeBureauViolations keeps violations separate per bureau', async () => {
     }
   ];
   const merged = mergeBureauViolations(input);
-  assert.equal(merged.length, 2);
-  assert.deepEqual(merged.map(v=>v.bureaus), [['TransUnion'], ['Experian']]);
+  assert.equal(merged.length, 1);
+  assert.deepEqual(merged[0].bureaus.sort(), ['Experian','TransUnion']);
 });
 
 test('mergeBureauViolations splits violations with bureaus array', async () => {


### PR DESCRIPTION
## Summary
- ignore bureau field when keying violations so identical issues across bureaus merge
- add regression test for cross-bureau consolidation

## Testing
- `node --test tests/violationMapping.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4545af3f8832391be2da2de111d83