### PR TITLE
feat: integrate metro2 audit violations into tradelines

### DIFF
--- a/metro2 (copy 1)/crm/tests/pullTradelineData.test.js
+++ b/metro2 (copy 1)/crm/tests/pullTradelineData.test.js
@@ -7,10 +7,20 @@ const SAMPLE_HTML = `<html><body><td class="ng-binding"><div class="sub_header">
 test('pullTradelineData parses and enriches tradelines', async () => {
   const fakeFetch = async () => ({ ok: true, text: async () => SAMPLE_HTML });
   const overrides = { 'Test Creditor': { date_opened: '01/01/2020' } };
-  const report = await pullTradelineData({ apiUrl: 'http://example.com', fetchImpl: fakeFetch, overrides });
+  const fakeAudit = async () => ({
+    tradelines: [
+      {
+        violations: [{ id: 'V1', title: 'Fake Violation' }],
+        violations_grouped: { Test: [{ id: 'V1', title: 'Fake Violation' }] }
+      }
+    ]
+  });
+  const report = await pullTradelineData({ apiUrl: 'http://example.com', fetchImpl: fakeFetch, overrides, auditImpl: fakeAudit });
   const tl = report.tradelines[0];
   assert.equal(tl.meta.creditor, 'Test Creditor');
   assert.equal(tl.per_bureau.TransUnion.account_number, '1234');
   assert.equal(tl.per_bureau.Experian.date_opened, '01/01/2020');
   assert.equal(tl.per_bureau.Equifax.date_opened, '01/01/2020');
+  assert.deepEqual(tl.violations, [{ id: 'V1', title: 'Fake Violation' }]);
+  assert.deepEqual(tl.violations_grouped, { Test: [{ id: 'V1', title: 'Fake Violation' }] });
 });


### PR DESCRIPTION
## Summary
- invoke `metro2_audit_multi.py` inside `pullTradelineData` to analyze fetched reports
- merge audit `violations` and `violations_grouped` into each tradeline
- test coverage for merged violation fields

## Testing
- `node --test tests/pullTradelineData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c457f0cf508323bfb34eef5cf99009