### PR TITLE
Enrich tradelines with bureau account numbers for filtering

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -612,7 +612,7 @@ function renderTradelines(tradelines){
     const pb = tl.per_bureau || {};
     const hasBureauData = ["TransUnion","Experian","Equifax"]
       .some(b => Object.keys(pb[b] || {}).length);
-    const hasAcct = Object.values(tl.meta?.account_numbers || {}).some(v => v);
+    const hasAcct = Object.values(pb).some(b => b?.account_number);
     const hasVios = (tl.violations || []).length > 0;
     if (!hasBureauData && !hasAcct && !hasVios) return;
 

--- a/metro2 (copy 1)/crm/pullTradelineData.js
+++ b/metro2 (copy 1)/crm/pullTradelineData.js
@@ -49,6 +49,14 @@ async function pullTradelineData({ apiUrl, fetchImpl = fetch, overrides = {} }) 
   for (const tl of report.tradelines || []) {
     const ov = overrides[tl.meta?.creditor] || {};
     enrichTradeline(tl, ov);
+    tl.meta = tl.meta || {};
+    tl.meta.account_numbers = tl.meta.account_numbers || {};
+    for (const b of ALL_BUREAUS) {
+      const acct = tl.per_bureau?.[b]?.account_number;
+      if (acct && !tl.meta.account_numbers[b]) {
+        tl.meta.account_numbers[b] = acct;
+      }
+    }
   }
   return report;
 }


### PR DESCRIPTION
## Summary
- Build `meta.account_numbers` during data pull so each bureau's account number is available for downstream tools.
- Derive tradeline account-number presence from `per_bureau` data to avoid filtering out valid entries.

## Testing
- `timeout 60 npm test` *(fails: command timed out after 60s; partial output shows initial tests pass)*


------
https://chatgpt.com/codex/tasks/task_e_68c457e9174c8323882267adb7dc9bfb