### PR TITLE
Skip DOFD rule for empty tradelines

### DIFF
--- a/metro2 (copy 1)/crm/metro2_audit_multi.py
+++ b/metro2 (copy 1)/crm/metro2_audit_multi.py
@@ -432,6 +432,8 @@ def r_cross_bureau_utilization_disparity(ctx, add):
 
 @rule("MISSING_DOFD", "Dates")
 def r_missing_dofd(ctx, bureau, data, add):
+    if not (data.get("account_number") or data.get("balance")):
+        return
     if not data.get("date_first_delinquency"):
         add(make_violation("Dates",
                            f"Missing Date of First Delinquency ({bureau})",

--- a/metro2 (copy 1)/crm/tests/test_metro2_audit_multi.py
+++ b/metro2 (copy 1)/crm/tests/test_metro2_audit_multi.py
@@ -1,0 +1,14 @@
+import unittest
+
+import metro2_audit_multi as m2
+
+
+class TestMissingDOFD(unittest.TestCase):
+    def test_empty_tradeline_skipped(self):
+        violations = []
+        m2.r_missing_dofd({}, "Experian", {}, violations.append)
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip missing-DOFD rule when tradeline lacks key identifiers like account number or balance
- add regression test to ensure empty tradelines are ignored

## Testing
- `npm test` (fails: process hangs waiting for shutdown)
- `python -m unittest tests/test_metro2_audit_multi.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68c45f74d3c88323930d0001bf5877be