### PR TITLE
Handle "Last Payment Date" label in parser

### DIFF
--- a/metro2 (copy 1)/crm/parser.js
+++ b/metro2 (copy 1)/crm/parser.js
@@ -69,7 +69,7 @@ function parseCreditReportHTML(doc) {
       rule("Past Due", ["past_due"]),
       rule("Date Opened", ["date_opened"]),
       rule("Last Reported", ["last_reported"]),
-      rule(/Date(?: of)? Last Payment/i, ["date_last_payment"]),
+      rule(/(Date\s*of\s*)?Last Payment(?:\s*Date)?/i, ["date_last_payment"]),
       rule("Date Last Active", ["date_last_active"]),
       rule("No. of Months (terms)", ["months_terms"]),
 

--- a/metro2 (copy 1)/crm/tests/parserDateLastPayment.test.js
+++ b/metro2 (copy 1)/crm/tests/parserDateLastPayment.test.js
@@ -19,3 +19,21 @@ test('parses Date of Last Payment label', () => {
   const { tradelines } = parseCreditReportHTML(dom.window.document);
   assert.equal(tradelines[0].per_bureau.TransUnion.date_last_payment, '01/02/2023');
 });
+
+
+test('parses Last Payment Date label', () => {
+  const html = `
+    <table class="rpt_content_table rpt_content_header rpt_table4column">
+      <tbody>
+        <tr><th></th><th>TransUnion</th></tr>
+        <tr>
+          <td class="label">Last Payment Date:</td>
+          <td class="info">01/02/2023</td>
+        </tr>
+      </tbody>
+    </table>
+  `;
+  const dom = new JSDOM(html);
+  const { tradelines } = parseCreditReportHTML(dom.window.document);
+  assert.equal(tradelines[0].per_bureau.TransUnion.date_last_payment, '01/02/2023');
+});


### PR DESCRIPTION
## Summary
- broaden last payment parser rule to match both "Date of Last Payment" and "Last Payment Date"
- add regression test for "Last Payment Date:" label

## Testing
- `node --test tests/parserDateLastPayment.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c45f72c5e48323b68eea77a3adfb13