### PR TITLE
Parse Date First Delinquency in credit report parser

### DIFF
--- a/metro2 (copy 1)/crm/parser.js
+++ b/metro2 (copy 1)/crm/parser.js
@@ -71,13 +71,18 @@ function parseCreditReportHTML(doc) {
       rule("Last Reported", ["last_reported"]),
       rule(/Date(?: of)? Last Payment/i, ["date_last_payment"]),
       rule("Date Last Active", ["date_last_active"]),
+      rule(/Date(?: of)? First Delinquency/i, ["date_first_delinquency"]),
       rule("No. of Months (terms)", ["months_terms"]),
 
       // combined rows
       rule("Account Status / Payment Status", ["account_status", "payment_status"], "combined"),
       rule("Balance / Past Due", ["balance", "past_due"], "combined"),
       rule("Credit Limit / High Credit", ["credit_limit", "high_credit"], "combined"),
-      rule("Dates", ["date_opened", "last_reported", "date_last_payment"], "combined"),
+      rule(
+        "Dates",
+        ["date_opened", "last_reported", "date_last_payment", "date_first_delinquency"],
+        "combined"
+      ),
 
       // comments row
       rule("Comments", ["comments"], "comments"),

--- a/metro2 (copy 1)/crm/tests/parserDateFirstDelinquency.test.js
+++ b/metro2 (copy 1)/crm/tests/parserDateFirstDelinquency.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { parseCreditReportHTML } from '../parser.js';
+
+test('parses Date of First Delinquency label', () => {
+  const html = `
+    <table class="rpt_content_table rpt_content_header rpt_table4column">
+      <tbody>
+        <tr><th></th><th>TransUnion</th></tr>
+        <tr>
+          <td class="label">Date of First Delinquency:</td>
+          <td class="info">02/03/2024</td>
+        </tr>
+      </tbody>
+    </table>
+  `;
+  const dom = new JSDOM(html);
+  const { tradelines } = parseCreditReportHTML(dom.window.document);
+  assert.equal(tradelines[0].per_bureau.TransUnion.date_first_delinquency, '02/03/2024');
+});


### PR DESCRIPTION
## Summary
- parse "Date of First Delinquency" fields in single and combined "Dates" rows
- test parser populates `date_first_delinquency`

## Testing
- `node --test tests/parserInquiries.test.js tests/parserDateLastPayment.test.js tests/parserDateFirstDelinquency.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c45f66925c8323b60b3fee734e56aa