### PR TITLE
Audit tradelines on upload and add integration test

### DIFF
--- a/metro2 (copy 1)/crm/data/report.html
+++ b/metro2 (copy 1)/crm/data/report.html
@@ -1,0 +1,11 @@
+<html><body>
+  <td class="ng-binding">
+    <div class="sub_header">Test Creditor</div>
+    <table class="rpt_content_table rpt_content_header rpt_table4column">
+      <tr><th></th><th>TransUnion</th><th>Experian</th><th>Equifax</th></tr>
+      <tr><td class="label">Account #:</td><td class="info">1234</td><td class="info">1234</td><td class="info">1234</td></tr>
+      <tr><td class="label">Account Status:</td><td class="info">Current</td><td class="info"></td><td class="info"></td></tr>
+      <tr><td class="label">Past Due:</td><td class="info">$100</td><td class="info"></td><td class="info"></td></tr>
+    </table>
+  </td>
+</body></html>

--- a/metro2 (copy 1)/crm/tests/uploadReport.test.js
+++ b/metro2 (copy 1)/crm/tests/uploadReport.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import request from 'supertest';
+import fs from 'node:fs/promises';
+
+process.env.NODE_ENV = 'test';
+const { default: app } = await import('../server.js');
+
+const reportPath = new URL('../data/report.html', import.meta.url);
+
+test('uploading a report populates violations', async () => {
+  const reportHtml = await fs.readFile(reportPath);
+  const create = await request(app).post('/api/consumers').send({ name: 'Test User' });
+  assert.equal(create.status, 200);
+  const id = create.body.consumer.id;
+
+  const upload = await request(app)
+    .post(`/api/consumers/${id}/upload`)
+    .attach('file', reportHtml, 'report.html');
+  assert.equal(upload.status, 200);
+  const rid = upload.body.reportId;
+  assert.ok(rid);
+
+  const fetched = await request(app).get(`/api/consumers/${id}/report/${rid}`);
+  assert.equal(fetched.status, 200);
+  const tlines = fetched.body.report.tradelines || [];
+  const has = tlines.some(tl => (tl.violations || []).length > 0);
+  assert.equal(has, true);
+});


### PR DESCRIPTION
## Summary
- Run Python analyzer after JS parsing and merge results, logging failures
- Add simple Metro-2 rule check for past-due accounts marked current
- Provide sample report and integration test ensuring violations are returned

## Testing
- `node --test tests/uploadReport.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c46647546c832381e19b87df6fe22a