### PR TITLE
test: verify violation metadata enrichment

### DIFF
--- a/metro2 (copy 1)/crm/metro2_audit_multi.py
+++ b/metro2 (copy 1)/crm/metro2_audit_multi.py
@@ -80,22 +80,28 @@ SEVERITY = {
 TODAY = date.today().isoformat()
 
 # Load violation metadata for enrichment
-_VIOLATION_DATA_PATH = os.path.join(
-    os.path.dirname(__file__), "data", "metro2Violations.json"
-)
-try:
-    with open(_VIOLATION_DATA_PATH, "r", encoding="utf-8") as f:
-        _raw = json.load(f)
-        if isinstance(_raw, dict):
-            VIOLATION_META = _raw
-        else:
-            VIOLATION_META = {}
-            for itm in _raw:
-                key = itm.get("id") or itm.get("key") or itm.get("title")
-                if key:
-                    VIOLATION_META[key] = itm
-except Exception:
-    VIOLATION_META = {}
+_BASE_DIR = os.path.dirname(__file__)
+_VIOLATION_PATHS = [
+    os.path.join(_BASE_DIR, "metro2Violations.json"),
+    os.path.join(_BASE_DIR, "data", "metro2Violations.json"),
+]
+VIOLATION_META = {}
+for _VIOLATION_DATA_PATH in _VIOLATION_PATHS:
+    if not os.path.exists(_VIOLATION_DATA_PATH):
+        continue
+    try:
+        with open(_VIOLATION_DATA_PATH, "r", encoding="utf-8") as f:
+            _raw = json.load(f)
+            if isinstance(_raw, dict):
+                VIOLATION_META = _raw
+            else:
+                for itm in _raw:
+                    key = itm.get("id") or itm.get("key") or itm.get("title")
+                    if key:
+                        VIOLATION_META[key] = itm
+            break
+    except Exception:
+        continue
 
 _CURRENT_RULE_ID = None
 

--- a/metro2 (copy 1)/crm/tests/test_metro2_audit_multi.py
+++ b/metro2 (copy 1)/crm/tests/test_metro2_audit_multi.py
@@ -9,6 +9,25 @@ class TestMissingDOFD(unittest.TestCase):
         m2.r_missing_dofd({}, "Experian", {}, violations.append)
         self.assertEqual(violations, [])
 
+    def test_enriched_violation_has_severity_and_fcra(self):
+        violations = []
+        # Simulate rule execution context
+        m2._CURRENT_RULE_ID = "MISSING_DOFD"
+        m2.r_missing_dofd({}, "Experian", {"account_number": "1", "balance": 50}, violations.append)
+        m2._CURRENT_RULE_ID = None
+        self.assertEqual(len(violations), 1)
+        v = violations[0]
+        self.assertEqual(v["severity"], 5)
+        self.assertEqual(v["fcraSection"], "§ 623(a)(5)")
+
+    def test_unknown_rule_falls_back(self):
+        # Directly create violation with unknown code
+        m2._CURRENT_RULE_ID = "UNKNOWN_RULE"
+        v = m2.make_violation("Dates", "Unknown", "", {})
+        m2._CURRENT_RULE_ID = None
+        self.assertNotIn("fcraSection", v)
+        self.assertEqual(v["severity"], m2.SEVERITY["Dates"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/metro2 (copy 1)/crm/tests/violationMetadata.test.js
+++ b/metro2 (copy 1)/crm/tests/violationMetadata.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { filterViolationsBySeverity } from '../letterEngine.js';
+
+test('enriches MISSING_DOFD with severity and FCRA section', () => {
+  const result = filterViolationsBySeverity([{ code: 'MISSING_DOFD' }]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].severity, 5);
+  assert.equal(result[0].fcraSection, '§ 623(a)(5)');
+});
+
+test('unknown violation codes fall back gracefully', () => {
+  const result = filterViolationsBySeverity([{ code: 'UNKNOWN_RULE' }]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].severity, 1);
+  assert.ok(!('fcraSection' in result[0]));
+});
+


### PR DESCRIPTION
## Summary
- load violation metadata from shared metro2Violations.json with fallback to legacy data file
- add Python tests for MISSING_DOFD enrichment and unknown rule fallback
- add Node tests verifying metadata enrichment and graceful fallback for unknown codes

## Testing
- `node --test tests/violationMapping.test.js tests/violationMetadata.test.js`
- `python -m pytest tests/test_metro2_audit_multi.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4701c90d48323af96d649f6f0fc85