### PR TITLE
refactor: use rule-code keyed violations

### DIFF
--- a/metro2 (copy 1)/crm/data/metro2Violations.json
+++ b/metro2 (copy 1)/crm/data/metro2Violations.json
@@ -1,14 +1,14 @@
-[
-  {
+{
+  "MISSING_DOFD": {
     "id": 1,
     "violation": "Missing or invalid Date of First Delinquency",
     "fieldsImpacted": [
       "Date of First Delinquency"
     ],
     "severity": 5,
-    "fcraSection": "\u00a7 623(a)(5)"
+    "fcraSection": "§ 623(a)(5)"
   },
-  {
+  "LATE_STATUS_NO_PASTDUE": {
     "id": 2,
     "violation": "Payment history inconsistent with status",
     "fieldsImpacted": [
@@ -16,27 +16,27 @@
       "Account Status"
     ],
     "severity": 4,
-    "fcraSection": "\u00a7 607(b)"
+    "fcraSection": "§ 607(b)"
   },
-  {
+  "3": {
     "id": 3,
     "violation": "Account reported as open after closure",
     "fieldsImpacted": [
       "Account Status"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(2)"
+    "fcraSection": "§ 623(a)(2)"
   },
-  {
+  "SL_NO_LATES_DURING_DEFERMENT": {
     "id": 4,
     "violation": "Late payment reported after account paid",
     "fieldsImpacted": [
       "Payment History"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 607(b)"
+    "fcraSection": "§ 607(b)"
   },
-  {
+  "OPEN_ZERO_CL_WITH_HC_COMMENT": {
     "id": 5,
     "violation": "Balance reported greater than credit limit",
     "fieldsImpacted": [
@@ -44,9 +44,9 @@
       "Credit Limit"
     ],
     "severity": 4,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "INSTALLMENT_WITH_CL": {
     "id": 6,
     "violation": "Incorrect high credit/limit for installment loan",
     "fieldsImpacted": [
@@ -54,9 +54,9 @@
       "Credit Limit"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "DEROG_RATING_BUT_CURRENT": {
     "id": 7,
     "violation": "Payment rating inconsistent with account status",
     "fieldsImpacted": [
@@ -64,9 +64,9 @@
       "Account Status"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "8": {
     "id": 8,
     "violation": "Charge-off lacks required DOFD",
     "fieldsImpacted": [
@@ -74,36 +74,36 @@
       "Charge-Off"
     ],
     "severity": 5,
-    "fcraSection": "\u00a7 623(a)(5)"
+    "fcraSection": "§ 623(a)(5)"
   },
-  {
+  "9": {
     "id": 9,
     "violation": "Missing original creditor name on collection account",
     "fieldsImpacted": [
       "Creditor Name"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "10": {
     "id": 10,
     "violation": "Duplicate account reported",
     "fieldsImpacted": [
       "Account Number"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 607(b)"
+    "fcraSection": "§ 607(b)"
   },
-  {
+  "REVOLVING_WITH_TERMS": {
     "id": 11,
     "violation": "Wrong account type (revolving vs installment)",
     "fieldsImpacted": [
       "Account Type"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 607(b)"
+    "fcraSection": "§ 607(b)"
   },
-  {
+  "CURRENT_BUT_PASTDUE": {
     "id": 12,
     "violation": "Past due amount reported on current account",
     "fieldsImpacted": [
@@ -111,9 +111,9 @@
       "Account Status"
     ],
     "severity": 4,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "13": {
     "id": 13,
     "violation": "Account re-aged without proof",
     "fieldsImpacted": [
@@ -121,99 +121,99 @@
       "Payment History"
     ],
     "severity": 4,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "14": {
     "id": 14,
     "violation": "Inaccurate last payment date",
     "fieldsImpacted": [
       "Last Payment Date"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(2)"
+    "fcraSection": "§ 623(a)(2)"
   },
-  {
+  "15": {
     "id": 15,
     "violation": "Inaccurate account status code",
     "fieldsImpacted": [
       "Account Status"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "16": {
     "id": 16,
     "violation": "Balance reported after bankruptcy discharge",
     "fieldsImpacted": [
       "Balance"
     ],
     "severity": 5,
-    "fcraSection": "\u00a7 607(b)"
+    "fcraSection": "§ 607(b)"
   },
-  {
+  "17": {
     "id": 17,
     "violation": "Account reported as active after settlement",
     "fieldsImpacted": [
       "Account Status"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "18": {
     "id": 18,
     "violation": "Payment history reported after account closed",
     "fieldsImpacted": [
       "Payment History"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 607(b)"
+    "fcraSection": "§ 607(b)"
   },
-  {
+  "REVOLVING_NO_CL_OR_HC": {
     "id": 19,
     "violation": "Missing credit limit for revolving account",
     "fieldsImpacted": [
       "Credit Limit"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "20": {
     "id": 20,
     "violation": "Missing current balance",
     "fieldsImpacted": [
       "Balance"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "21": {
     "id": 21,
     "violation": "Consumer statement omitted",
     "fieldsImpacted": [
       "Consumer Statement"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 609(c)"
+    "fcraSection": "§ 609(c)"
   },
-  {
+  "DISPUTE_COMMENT_NEEDS_XB": {
     "id": 22,
     "violation": "Dispute flag missing when account disputed",
     "fieldsImpacted": [
       "Dispute Flag"
     ],
     "severity": 4,
-    "fcraSection": "\u00a7 623(a)(3)"
+    "fcraSection": "§ 623(a)(3)"
   },
-  {
+  "23": {
     "id": 23,
     "violation": "Dispute flag left after dispute resolved",
     "fieldsImpacted": [
       "Dispute Flag"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(3)"
+    "fcraSection": "§ 623(a)(3)"
   },
-  {
+  "24": {
     "id": 24,
     "violation": "Account opened date after last payment date",
     "fieldsImpacted": [
@@ -221,9 +221,9 @@
       "Last Payment Date"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "DATE_ORDER_SANITY": {
     "id": 25,
     "violation": "Last reported date before date opened",
     "fieldsImpacted": [
@@ -231,9 +231,9 @@
       "Date Opened"
     ],
     "severity": 4,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "CO_OR_COLLECTION_PASTDUE": {
     "id": 26,
     "violation": "Charge-off amount differs from balance",
     "fieldsImpacted": [
@@ -241,72 +241,72 @@
       "Balance"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "27": {
     "id": 27,
     "violation": "Missing creditor classification code",
     "fieldsImpacted": [
       "Creditor Classification"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "AU_COMMENT_ECOA_CONFLICT": {
     "id": 28,
     "violation": "Ownership code incorrect",
     "fieldsImpacted": [
       "Ownership Code"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "29": {
     "id": 29,
     "violation": "Debt reported as joint when individual",
     "fieldsImpacted": [
       "Ownership Code"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "30": {
     "id": 30,
     "violation": "Missing Terms Duration for installment account",
     "fieldsImpacted": [
       "Terms Duration"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "CLOSED_BUT_MONTHLY_PAYMENT": {
     "id": 31,
     "violation": "Inaccurate scheduled monthly payment",
     "fieldsImpacted": [
       "Scheduled Monthly Payment"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "32": {
     "id": 32,
     "violation": "Portfolio type missing for collection",
     "fieldsImpacted": [
       "Portfolio Type"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "33": {
     "id": 33,
     "violation": "Inaccurate collateral code",
     "fieldsImpacted": [
       "Collateral"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "34": {
     "id": 34,
     "violation": "Account reported as repossessed but balance >0",
     "fieldsImpacted": [
@@ -314,27 +314,27 @@
       "Balance"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "35": {
     "id": 35,
     "violation": "Missing ECOA code",
     "fieldsImpacted": [
       "ECOA Code"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "36": {
     "id": 36,
     "violation": "Payment history blocks incorrect",
     "fieldsImpacted": [
       "Payment History"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 607(b)"
+    "fcraSection": "§ 607(b)"
   },
-  {
+  "STALE_ACTIVE_REPORTING": {
     "id": 37,
     "violation": "Date of last activity inconsistent with status",
     "fieldsImpacted": [
@@ -342,27 +342,27 @@
       "Account Status"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "38": {
     "id": 38,
     "violation": "Incorrect MOP code",
     "fieldsImpacted": [
       "MOP"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "39": {
     "id": 39,
     "violation": "Missing Special Comment code for paid collection",
     "fieldsImpacted": [
       "Special Comment"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "DOFD_OBSOLETE_7Y": {
     "id": 40,
     "violation": "Obsolete account still reporting",
     "fieldsImpacted": [
@@ -370,9 +370,9 @@
       "Status"
     ],
     "severity": 5,
-    "fcraSection": "\u00a7 605(a)"
+    "fcraSection": "§ 605(a)"
   },
-  {
+  "ZERO_BALANCE_BUT_PASTDUE": {
     "id": 41,
     "violation": "Closed account shows past due",
     "fieldsImpacted": [
@@ -380,9 +380,9 @@
       "Past Due"
     ],
     "severity": 4,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "42": {
     "id": 42,
     "violation": "Account transferred but still reporting balance",
     "fieldsImpacted": [
@@ -390,79 +390,500 @@
       "Balance"
     ],
     "severity": 4,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "43": {
     "id": 43,
     "violation": "Missing bankruptcy chapter",
     "fieldsImpacted": [
       "Bankruptcy Chapter"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "44": {
     "id": 44,
     "violation": "Wrong currency code",
     "fieldsImpacted": [
       "Currency Code"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "X_BUREAU_FIELD_MISMATCH": {
     "id": 45,
     "violation": "Account status inconsistent across bureaus",
     "fieldsImpacted": [
       "Account Status"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "X_BUREAU_UTIL_DISPARITY": {
     "id": 46,
     "violation": "Inaccurate charge-off date",
     "fieldsImpacted": [
       "Charge-Off Date"
     ],
     "severity": 4,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "47": {
     "id": 47,
     "violation": "Missing first delinquency date on collection",
     "fieldsImpacted": [
       "Date of First Delinquency"
     ],
     "severity": 5,
-    "fcraSection": "\u00a7 623(a)(5)"
+    "fcraSection": "§ 623(a)(5)"
   },
-  {
+  "48": {
     "id": 48,
     "violation": "Inaccurate original loan amount",
     "fieldsImpacted": [
       "Original Loan Amount"
     ],
     "severity": 3,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "49": {
     "id": 49,
     "violation": "Missing secured indicator",
     "fieldsImpacted": [
       "Secured Indicator"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)"
   },
-  {
+  "50": {
     "id": 50,
     "violation": "Incorrect FCRA compliance code",
     "fieldsImpacted": [
       "Compliance Code"
     ],
     "severity": 2,
-    "fcraSection": "\u00a7 607(b)"
+    "fcraSection": "§ 607(b)"
+  },
+  "51": {
+    "id": 51,
+    "violation": "Authorized user reported as individual or joint",
+    "fieldsImpacted": [
+      "ECOA Code",
+      "Ownership Code"
+    ],
+    "severity": 4,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), data must be maximally accurate. Reporting an authorized user as an individual or joint obligor misstates liability.",
+      "es": "Según la FCRA §607(b), los datos deben ser lo más exactos posible. Reportar a un usuario autorizado como deudor individual o conjunto tergiversa la responsabilidad."
+    }
+  },
+  "52": {
+    "id": 52,
+    "violation": "Consumer-closed account not labeled 'closed at consumer's request'",
+    "fieldsImpacted": [
+      "Account Status",
+      "Special Comment"
+    ],
+    "severity": 2,
+    "fcraSection": "§ 623(a)(2)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(2), furnishers must update information for accuracy. Failing to mark an account closed at consumer’s request misrepresents closure.",
+      "es": "Según la FCRA §623(a)(2), los proveedores deben actualizar la información para asegurar exactitud. No marcar una cuenta como cerrada por el consumidor tergiversa el cierre."
+    }
+  },
+  "53": {
+    "id": 53,
+    "violation": "Account sold/assigned but still reported with collectible balance",
+    "fieldsImpacted": [
+      "Account Status",
+      "Balance",
+      "Special Comment"
+    ],
+    "severity": 4,
+    "fcraSection": "§ 623(a)(2)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(2), once a debt is sold or transferred, the original account must reflect $0 balance and transfer notation.",
+      "es": "Según la FCRA §623(a)(2), una vez que se vende o se transfiere una deuda, la cuenta original debe reflejar saldo $0 y la anotación de transferencia."
+    }
+  },
+  "54": {
+    "id": 54,
+    "violation": "Paid charge-off still reporting non-zero balance",
+    "fieldsImpacted": [
+      "Balance",
+      "Special Comment"
+    ],
+    "severity": 4,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), furnishers must maintain accuracy. A paid charge-off must show $0 balance.",
+      "es": "Según la FCRA §607(b), los proveedores deben mantener exactitud. Una cuenta castigada pagada debe mostrar saldo $0."
+    }
+  },
+  "55": {
+    "id": 55,
+    "violation": "Settlement not reflected ('settled for less than full balance' missing)",
+    "fieldsImpacted": [
+      "Account Status",
+      "Special Comment",
+      "Balance"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 623(a)(2)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(2), furnishers must update settled debts. Accounts should reflect 'settled for less' when applicable.",
+      "es": "Según la FCRA §623(a)(2), los proveedores deben actualizar deudas liquidadas. Las cuentas deben reflejar 'liquidada por menos' cuando corresponda."
+    }
+  },
+  "56": {
+    "id": 56,
+    "violation": "Collection account includes payment history grid",
+    "fieldsImpacted": [
+      "Payment History",
+      "Portfolio Type"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), data must not mislead. Collections should not carry monthly payment grids.",
+      "es": "Según la FCRA §607(b), los datos no deben inducir a error. Las cobranzas no deben incluir historiales de pago mensuales."
+    }
+  },
+  "57": {
+    "id": 57,
+    "violation": "Date closed missing or inconsistent with status",
+    "fieldsImpacted": [
+      "Date Closed",
+      "Account Status"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 623(a)(1)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(1), accuracy requires closure dates to align with status. Missing or inconsistent dates are misleading.",
+      "es": "Según la FCRA §623(a)(1), la exactitud requiere que las fechas de cierre coincidan con el estado. Las fechas faltantes o inconsistentes son engañosas."
+    }
+  },
+  "58": {
+    "id": 58,
+    "violation": "Date closed precedes date opened",
+    "fieldsImpacted": [
+      "Date Closed",
+      "Date Opened"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), dates must be consistent. A closure date earlier than the open date is impossible and inaccurate.",
+      "es": "Según la FCRA §607(b), las fechas deben ser consistentes. Una fecha de cierre anterior a la de apertura es imposible e inexacta."
+    }
+  },
+  "59": {
+    "id": 59,
+    "violation": "High credit missing for charge card (no preset limit)",
+    "fieldsImpacted": [
+      "High Credit",
+      "Credit Limit",
+      "Account Type"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), furnishers must provide complete data. Charge cards require reporting of highest balance used.",
+      "es": "Según la FCRA §607(b), los proveedores deben proporcionar datos completos. Las tarjetas de cargo requieren reportar el saldo más alto usado."
+    }
+  },
+  "60": {
+    "id": 60,
+    "violation": "Terms frequency/duration missing on installment loan",
+    "fieldsImpacted": [
+      "Terms Frequency",
+      "Terms Duration"
+    ],
+    "severity": 2,
+    "fcraSection": "§ 623(a)(1)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(1), furnishers must report accurate account terms. Missing term details make the loan misleading.",
+      "es": "Según la FCRA §623(a)(1), los proveedores deben reportar términos precisos de la cuenta. La falta de términos hace que el préstamo sea engañoso."
+    }
+  },
+  "61": {
+    "id": 61,
+    "violation": "Scheduled payment amount reported after payoff",
+    "fieldsImpacted": [
+      "Scheduled Monthly Payment",
+      "Account Status"
+    ],
+    "severity": 2,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), reporting a scheduled payment after payoff is inaccurate and must be corrected.",
+      "es": "Según la FCRA §607(b), reportar un pago programado después de liquidar la deuda es inexacto y debe corregirse."
+    }
+  },
+  "62": {
+    "id": 62,
+    "violation": "Post-discharge late codes on bankruptcy accounts",
+    "fieldsImpacted": [
+      "Payment History",
+      "Special Comment",
+      "Balance"
+    ],
+    "severity": 5,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), reporting new lates after bankruptcy discharge misrepresents liability and must be removed.",
+      "es": "Según la FCRA §607(b), reportar nuevas moras después de una descarga de bancarrota tergiversa la obligación y debe eliminarse."
+    }
+  },
+  "63": {
+    "id": 63,
+    "violation": "Bankruptcy included account not coded with correct CII/remark",
+    "fieldsImpacted": [
+      "Consumer Information Indicator",
+      "Special Comment"
+    ],
+    "severity": 4,
+    "fcraSection": "§ 623(a)(2)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(2), bankruptcy-included accounts must be updated with proper coding. Omission misleads about liability.",
+      "es": "Según la FCRA §623(a)(2), las cuentas incluidas en la bancarrota deben actualizarse con el código apropiado. La omisión confunde sobre la obligación."
+    }
+  },
+  "64": {
+    "id": 64,
+    "violation": "Reaffirmed debt not identified post-bankruptcy",
+    "fieldsImpacted": [
+      "Special Comment",
+      "Consumer Information Indicator"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 623(a)(2)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(2), reaffirmed debts must be identified clearly after bankruptcy.",
+      "es": "Según la FCRA §623(a)(2), las deudas reafirmadas deben identificarse claramente después de la bancarrota."
+    }
+  },
+  "65": {
+    "id": 65,
+    "violation": "Natural disaster forbearance not coded (CII 'D')",
+    "fieldsImpacted": [
+      "Consumer Information Indicator",
+      "Special Comment"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 623(a)(2)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(2), furnishers must update accounts in forbearance due to natural disaster with proper indicator.",
+      "es": "Según la FCRA §623(a)(2), los proveedores deben actualizar las cuentas en indulgencia por desastre natural con el indicador apropiado."
+    }
+  },
+  "66": {
+    "id": 66,
+    "violation": "Active duty alert/indicator omitted when provided",
+    "fieldsImpacted": [
+      "Consumer Information Indicator"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 605A",
+    "snippets": {
+      "en": "Per FCRA §605A, CRAs must honor requests for active duty alerts. Omission fails to protect service members.",
+      "es": "Según la FCRA §605A, las agencias deben cumplir con las alertas de servicio activo. La omisión no protege a los miembros del servicio."
+    }
+  },
+  "67": {
+    "id": 67,
+    "violation": "Deceased indicator used without verification",
+    "fieldsImpacted": [
+      "Consumer Information Indicator"
+    ],
+    "severity": 5,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), furnishers must not report a consumer as deceased without verified evidence.",
+      "es": "Según la FCRA §607(b), los proveedores no deben reportar a un consumidor como fallecido sin evidencia verificada."
+    }
+  },
+  "68": {
+    "id": 68,
+    "violation": "Inconsistent DOFD across multiple tradelines of same debt",
+    "fieldsImpacted": [
+      "Date of First Delinquency"
+    ],
+    "severity": 4,
+    "fcraSection": "§ 623(a)(5)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(5), all tradelines for the same debt must share the same DOFD. Inconsistencies unlawfully extend reporting.",
+      "es": "Según la FCRA §623(a)(5), todas las líneas de crédito de la misma deuda deben compartir la misma DOFD. Las inconsistencias extienden ilegalmente el reporte."
+    }
+  },
+  "69": {
+    "id": 69,
+    "violation": "Charge-off continues accruing new delinquencies",
+    "fieldsImpacted": [
+      "Payment History",
+      "Account Status"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), once charged-off, accounts should not accumulate new late codes.",
+      "es": "Según la FCRA §607(b), una vez castigadas, las cuentas no deben acumular nuevas moras."
+    }
+  },
+  "70": {
+    "id": 70,
+    "violation": "Interest/fees accruing after charge-off not reflected correctly",
+    "fieldsImpacted": [
+      "Balance",
+      "Charge-Off Amount",
+      "Special Comment"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), furnishers must reflect accurate balances. Improper handling of interest/fees post-charge-off misleads.",
+      "es": "Según la FCRA §607(b), los proveedores deben reflejar saldos exactos. El manejo inadecuado de intereses/cargos después del castigo es engañoso."
+    }
+  },
+  "71": {
+    "id": 71,
+    "violation": "Original creditor name missing on sold/collection debt",
+    "fieldsImpacted": [
+      "Creditor Name",
+      "Portfolio Type"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 623(a)(1)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(1), collections must identify the original creditor. Omission prevents proper verification.",
+      "es": "Según la FCRA §623(a)(1), las cobranzas deben identificar al acreedor original. La omisión impide la verificación adecuada."
+    }
+  },
+  "72": {
+    "id": 72,
+    "violation": "Portfolio type inconsistent with account type",
+    "fieldsImpacted": [
+      "Portfolio Type",
+      "Account Type"
+    ],
+    "severity": 2,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), data must be consistent. Portfolio type must align with account type.",
+      "es": "Según la FCRA §607(b), los datos deben ser consistentes. El tipo de portafolio debe coincidir con el tipo de cuenta."
+    }
+  },
+  "73": {
+    "id": 73,
+    "violation": "Collateral/secured indicator conflicts with account type",
+    "fieldsImpacted": [
+      "Collateral",
+      "Secured Indicator",
+      "Account Type"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), security indicators must align with account type. Conflicts indicate inaccurate reporting.",
+      "es": "Según la FCRA §607(b), los indicadores de garantía deben coincidir con el tipo de cuenta. Los conflictos indican un reporte inexacto."
+    }
+  },
+  "74": {
+    "id": 74,
+    "violation": "Missing or invalid creditor classification (industry) code",
+    "fieldsImpacted": [
+      "Creditor Classification"
+    ],
+    "severity": 2,
+    "fcraSection": "§ 623(a)(1)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(1), creditor classification must be reported correctly. Missing or invalid codes impair accuracy.",
+      "es": "Según la FCRA §623(a)(1), la clasificación del acreedor debe reportarse correctamente. Los códigos faltantes o inválidos afectan la exactitud."
+    }
+  },
+  "75": {
+    "id": 75,
+    "violation": "Narrative/Special Comment contradicts status (e.g., 'paid' but shows past due)",
+    "fieldsImpacted": [
+      "Special Comment",
+      "Account Status",
+      "Past Due"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), remarks must not conflict with status. Contradictions mislead lenders and consumers.",
+      "es": "Según la FCRA §607(b), los comentarios no deben contradecir el estado. Las contradicciones engañan a prestamistas y consumidores."
+    }
+  },
+  "76": {
+    "id": 76,
+    "violation": "Last reported date not refreshed after material update",
+    "fieldsImpacted": [
+      "Last Reported"
+    ],
+    "severity": 2,
+    "fcraSection": "§ 623(a)(2)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(2), furnishers must update last reported date when data changes materially.",
+      "es": "Según la FCRA §623(a)(2), los proveedores deben actualizar la última fecha de reporte cuando los datos cambien materialmente."
+    }
+  },
+  "77": {
+    "id": 77,
+    "violation": "Date of account information (DAI) missing or stale",
+    "fieldsImpacted": [
+      "Date of Account Information"
+    ],
+    "severity": 2,
+    "fcraSection": "§ 623(a)(2)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(2), furnishers must provide current account information dates for accuracy.",
+      "es": "Según la FCRA §623(a)(2), los proveedores deben proporcionar fechas actuales de información de cuenta para exactitud."
+    }
+  },
+  "78": {
+    "id": 78,
+    "violation": "Past-due amount reported on closed, $0 balance account",
+    "fieldsImpacted": [
+      "Past Due",
+      "Account Status",
+      "Balance"
+    ],
+    "severity": 4,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), closed accounts with $0 balance cannot show a past-due amount.",
+      "es": "Según la FCRA §607(b), las cuentas cerradas con saldo $0 no pueden mostrar un monto vencido."
+    }
+  },
+  "79": {
+    "id": 79,
+    "violation": "Open-end account missing credit limit causing inflated utilization",
+    "fieldsImpacted": [
+      "Credit Limit",
+      "Balance"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 607(b)",
+    "snippets": {
+      "en": "Per FCRA §607(b), omitting a credit limit on revolving accounts misstates utilization ratios.",
+      "es": "Según la FCRA §607(b), omitir un límite de crédito en cuentas revolventes tergiversa las proporciones de utilización."
+    }
+  },
+  "80": {
+    "id": 80,
+    "violation": "Inaccurate payment rating (e.g., 'OK') while status is delinquent",
+    "fieldsImpacted": [
+      "Payment Rating",
+      "Account Status"
+    ],
+    "severity": 3,
+    "fcraSection": "§ 623(a)(1)",
+    "snippets": {
+      "en": "Per FCRA §623(a)(1), payment rating must reflect actual status. 'OK' while delinquent is inaccurate.",
+      "es": "Según la FCRA §623(a)(1), la calificación de pago debe reflejar el estado real. 'OK' mientras esté moroso es inexacto."
+    }
   }
-]
-
+}

--- a/metro2 (copy 1)/crm/metro2_audit_multi.py
+++ b/metro2 (copy 1)/crm/metro2_audit_multi.py
@@ -86,14 +86,7 @@ _VIOLATION_DATA_PATH = os.path.join(
 try:
     with open(_VIOLATION_DATA_PATH, "r", encoding="utf-8") as f:
         _raw = json.load(f)
-        if isinstance(_raw, dict):
-            VIOLATION_META = _raw
-        else:
-            VIOLATION_META = {}
-            for itm in _raw:
-                key = itm.get("id") or itm.get("key") or itm.get("title")
-                if key:
-                    VIOLATION_META[key] = itm
+        VIOLATION_META = _raw if isinstance(_raw, dict) else {}
 except Exception:
     VIOLATION_META = {}
 

--- a/metro2 (copy 1)/crm/utils.js
+++ b/metro2 (copy 1)/crm/utils.js
@@ -26,6 +26,6 @@ const METRO2_VIOLATIONS_PATH = path.join(
 );
 
 export function loadMetro2Violations() {
-  return readJson(METRO2_VIOLATIONS_PATH, []);
+  return readJson(METRO2_VIOLATIONS_PATH, {});
 }
 


### PR DESCRIPTION
## Summary
- represent metro2 violations as a rule-code keyed object
- load violation metadata as object for audit script
- expect object format in utilities

## Testing
- `npm test` *(fails: process hung in container)*
- `PYTHONPATH=. pytest tests/test_metro2_audit_multi.py`


------
https://chatgpt.com/codex/tasks/task_e_68c470091f508323919ebafe20eaa3b5