### PR TITLE
Enrich Metro2 violations with metadata

### DIFF
--- a/metro2-parser/src/data/metro2Violations.json
+++ b/metro2-parser/src/data/metro2Violations.json
@@ -1,0 +1,12 @@
+{
+  "CURRENT_BUT_PASTDUE": {
+    "violation": "Past due amount reported on current account",
+    "severity": 4,
+    "fcraSection": "§ 623(a)(1)"
+  },
+  "MISSING_DOFD": {
+    "violation": "Missing or invalid Date of First Delinquency",
+    "severity": 5,
+    "fcraSection": "§ 623(a)(5)"
+  }
+}

--- a/metro2-parser/src/utils.js
+++ b/metro2-parser/src/utils.js
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const METRO2_VIOLATIONS_PATH = path.join(__dirname, 'data', 'metro2Violations.json');
+
+export function loadMetro2Violations() {
+  return JSON.parse(fs.readFileSync(METRO2_VIOLATIONS_PATH, 'utf-8'));
+}

--- a/metro2-parser/src/validators.js
+++ b/metro2-parser/src/validators.js
@@ -1,10 +1,18 @@
+import { loadMetro2Violations } from './utils.js';
+
+const metadata = loadMetro2Violations();
+
+function enrich(code, extra = {}) {
+  return { code, ...metadata[code], ...extra };
+}
+
 export function validateTradeline(t){
   const violations = [];
   if(t.account_status === "Current" && t.past_due > 0){
-    violations.push({ code:"CURRENT_BUT_PASTDUE", detail:"Past due on current account" });
+    violations.push(enrich("CURRENT_BUT_PASTDUE"));
   }
   if(t.account_status === "Charge-off" && !t.date_first_delinquency){
-    violations.push({ code:"MISSING_DOFD", detail:"Charge-off missing DOFD" });
+    violations.push(enrich("MISSING_DOFD"));
   }
   return violations;
 }

--- a/metro2-parser/tests/parser.spec.js
+++ b/metro2-parser/tests/parser.spec.js
@@ -6,8 +6,15 @@ import fs from 'fs';
 test('extracts DOFD and flags past-due inconsistency', () => {
   const html = fs.readFileSync('tests/fixtures/report.html','utf8');
   const result = parseReport(html);
-  assert.ok(
-    result.tradelines[0].violations.find(v => v.code === 'CURRENT_BUT_PASTDUE' && v.bureau === 'TransUnion'),
-    'should flag past-due inconsistency for TransUnion'
+  const v = result.tradelines[0].violations.find(v => v.code === 'CURRENT_BUT_PASTDUE' && v.bureau === 'TransUnion');
+  assert.ok(v, 'should flag past-due inconsistency for TransUnion');
+  assert.deepStrictEqual(
+    { code: v.code, violation: v.violation, severity: v.severity, fcraSection: v.fcraSection },
+    {
+      code: 'CURRENT_BUT_PASTDUE',
+      violation: 'Past due amount reported on current account',
+      severity: 4,
+      fcraSection: '§ 623(a)(1)'
+    }
   );
 });


### PR DESCRIPTION
## Summary
- load Metro2 violation metadata and enrich validator output
- add metadata loader and seed data file
- assert enriched violations in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c48c4645308323ad236cf57879a04d