### PR TITLE
Handle missing metadata in enrich

### DIFF
--- a/metro2-parser/src/validators.js
+++ b/metro2-parser/src/validators.js
@@ -2,8 +2,8 @@ import { loadMetro2Violations } from './utils.js';
 
 const metadata = loadMetro2Violations();
 
-function enrich(code, extra = {}) {
-  return { code, ...metadata[code], ...extra };
+export function enrich(code, extra = {}) {
+  return { code, ...(metadata[code] || {}), ...extra };
 }
 
 export function validateTradeline(t){

--- a/metro2-parser/tests/parser.spec.js
+++ b/metro2-parser/tests/parser.spec.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { parseReport } from '../src/index.js';
+import { enrich } from '../src/validators.js';
 import fs from 'fs';
 
 test('extracts DOFD and flags past-due inconsistency', () => {
@@ -17,4 +18,8 @@ test('extracts DOFD and flags past-due inconsistency', () => {
       fcraSection: '§ 623(a)(1)'
     }
   );
+});
+
+test('unknown violation codes return only code', () => {
+  assert.deepStrictEqual(enrich('UNKNOWN_CODE'), { code: 'UNKNOWN_CODE' });
 });


### PR DESCRIPTION
## Summary
- avoid spreading undefined in `enrich` by merging metadata only when present
- cover unknown violation codes with a dedicated unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4996c1af48323b3599efc50798a37