### PR TITLE
Implement initial numeric Metro2 rules

### DIFF
--- a/metro2 (copy 1)/crm/data/metro2Violations.json
+++ b/metro2 (copy 1)/crm/data/metro2Violations.json
@@ -25,7 +25,8 @@
       "Account Status"
     ],
     "severity": 3,
-    "fcraSection": "§ 623(a)(2)"
+    "fcraSection": "§ 623(a)(2)",
+    "ruleSet": "Account Status & Codes"
   },
   "SL_NO_LATES_DURING_DEFERMENT": {
     "id": 4,
@@ -74,7 +75,8 @@
       "Charge-Off"
     ],
     "severity": 5,
-    "fcraSection": "§ 623(a)(5)"
+    "fcraSection": "§ 623(a)(5)",
+    "ruleSet": "Dates"
   },
   "9": {
     "id": 9,
@@ -83,7 +85,8 @@
       "Creditor Name"
     ],
     "severity": 3,
-    "fcraSection": "§ 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)",
+    "ruleSet": "Data Definitions"
   },
   "10": {
     "id": 10,
@@ -92,7 +95,8 @@
       "Account Number"
     ],
     "severity": 3,
-    "fcraSection": "§ 607(b)"
+    "fcraSection": "§ 607(b)",
+    "ruleSet": "Duplicate/Conflicting Reporting"
   },
   "REVOLVING_WITH_TERMS": {
     "id": 11,

--- a/metro2 (copy 1)/crm/tests/test_metro2_audit_multi.py
+++ b/metro2 (copy 1)/crm/tests/test_metro2_audit_multi.py
@@ -29,5 +29,43 @@ class TestMissingDOFD(unittest.TestCase):
         self.assertEqual(v["severity"], m2.SEVERITY["Dates"])
 
 
+class TestRule3(unittest.TestCase):
+    def test_open_after_closure(self):
+        violations = []
+        m2._CURRENT_RULE_ID = "3"
+        m2.r_3({}, "Experian", {"account_status": "Open", "date_closed": "2020-01-01"}, violations.append)
+        m2._CURRENT_RULE_ID = None
+        self.assertEqual(len(violations), 1)
+
+
+class TestRule8(unittest.TestCase):
+    def test_chargeoff_without_dofd(self):
+        violations = []
+        m2._CURRENT_RULE_ID = "8"
+        m2.r_8({}, "Experian", {"account_status": "Charge-Off"}, violations.append)
+        m2._CURRENT_RULE_ID = None
+        self.assertEqual(len(violations), 1)
+
+
+class TestRule9(unittest.TestCase):
+    def test_collection_missing_original_creditor(self):
+        violations = []
+        m2._CURRENT_RULE_ID = "9"
+        m2.r_9({}, "Experian", {"account_status": "Collection"}, violations.append)
+        m2._CURRENT_RULE_ID = None
+        self.assertEqual(len(violations), 1)
+
+
+class TestRule10(unittest.TestCase):
+    def test_duplicate_account(self):
+        ctx = {}
+        violations = []
+        m2._CURRENT_RULE_ID = "10"
+        m2.r_10(ctx, "Experian", {"account_number": "123"}, violations.append)
+        m2.r_10(ctx, "Experian", {"account_number": "123"}, violations.append)
+        m2._CURRENT_RULE_ID = None
+        self.assertEqual(len(violations), 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add ruleSet metadata for numeric violations 3, 8, 9 and 10
- implement audit checks for codes 3 (open after closure), 8 (charge-off w/o DOFD), 9 (missing original creditor), and 10 (duplicate account)
- cover new rules with unit tests

## Testing
- `python -m pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c49aabbe10832389f200131cf43fea