### PR TITLE
Handle unknown violation codes in metro2 parser

### DIFF
--- a/metro2-parser/src/validators.js
+++ b/metro2-parser/src/validators.js
@@ -3,7 +3,8 @@ import { loadMetro2Violations } from './utils.js';
 const metadata = loadMetro2Violations();
 
 export function enrich(code, extra = {}) {
-  return { code, ...(metadata[code] || {}), ...extra };
+  const meta = metadata[code] || { violation: 'Unknown violation code' };
+  return { code, ...meta, ...extra };
 }
 
 export function validateTradeline(t){

--- a/metro2-parser/tests/parser.spec.js
+++ b/metro2-parser/tests/parser.spec.js
@@ -20,6 +20,9 @@ test('extracts DOFD and flags past-due inconsistency', () => {
   );
 });
 
-test('unknown violation codes return only code', () => {
-  assert.deepStrictEqual(enrich('UNKNOWN_CODE'), { code: 'UNKNOWN_CODE' });
+test('unknown violation codes fall back to default message', () => {
+  assert.deepStrictEqual(
+    enrich('UNKNOWN_CODE'),
+    { code: 'UNKNOWN_CODE', violation: 'Unknown violation code' }
+  );
 });


### PR DESCRIPTION
## Summary
- add fallback message when violation metadata is missing
- assert default message for unknown codes in parser tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c49bbf6dac8323989dacc8d5d28bee