### PR TITLE
refactor: make fetchCreditReport internal

### DIFF
--- a/metro2 (copy 1)/crm/creditAuditTool.js
+++ b/metro2 (copy 1)/crm/creditAuditTool.js
@@ -8,7 +8,7 @@ import { detectChromium, launchBrowser } from './pdfUtils.js';
 // ----- Data Source -----
 // Load credit report JSON; if an HTML file is provided, run the Python
 // metro2_audit_multi.py script to convert it into JSON first.
-export async function fetchCreditReport(srcPath){
+async function fetchCreditReport(srcPath){
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   let reportPath = srcPath;
 


### PR DESCRIPTION
## Summary
- make `fetchCreditReport` internal to `creditAuditTool`

## Testing
- `node --test tests/generate.test.js`
- `npm test` *(fails: suite hangs after initial tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ae23a77c832388749476200cf566