### PR TITLE
refactor: remove unused pullTradelineData export

### DIFF
--- a/metro2 (copy 1)/crm/pullTradelineData.js
+++ b/metro2 (copy 1)/crm/pullTradelineData.js
@@ -76,7 +76,7 @@ async function pullTradelineData({ apiUrl, fetchImpl = fetch, overrides = {}, au
   return report;
 }
 
-export { pullTradelineData, enrichTradeline };
+export { enrichTradeline };
 export default pullTradelineData;
 
 async function runMetro2Audit(html) {

--- a/metro2 (copy 1)/crm/tests/pullTradelineData.test.js
+++ b/metro2 (copy 1)/crm/tests/pullTradelineData.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { pullTradelineData } from '../pullTradelineData.js';
+import pullTradelineData from '../pullTradelineData.js';
 
 const SAMPLE_HTML = `<html><body><td class="ng-binding"><div class="sub_header">Test Creditor</div><table class="rpt_content_table rpt_content_header rpt_table4column"><tr><th></th><th>TransUnion</th><th>Experian</th><th>Equifax</th></tr><tr><td class="label">Account #:</td><td class="info">1234</td><td class="info">1234</td><td class="info">1234</td></tr></table></td></body></html>`;
 


### PR DESCRIPTION
## Summary
- drop unused `pullTradelineData` named export and keep default export only
- update test to import default `pullTradelineData`

## Testing
- `node --test tests/pullTradelineData.test.js`
- `npm test` *(fails: process hangs after starting; appears to stall before completing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ae10af648323be98f0987332ba40