### PR TITLE
Load newly uploaded report immediately

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -1048,6 +1048,17 @@ $("#fileInput").addEventListener("change", async (e)=>{
       localStorage.setItem("creditScore", JSON.stringify(data.creditScore));
       window.dispatchEvent(new StorageEvent("storage", { key: "creditScore" }));
     }
+    currentReportId = data.reportId;
+    CURRENT_REPORT = null;
+    tlPage = 1;
+    tlTotalPages = 1;
+    CURRENT_COLLECTORS = [];
+    Object.keys(collectorSelection).forEach(k=> delete collectorSelection[k]);
+    hiddenTradelines.clear();
+    Object.keys(selectionState).forEach(k=> delete selectionState[k]);
+    trackerData = {};
+    trackerSteps = [];
+    await loadReportJSON();
     await refreshReports();
     await loadConsumerState();
   }catch(err){


### PR DESCRIPTION
## Summary
- Set `currentReportId` after uploading a report and reset report-specific globals
- Load fresh report JSON then refresh report picker for consistent UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4baba122c8323bf7c2fa0458b3801