### PR TITLE
test: ensure multiple report uploads return violations

### DIFF
--- a/metro2 (copy 1)/crm/tests/uploadReport.test.js
+++ b/metro2 (copy 1)/crm/tests/uploadReport.test.js
@@ -27,3 +27,36 @@ test('uploading a report populates violations', async () => {
   const has = tlines.some(tl => (tl.violations || []).length > 0);
   assert.equal(has, true);
 });
+
+test('uploading two reports stores both with violations', async () => {
+  const reportHtml = await fs.readFile(reportPath);
+  const create = await request(app).post('/api/consumers').send({ name: 'Repeat User' });
+  assert.equal(create.status, 200);
+  const id = create.body.consumer.id;
+
+  const upload1 = await request(app)
+    .post(`/api/consumers/${id}/upload`)
+    .attach('file', reportHtml, 'report.html');
+  assert.equal(upload1.status, 200);
+  const rid1 = upload1.body.reportId;
+  assert.ok(rid1);
+
+  const upload2 = await request(app)
+    .post(`/api/consumers/${id}/upload`)
+    .attach('file', reportHtml, 'report.html');
+  assert.equal(upload2.status, 200);
+  const rid2 = upload2.body.reportId;
+  assert.ok(rid2);
+
+  const fetched1 = await request(app).get(`/api/consumers/${id}/report/${rid1}`);
+  assert.equal(fetched1.status, 200);
+  const tlines1 = fetched1.body.report.tradelines || [];
+  const has1 = tlines1.some(tl => (tl.violations || []).length > 0);
+  assert.equal(has1, true);
+
+  const fetched2 = await request(app).get(`/api/consumers/${id}/report/${rid2}`);
+  assert.equal(fetched2.status, 200);
+  const tlines2 = fetched2.body.report.tradelines || [];
+  const has2 = tlines2.some(tl => (tl.violations || []).length > 0);
+  assert.equal(has2, true);
+});


### PR DESCRIPTION
## Summary
- add regression test to verify two report uploads for one consumer each retain tradeline violations

## Testing
- `npm test` *(fails: hangs after initial tests; environment issue)*
- `node --test tests/uploadReport.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4bac5bae88323bd553752d758c5a0