### PR TITLE
Reset filter state when loading reports

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -419,6 +419,7 @@ async function loadReportJSON(){
   tlPage = 1;
   hiddenTradelines.clear();
   Object.keys(selectionState).forEach(k=> delete selectionState[k]);
+  activeFilters.clear();
   renderFilterBar();
   renderTradelines(CURRENT_REPORT.tradelines);
   renderCollectors(CURRENT_REPORT.creditor_contacts || []);


### PR DESCRIPTION
## Summary
- Clear active filters whenever a new report JSON is loaded
- Re-render filters and tradelines after a report refresh

## Testing
- `cd "metro2 (copy 1)/crm" && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c3ea77448323b6dae2eb7e8c774f