### PR TITLE
Add end-to-end report pipeline script

### DIFF
--- a/metro2 (copy 1)/crm/README.md
+++ b/metro2 (copy 1)/crm/README.md
@@ -50,6 +50,16 @@ Without them, letter generation will fail with errors like `libnspr4.so: cannot 
    npm start
    ```
 
+4. **Full pipeline demo** – create tradeline cards and a sample dispute letter from the bundled sample report.
+
+   ```bash
+   node reportPipeline.js
+   ```
+
+   Outputs:
+   - `data/tradelineCards.json` – normalized accounts with issues for the client portal
+   - `letter.html` – demo letter for the first tradeline and violation
+
 ## Tests
 
 Install dependencies and run the test suite:

--- a/metro2 (copy 1)/crm/reportPipeline.js
+++ b/metro2 (copy 1)/crm/reportPipeline.js
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+import { normalizeReport } from './creditAuditTool.js';
+import { generateLetters } from './letterEngine.js';
+
+async function main() {
+  const reportPath = path.join('data', 'report.json');
+  const raw = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+
+  // 1. Normalize report into tradeline "cards" for client portal
+  const normalized = normalizeReport(raw);
+  const cardsPath = path.join('data', 'tradelineCards.json');
+  fs.writeFileSync(cardsPath, JSON.stringify(normalized.accounts, null, 2));
+  console.log(`Saved ${normalized.accounts.length} tradeline cards to ${cardsPath}`);
+
+  // 2. Generate a sample letter for the first tradeline and violation
+  if (raw.tradelines && raw.tradelines.length) {
+    const letters = generateLetters({
+      report: raw,
+      selections: [
+        { tradelineIndex: 0, bureaus: ['Experian'], violationIdxs: [0] }
+      ],
+      consumer: { name: 'Jane Doe', address: '123 Main St' },
+      requestType: 'investigation'
+    });
+
+    if (letters.length) {
+      fs.writeFileSync('letter.html', letters[0].html);
+      console.log('Letter saved to letter.html');
+    }
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- provide `reportPipeline.js` that converts an audited report into tradeline cards and a sample dispute letter
- document how to run the pipeline in README

## Testing
- `node reportPipeline.js`
- `npm test` *(hangs after a couple of tests; see partial log)*
- `node --test tests/parserDateLastPayment.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4d6027c3083238bc46a4e46f517c4