### PR TITLE
Add create and edit client buttons

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -144,8 +144,8 @@
       <div class="flex items-center justify-between">
         <div class="font-semibold">Consumers</div>
         <div class="flex gap-2">
-          <button id="btnNewConsumer" class="btn text-sm" data-tip="New Consumer (N)">New</button>
-          <button id="btnEditConsumer" class="btn text-sm" data-tip="Edit Consumer (E)">Edit</button>
+          <button id="btnCreateClient" class="btn text-sm" data-tip="Create Client (N)">Create Client</button>
+          <button id="btnEditClient" class="btn text-sm" data-tip="Edit Client (E)">Edit Client</button>
         </div>
       </div>
       <input id="consumerSearch" placeholder="Search consumers..." class="w-full border rounded px-2 py-1 text-sm" />

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -12,7 +12,7 @@ if (typeof window !== 'undefined' && role === 'client') {
 if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
   document.addEventListener('DOMContentLoaded', () => {
     if (role !== 'host') {
-      ['btnInvite', 'btnNewConsumer', 'btnEditConsumer', 'btnDeleteReport'].forEach(id => {
+      ['btnInvite', 'btnCreateClient', 'btnEditClient', 'btnDeleteReport'].forEach(id => {
         document.getElementById(id)?.classList.add('hidden');
       });
     }
@@ -949,7 +949,7 @@ $("#btnGenerate").addEventListener("click", async ()=>{
 });
 
 // ===================== Toolbar =====================
-$("#btnNewConsumer").addEventListener("click", ()=>{
+$("#btnCreateClient").addEventListener("click", ()=>{
   const m = $("#newModal");
   $("#newForm").reset();
   m.classList.remove("hidden");
@@ -975,7 +975,7 @@ $("#newForm").addEventListener("submit", async (e)=>{
   await selectConsumer(res.consumer.id);
 });
 
-$("#btnEditConsumer").addEventListener("click", ()=>{
+$("#btnEditClient").addEventListener("click", ()=>{
   const m = $("#editModal");
   if(!currentConsumerId){ showErr("Select a consumer first."); return; }
   const c = DB.consumers.find(x=>x.id===currentConsumerId);


### PR DESCRIPTION
## Summary
- add explicit Create Client and Edit Client buttons to consumer sidebar
- wire up button handlers for creating and editing clients

## Testing
- `npm test` *(fails: process did not exit; manual tail shows initial tests passing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ddbf15388323bc5b22e2a98fc737