### PR TITLE
feat: redact sensitive log fields

### DIFF
--- a/metro2 (copy 1)/crm/logger.js
+++ b/metro2 (copy 1)/crm/logger.js
@@ -1,3 +1,20 @@
+const SENSITIVE_KEYS = new Set(["ssn", "email", "token"]);
+
+function redactSensitive(data) {
+  if (!data || typeof data !== "object") return data;
+  if (Array.isArray(data)) return data.map(redactSensitive);
+
+  const result = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      result[key] = "[REDACTED]";
+    } else {
+      result[key] = redactSensitive(value);
+    }
+  }
+  return result;
+}
+
 function logInfo(code, message, meta = {}) {
   const entry = {
     level: "info",
@@ -6,7 +23,7 @@ function logInfo(code, message, meta = {}) {
     message,
     ...meta,
   };
-  console.log(JSON.stringify(entry));
+  console.log(JSON.stringify(redactSensitive(entry)));
 }
 
 function logError(code, message, err, meta = {}) {
@@ -22,7 +39,7 @@ function logError(code, message, err, meta = {}) {
     entry.error = err.message;
     if (err.stack) entry.stack = err.stack;
   }
-  console.error(JSON.stringify(entry));
+  console.error(JSON.stringify(redactSensitive(entry)));
 }
 
 function logWarn(code, message, meta = {}) {
@@ -33,8 +50,8 @@ function logWarn(code, message, meta = {}) {
     message,
     ...meta,
   };
-  console.warn(JSON.stringify(entry));
+  console.warn(JSON.stringify(redactSensitive(entry)));
 }
 
-export { logInfo, logError, logWarn };
+export { logInfo, logError, logWarn, redactSensitive };
 

--- a/metro2 (copy 1)/crm/tests/logger.test.js
+++ b/metro2 (copy 1)/crm/tests/logger.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { logInfo, logWarn, logError } from '../logger.js';
+
+const sensitiveMeta = {
+  ssn: '123-45-6789',
+  email: 'user@example.com',
+  token: 'secret-token',
+  nested: { token: 'nested-token', ok: 'value' }
+};
+
+test('loggers redact sensitive fields', () => {
+  const out = [];
+  const origLog = console.log;
+  const origWarn = console.warn;
+  const origErr = console.error;
+  console.log = (msg) => out.push(['info', msg]);
+  console.warn = (msg) => out.push(['warn', msg]);
+  console.error = (msg) => out.push(['error', msg]);
+
+  logInfo('I1', 'info', sensitiveMeta);
+  logWarn('W1', 'warn', sensitiveMeta);
+  logError('E1', 'error', new Error('fail'), sensitiveMeta);
+
+  console.log = origLog;
+  console.warn = origWarn;
+  console.error = origErr;
+
+  assert.equal(out.length, 3);
+  for (const [, msg] of out) {
+    const parsed = JSON.parse(msg);
+    assert.equal(parsed.ssn, '[REDACTED]');
+    assert.equal(parsed.email, '[REDACTED]');
+    assert.equal(parsed.token, '[REDACTED]');
+    assert.equal(parsed.nested.token, '[REDACTED]');
+    assert.equal(parsed.nested.ok, 'value');
+  }
+});


### PR DESCRIPTION
## Summary
- mask sensitive metadata keys before logging
- apply redaction to logInfo, logWarn, and logError
- test log redaction

## Testing
- `npm test` (partial run; suite lengthy)
- `node --test tests/logger.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4e061ffe48323adc4c39a239ec47a