### PR TITLE
refactor: centralize metro2 violations

### DIFF
--- a/metro2 (copy 1)/crm/README.md
+++ b/metro2 (copy 1)/crm/README.md
@@ -18,6 +18,15 @@ Use `metro2Violations.json` as a quick reference for common Metro-2 and FCRA con
 }
 ```
 
+### Usage example
+
+```js
+import { loadMetro2Violations } from './utils.js';
+
+const violations = await loadMetro2Violations();
+console.log(violations.MISSING_DOFD.severity); // 5
+```
+
 ### Extending the dataset
 
 1. Append new objects to `metro2Violations.json` with `code`, `title`, `detail`, `severity`, and `fcra` fields.

--- a/metro2 (copy 1)/crm/tests/fixtures/violations-sample.csv
+++ b/metro2 (copy 1)/crm/tests/fixtures/violations-sample.csv
@@ -1,0 +1,3 @@
+code,violation,severity,fcraSection
+MISSING_DOFD,Missing or invalid Date of First Delinquency,5,§ 623(a)(5)
+LATE_STATUS_NO_PASTDUE,Payment history inconsistent with status,4,§ 607(b)

--- a/metro2 (copy 1)/crm/tests/loadMetro2ViolationsCsv.test.js
+++ b/metro2 (copy 1)/crm/tests/loadMetro2ViolationsCsv.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadMetro2Violations } from '../utils.js';
+
+test('loadMetro2Violations returns violations matching sample CSV', async () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const csvPath = path.join(__dirname, 'fixtures', 'violations-sample.csv');
+  const rows = fs.readFileSync(csvPath, 'utf-8').trim().split('\n').slice(1);
+  const expected = {};
+  for (const line of rows) {
+    const [code, violation, severity, fcraSection] = line.split(',');
+    expected[code] = {
+      violation,
+      severity: Number(severity),
+      fcraSection
+    };
+  }
+  const violations = await loadMetro2Violations();
+  for (const code of Object.keys(expected)) {
+    assert.ok(code in violations, `Missing ${code} in violations`);
+    const v = violations[code];
+    const e = expected[code];
+    assert.equal(v.violation, e.violation);
+    assert.equal(v.severity, e.severity);
+    assert.equal(v.fcraSection, e.fcraSection);
+  }
+});

--- a/metro2 (copy 1)/crm/utils.js
+++ b/metro2 (copy 1)/crm/utils.js
@@ -1,5 +1,4 @@
 import fs from "fs";
-import { loadMetro2Violations } from "../../shared/violations.js";
 
 export function ensureBuffer(data) {
   return Buffer.isBuffer(data) ? data : Buffer.from(data);
@@ -24,13 +23,4 @@ export async function writeJson(filePath, data){
   }
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const METRO2_VIOLATIONS_PATH = path.join(
-  __dirname,
-  "data",
-  "metro2Violations.json"
-);
-
-export async function loadMetro2Violations() {
-  return readJson(METRO2_VIOLATIONS_PATH, {});
-}
+export { loadMetro2Violations } from "../../shared/violations.js";


### PR DESCRIPTION
## Summary
- avoid duplicate `loadMetro2Violations` definitions by re-exporting shared version
- add integration test with sample CSV to validate violation data
- document how to load violations in README

## Testing
- `npm test` *(fails: Expected 403 but received 200 in authorization tests)*
- `node --test tests/loadMetro2Violations*.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c51d5fbd308323a532285dff0a3b5e