### PR TITLE
Return JSON on forbidden and server errors

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -187,7 +187,7 @@ function requireRole(role){
     if (req.user && req.user.role === role) {
       return next();
     }
-    res.status(403).send("Forbidden");
+    res.status(403).json({ ok:false, error:'Forbidden' });
   };
 }
 
@@ -199,12 +199,12 @@ function hasPermission(user, perm){
 function requirePermission(perm){
   return (req, res, next) => {
     if (hasPermission(req.user, perm)) return next();
-    res.status(403).send("Forbidden");
+    res.status(403).json({ ok:false, error:'Forbidden' });
   };
 }
 
 function forbidMember(req,res,next){
-  if(req.user && req.user.role === "member") return res.status(403).send("Forbidden");
+  if(req.user && req.user.role === "member") return res.status(403).json({ ok:false, error:'Forbidden' });
   next();
 }
 
@@ -301,7 +301,7 @@ app.get("/buy", async (req, res) => {
   const { bank = "", price = "" } = req.query || {};
   const settings = await loadSettings();
   if (!StripeLib || !settings.stripeApiKey) {
-    return res.status(500).send("Stripe not configured");
+    return res.status(500).json({ ok:false, error:'Stripe not configured' });
   }
   const amt = Math.round(parseFloat(price) * 100);
   if (!amt) return res.status(400).send("Invalid price");
@@ -325,7 +325,7 @@ app.get("/buy", async (req, res) => {
     res.redirect(303, session.url);
   } catch (e) {
     console.error("Stripe checkout error", e);
-    res.status(500).send("Checkout failed");
+    res.status(500).json({ ok:false, error:'Checkout failed' });
   }
 });
 
@@ -1771,7 +1771,7 @@ app.get("/api/letters/:jobId/:idx.pdf", authenticate, requirePermission("letters
 
   if(!html || !html.trim()){
     logError("LETTER_HTML_MISSING", "No HTML content for PDF generation", null, { jobId, idx });
-    return res.status(500).send("No HTML content to render");
+    return res.status(500).json({ ok:false, error:'No HTML content to render' });
   }
 
   if(useOcr){
@@ -1784,7 +1784,7 @@ app.get("/api/letters/:jobId/:idx.pdf", authenticate, requirePermission("letters
       return res.send(pdfBuffer);
     }catch(e){
       console.error("OCR PDF error:", e);
-      return res.status(500).send("Failed to render OCR PDF.");
+      return res.status(500).json({ ok:false, error:'Failed to render OCR PDF.' });
     }
   }
 
@@ -1813,7 +1813,7 @@ app.get("/api/letters/:jobId/:idx.pdf", authenticate, requirePermission("letters
     res.send(pdfBuffer);
   }catch(e){
     console.error("PDF error:", e);
-    res.status(500).send("Failed to render PDF.");
+    res.status(500).json({ ok:false, error:'Failed to render PDF.' });
   }finally{ try{ await browserInstance?.close(); }catch{} }
 
 });

--- a/metro2 (copy 1)/crm/tests/consumersForbidden.test.js
+++ b/metro2 (copy 1)/crm/tests/consumersForbidden.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+const { default: app } = await import('../server.js');
+
+test('unauthenticated access to /api/consumers returns forbidden json', async () => {
+  const res = await request(app).get('/api/consumers');
+  assert.equal(res.status, 403);
+  assert.deepEqual(res.body, { ok: false, error: 'Forbidden' });
+});


### PR DESCRIPTION
## Summary
- Respond with JSON `{ ok:false, error:'Forbidden' }` in permission and role middleware
- Replace remaining 500 error string responses with JSON payloads
- Add integration test to verify unauthorized `/api/consumers` returns forbidden JSON

## Testing
- `node --test tests/consumersForbidden.test.js`
- `npm test` *(fails: hangs due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68c572f60de08323ac3c5cb4b988f3b6