### PR TITLE
feat: centralize api helper with auth

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -86,7 +86,7 @@
     </div>
   </div>
 </main>
-<script src="/common.js"></script>
+<script type="module" src="/common.js"></script>
 <script src="/hotkeys.js"></script>
 <script src="/billing.js" type="module"></script>
 

--- a/metro2 (copy 1)/crm/public/billing.js
+++ b/metro2 (copy 1)/crm/public/billing.js
@@ -1,6 +1,6 @@
 // public/billing.js
+import { api } from './common.js';
 const $ = (s) => document.querySelector(s);
-const api = (u,o={}) => fetch(u,o).then(r=>r.json());
 
 const consumerId = getSelectedConsumerId();
 
@@ -31,7 +31,7 @@ async function loadInvoices(){
     const btn = tr.querySelector('.mark-paid');
     if(btn){
       btn.addEventListener('click', async ()=>{
-        await api(`/api/invoices/${inv.id}`, { method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify({paid:true}) });
+        await api(`/api/invoices/${inv.id}`, { method:'PUT', body: JSON.stringify({paid:true}) });
         trackEvent('purchase', { amount: inv.amount });
         loadInvoices();
       });
@@ -46,7 +46,7 @@ document.getElementById('invAdd')?.addEventListener('click', async ()=>{
   const due = $('#invDue').value;
   if(!desc || !amount) return;
   const company = JSON.parse(localStorage.getItem('companyInfo')||'{}');
-  await api('/api/invoices', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ consumerId, desc, amount, due, company }) });
+  await api('/api/invoices', { method:'POST', body: JSON.stringify({ consumerId, desc, amount, due, company }) });
   $('#invDesc').value='';
   $('#invAmount').value='';
   $('#invDue').value='';

--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -25,7 +25,7 @@ function trackEvent(name, props = {}) {
     console.debug('trackEvent', name, props);
   }
 }
-window.trackEvent = trackEvent;
+if (typeof window !== 'undefined') window.trackEvent = trackEvent;
 
 document.addEventListener('DOMContentLoaded', () => {
   trackEvent('page_view', { path: location.pathname });
@@ -237,12 +237,31 @@ function initPalette(){
   }
 }
 
-function authHeader(){
+export function authHeader(){
   const token = localStorage.getItem('token');
   if(token) return { Authorization: 'Bearer '+token };
   const auth = localStorage.getItem('auth');
   if(auth) return { Authorization: 'Basic '+auth };
   return {};
+}
+
+export async function api(url, options = {}) {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...authHeader(),
+    ...(options.headers || {})
+  };
+  try {
+    const res = await fetch(url, { ...options, headers });
+    const text = await res.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
 }
 
 async function limitNavForMembers(){
@@ -428,7 +447,7 @@ function initVoiceNotes(){
     document.body.classList.add('voice-active');
     startRec();
   }
-  function closeNotes(){
+function closeNotes(){
     active = false;
     document.body.classList.remove('voice-active');
     try{ rec.stop(); }catch{}
@@ -445,4 +464,8 @@ function initVoiceNotes(){
   mic.addEventListener('click', openNotes);
   closeBtn.addEventListener('click', ()=>{ closeNotes(); });
   startRec();
+}
+
+if (typeof window !== 'undefined') {
+  Object.assign(window, { escapeHtml, formatCurrency, trackEvent, authHeader, api });
 }

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -175,7 +175,7 @@
 
   </div>
   </main>
-  <script src="/common.js"></script>
+  <script type="module" src="/common.js"></script>
   <script src="/hotkeys.js"></script>
   <script src="/dashboard.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -471,7 +471,7 @@
   </div>
 </div>
 
-<script src="common.js"></script>
+<script type="module" src="common.js"></script>
 <script src="hotkeys.js"></script>
 <script type="module" src="index.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -1,9 +1,9 @@
 /* public/index.js */
 
 import { PLAYBOOKS } from './playbooks.js';
+import { authHeader, api } from './common.js';
 
 const $ = (s) => document.querySelector(s);
-const api = (u, o = {}) => fetch(u, o).then(r => r.json()).catch(e => ({ ok:false, error:String(e) }));
 
 const role = typeof window !== 'undefined' ? (window.userRole || 'host') : 'host';
 if (typeof window !== 'undefined' && role === 'client') {

--- a/metro2 (copy 1)/crm/public/leads.html
+++ b/metro2 (copy 1)/crm/public/leads.html
@@ -72,7 +72,7 @@
     <div id="leadList" class="space-y-2 text-sm"></div>
   </div>
 </main>
-<script src="/common.js"></script>
+<script type="module" src="/common.js"></script>
 <script src="/hotkeys.js"></script>
 <script src="/leads.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -131,7 +131,7 @@
   </div>
 </div>
 
-<script src="/common.js"></script>
+<script type="module" src="/common.js"></script>
   <script src="/hotkeys.js"></script>
 <script src="letters.js" type="module"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/letters.js
+++ b/metro2 (copy 1)/crm/public/letters.js
@@ -1,6 +1,6 @@
 // public/letters.js
+import { api } from './common.js';
 const $ = (s) => document.querySelector(s);
-const api = (u, o={}) => fetch(u, o).then(r => r.json());
 
 function showErr(msg){
   const e=$("#err"); e.textContent=msg; e.classList.remove("hidden");
@@ -192,12 +192,10 @@ $("#btnEmailAll").addEventListener("click", async ()=>{
   btn.disabled = true;
   btn.textContent = "Sending...";
   try{
-    const resp = await fetch(`/api/letters/${encodeURIComponent(JOB_ID)}/email`, {
-      method:"POST",
-      headers:{ "Content-Type":"application/json" },
+    const data = await api(`/api/letters/${encodeURIComponent(JOB_ID)}/email`, {
+      method: 'POST',
       body: JSON.stringify({ to })
     });
-    const data = await resp.json().catch(()=> ({}));
     if(!data?.ok) throw new Error(data?.error || "Failed to email letters.");
     alert("Letters emailed.");
   }catch(e){ showErr(e.message || String(e)); }

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -119,7 +119,7 @@
     </div>
   </div>
 </main>
-<script src="/common.js"></script>
+<script type="module" src="/common.js"></script>
 <script src="/library.js"></script>
 </body>
 </html>

--- a/metro2 (copy 1)/crm/public/login.html
+++ b/metro2 (copy 1)/crm/public/login.html
@@ -55,7 +55,7 @@
     <button id="btnRegister" class="btn w-full" style="background:var(--green-bg)">Register</button>
     <button id="btnReset" class="btn w-full" style="background:var(--accent-bg)">Reset Password</button>
   </div>
-  <script src="/common.js"></script>
+  <script type="module" src="/common.js"></script>
   <script src="/login.js"></script>
 </body>
 </html>

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -69,7 +69,7 @@
     <button id="saveCompany" class="btn text-sm">Save</button>
   </div>
 </main>
-<script src="/common.js"></script>
+<script type="module" src="/common.js"></script>
 <script src="/hotkeys.js"></script>
 <script src="/my-company.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -77,7 +77,7 @@
   </main>
 
   <script type="module" src="quiz.js"></script>
-  <script src="/common.js"></script>
+  <script type="module" src="/common.js"></script>
   <script src="/hotkeys.js"></script>
 </body>
 </html>

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -74,7 +74,7 @@
     </div>
   </div>
 </main>
-<script src="/common.js"></script>
+<script type="module" src="/common.js"></script>
 <script src="/hotkeys.js"></script>
 <script src="/schedule.js"></script>
 

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -72,7 +72,7 @@
     <div id="saveMsg" class="text-sm muted hidden">Saved!</div>
   </div>
 </main>
-<script src="/common.js"></script>
+<script type="module" src="/common.js"></script>
 <script src="/hotkeys.js"></script>
 <script src="/settings.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/tradelines.html
+++ b/metro2 (copy 1)/crm/public/tradelines.html
@@ -84,7 +84,7 @@
 
 <a href="#" id="mobile-buy" class="fixed bottom-5 right-5 bg-blue-600 text-white text-sm px-4 py-2 rounded-full shadow-lg block md:hidden hidden z-50">Buy Now</a>
 
-<script src="/common.js"></script>
+<script type="module" src="/common.js"></script>
 <script src="/hotkeys.js"></script>
 <script src="/tradelines.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- expose `authHeader` and new `api` helper in `common.js` to inject Authorization, default JSON headers, and safe response parsing
- update index, letters, and billing modules to import the shared helper instead of ad-hoc fetch logic
- load `common.js` as an ES module across pages for consistent access

## Testing
- `node --test tests/*.test.js` *(fails: process hung after partial output)*
- `node --input-type=module <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c572f5eaa88323a8d7da13b254c586