### PR TITLE
refactor library layout and add template modal

### DIFF
--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -45,6 +45,11 @@
       width: 90vw;
       max-width: 1100px;
     }
+
+    .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:none;align-items:center;justify-content:center;z-index:50}
+    .modal{width:min(1100px,96vw);max-height:min(90vh,900px);border-radius:18px;box-shadow:0 20px 60px rgba(0,0,0,.25);background:white;display:flex;flex-direction:column;overflow:hidden}
+    .modal header{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 16px;border-bottom:1px solid rgba(0,0,0,.08);background:var(--glass-bg);backdrop-filter: blur(10px)}
+    .modal .body{padding:16px;overflow-y:auto}
   </style>
 </head>
 <body>
@@ -79,10 +84,6 @@
     <div class="flex gap-4">
       <div class="w-1/3 space-y-4">
         <div>
-          <button id="newTemplate" class="btn w-full mb-2">New Template</button>
-          <div id="templateList" class="space-y-1 text-sm"></div>
-        </div>
-        <div>
           <div class="font-medium text-sm">Main Letters</div>
           <div id="mainList" class="space-y-1 text-sm"></div>
         </div>
@@ -93,13 +94,16 @@
         <textarea id="tplAsk" class="input w-full text-sm" placeholder="Ask"></textarea>
         <textarea id="tplAfter" class="input w-full text-sm" placeholder="After Issues"></textarea>
         <textarea id="tplEvidence" class="input w-full text-sm" placeholder="Evidence"></textarea>
-        <div class="flex gap-2">
+        <div id="tplPreview" class="input w-full text-sm whitespace-pre-line h-48 overflow-y-auto" title="Drop a template here to load it"></div>
+        <div class="flex justify-end gap-2">
           <button id="saveTemplate" class="btn text-sm">Save Template</button>
           <button id="saveTemplateCopy" class="btn text-sm">Save As New</button>
         </div>
       </div>
-      <div class="flex-1">
-        <div id="tplPreview" class="input w-full text-sm whitespace-pre-line" title="Drop a template here to load it"></div>
+      <div class="w-1/3 space-y-4">
+        <button id="newTemplate" class="btn w-full mb-2">New Template</button>
+        <div class="font-medium text-sm">Letter Templates</div>
+        <div id="templateList" class="space-y-1 text-sm max-h-96 overflow-y-auto"></div>
       </div>
     </div>
   </div>
@@ -119,6 +123,26 @@
     </div>
   </div>
 </main>
+<!-- New Template Modal -->
+<div id="tplModal" class="modal-backdrop">
+  <div class="modal">
+    <header>
+      <div class="font-medium">New Template</div>
+      <button id="tplModalClose" class="btn text-sm">Close</button>
+    </header>
+    <div class="body space-y-2">
+      <input id="modalTplHeading" class="input w-full text-sm" placeholder="Heading" />
+      <textarea id="modalTplIntro" class="input w-full text-sm" placeholder="Intro"></textarea>
+      <textarea id="modalTplAsk" class="input w-full text-sm" placeholder="Ask"></textarea>
+      <textarea id="modalTplAfter" class="input w-full text-sm" placeholder="After Issues"></textarea>
+      <textarea id="modalTplEvidence" class="input w-full text-sm" placeholder="Evidence"></textarea>
+      <div class="flex justify-end gap-2">
+        <button id="modalSaveTemplate" class="btn text-sm">Save Template</button>
+        <button id="modalSaveTemplateCopy" class="btn text-sm">Save As New</button>
+      </div>
+    </div>
+  </div>
+</div>
 <script type="module" src="/common.js"></script>
 <script src="/library.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/library.js
+++ b/metro2 (copy 1)/crm/public/library.js
@@ -88,25 +88,19 @@ async function assignMainTemplate(slotId, templateId){
   }
 }
 
-function newTemplate(){
+function openTemplateModal(){
   currentTemplateId = null;
-  document.getElementById('tplHeading').value = '';
-  document.getElementById('tplIntro').value = '';
-  document.getElementById('tplAsk').value = '';
-  document.getElementById('tplAfter').value = '';
-  document.getElementById('tplEvidence').value = '';
-  updatePreview();
+  document.getElementById('tplModal').style.display='flex';
+  ['modalTplHeading','modalTplIntro','modalTplAsk','modalTplAfter','modalTplEvidence'].forEach(id=>{
+    document.getElementById(id).value='';
+  });
 }
 
-async function saveTemplate(){
-  const payload = {
-    heading: document.getElementById('tplHeading').value,
-    intro: document.getElementById('tplIntro').value,
-    ask: document.getElementById('tplAsk').value,
-    afterIssues: document.getElementById('tplAfter').value,
-    evidence: document.getElementById('tplEvidence').value
-  };
-  if(currentTemplateId) payload.id = currentTemplateId;
+function closeTemplateModal(){
+  document.getElementById('tplModal').style.display='none';
+}
+
+async function upsertTemplate(payload){
   const res = await fetch('/api/templates', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -118,15 +112,41 @@ async function saveTemplate(){
     if(existing){ Object.assign(existing, data.template); }
     else { templates.push(data.template); }
     renderTemplates();
-    editTemplate(data.template.id);
     const selected = Array.from(document.querySelectorAll('#seqTemplates input[type="checkbox"]:checked')).map(cb => cb.value);
     renderSeqTemplateOptions(selected);
+    return data.template.id;
   }
+}
+
+async function saveTemplate(){
+  const payload = {
+    heading: document.getElementById('tplHeading').value,
+    intro: document.getElementById('tplIntro').value,
+    ask: document.getElementById('tplAsk').value,
+    afterIssues: document.getElementById('tplAfter').value,
+    evidence: document.getElementById('tplEvidence').value
+  };
+  if(currentTemplateId) payload.id = currentTemplateId;
+  const id = await upsertTemplate(payload);
+  if(id) editTemplate(id);
 }
 
 function saveTemplateAsNew(){
   currentTemplateId = null;
   saveTemplate();
+}
+
+async function saveTemplateFromModal(){
+  const payload = {
+    heading: document.getElementById('modalTplHeading').value,
+    intro: document.getElementById('modalTplIntro').value,
+    ask: document.getElementById('modalTplAsk').value,
+    afterIssues: document.getElementById('modalTplAfter').value,
+    evidence: document.getElementById('modalTplEvidence').value
+  };
+  const id = await upsertTemplate(payload);
+  if(id) editTemplate(id);
+  closeTemplateModal();
 }
 
 function updatePreview(){
@@ -204,8 +224,11 @@ async function saveSequence(){
 }
 
 document.getElementById('saveTemplate').onclick = saveTemplate;
-document.getElementById('newTemplate').onclick = newTemplate;
 document.getElementById('saveTemplateCopy').onclick = saveTemplateAsNew;
+document.getElementById('newTemplate').onclick = openTemplateModal;
+document.getElementById('tplModalClose').onclick = closeTemplateModal;
+document.getElementById('modalSaveTemplate').onclick = saveTemplateFromModal;
+document.getElementById('modalSaveTemplateCopy').onclick = saveTemplateFromModal;
 document.getElementById('saveSequence').onclick = saveSequence;
 document.getElementById('newSequence').onclick = newSequence;
 


### PR DESCRIPTION
## Summary
- swap Main Letters and Letter Templates positions for clearer separation
- show letter templates in dedicated side list with scroll and move save buttons under preview
- add popup modal for creating new letter templates

## Testing
- `npm test` *(fails: 10 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c57ce5e16c8323bf916bb0990430f1