### PR TITLE
feat: manage user permissions

### DIFF
--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -71,6 +71,11 @@
     <button id="saveSettings" class="btn text-sm">Save</button>
     <div id="saveMsg" class="text-sm muted hidden">Saved!</div>
   </div>
+
+  <div id="userManager" class="glass card space-y-2 hidden">
+    <div class="font-medium">User Permissions</div>
+    <div id="userList" class="space-y-2 text-sm"></div>
+  </div>
 </main>
 <script type="module" src="/common.js"></script>
 <script src="/hotkeys.js"></script>

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -899,6 +899,18 @@ app.get("/api/users", authenticate, requireRole("admin"), async (_req,res)=>{
   res.json({ ok:true, users: db.users.map(u=>({ id:u.id, username:u.username, name:u.name, role:u.role, permissions: u.permissions || [] })) });
 });
 
+app.put("/api/users/:id", authenticate, requireRole("admin"), async (req,res)=>{
+  const db = await loadUsersDB();
+  const user = db.users.find(u=>u.id === req.params.id);
+  if(!user) return res.status(404).json({ ok:false, error:"Not found" });
+  if(typeof req.body.name === "string") user.name = req.body.name;
+  if(typeof req.body.username === "string") user.username = req.body.username;
+  if(req.body.password) user.password = bcrypt.hashSync(req.body.password,10);
+  if(Array.isArray(req.body.permissions)) user.permissions = req.body.permissions;
+  await saveUsersDB(db);
+  res.json({ ok:true, user: { id:user.id, username:user.username, name:user.name, role:user.role, permissions:user.permissions || [] } });
+});
+
 app.get("/api/me", authenticate, (req,res)=>{
   res.json({ ok:true, user: { id: req.user.id, username: req.user.username, name: req.user.name, role: req.user.role, permissions: req.user.permissions || [] } });
 });

--- a/metro2 (copy 1)/crm/tests/consumersAllowed.test.js
+++ b/metro2 (copy 1)/crm/tests/consumersAllowed.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import request from 'supertest';
+import { readKey, writeKey } from '../kvdb.js';
+
+test('member with consumers permission can access /api/consumers', async () => {
+  const original = await readKey('users', null);
+  await writeKey('users', { users: [] });
+  process.env.NODE_ENV = 'test';
+  const { default: app } = await import('../server.js');
+
+  await request(app).post('/api/users').send({ username: 'admin', password: 'secret' });
+  const adminLogin = await request(app).post('/api/login').send({ username: 'admin', password: 'secret' });
+  const adminToken = adminLogin.body.token;
+
+  const memberRes = await request(app)
+    .post('/api/users')
+    .set('Authorization', 'Bearer ' + adminToken)
+    .send({ username: 'member', password: 'pw' });
+  const memberId = memberRes.body.user.id;
+
+  await request(app)
+    .put(`/api/users/${memberId}`)
+    .set('Authorization', 'Bearer ' + adminToken)
+    .send({ permissions: ['consumers'] });
+
+  const memberLogin = await request(app).post('/api/login').send({ username: 'member', password: 'pw' });
+  const memberToken = memberLogin.body.token;
+
+  const res = await request(app).get('/api/consumers').set('Authorization', 'Bearer ' + memberToken);
+  assert.equal(res.status, 200);
+
+  if (original) await writeKey('users', original); else await writeKey('users', { users: [] });
+});


### PR DESCRIPTION
## Summary
- allow admins to update a user's permissions
- expose user-permission controls in settings UI
- permit staff with `consumers` permission to access consumer APIs

## Testing
- `node --test tests/consumersAllowed.test.js`
- `npm test` *(fails: process terminated after 5s)*

------
https://chatgpt.com/codex/tasks/task_e_68c57e042f908323b3bf293c5e81cbf1