### PR TITLE
Handle auth failures on consumers fetch

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -255,12 +255,16 @@ export async function api(url, options = {}) {
     const res = await fetch(url, { ...options, headers });
     const text = await res.text();
     try {
-      return JSON.parse(text);
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed === 'object') {
+        return { status: res.status, ...parsed };
+      }
+      return { status: res.status, data: parsed };
     } catch {
-      return text;
+      return { status: res.status, ok: res.ok, data: text };
     }
   } catch (err) {
-    return { ok: false, error: String(err) };
+    return { ok: false, status: 0, error: String(err) };
   }
 }
 

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -156,7 +156,15 @@ function currentPageItems(){
 async function loadConsumers(restore = true){
   clearErr();
   const data = await api("/api/consumers");
-  if (!data || !data.consumers) { showErr("Could not load consumers."); return; }
+  if (data.status === 401 || data.status === 403 || data.error === 'Forbidden') {
+    alert('Please log in');
+    location.href = '/login.html';
+    return;
+  }
+  if (data.ok === false || !data.consumers) {
+    showErr(data.error || 'Could not load consumers.');
+    return;
+  }
   DB = data;
   renderConsumers();
   if (restore) restoreSelectedConsumer();


### PR DESCRIPTION
## Summary
- surface HTTP status from `api` helper to allow auth checks
- guard consumer load for 401/403 or Forbidden errors and redirect to login

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'id'))*
- `curl -i localhost:3000/api/consumers` returns 403 when unauthenticated


------
https://chatgpt.com/codex/tasks/task_e_68c57fc3b4f08323a3a751f2ead735f4