### PR TITLE
feat: allow customizable hotkeys

### DIFF
--- a/metro2 (copy 1)/crm/public/hotkeys.js
+++ b/metro2 (copy 1)/crm/public/hotkeys.js
@@ -3,18 +3,43 @@ function isTyping(el){
   return el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable);
 }
 
+const defaultHotkeys = {
+  help: 'h',
+  newConsumer: 'n',
+  upload: 'u',
+  editConsumer: 'e',
+  generate: 'g',
+  remove: 'r',
+  modeBreach: 'd',
+  modeAssault: 's',
+  modeIdentity: 'i'
+};
+
+function getHotkeys(){
+  try {
+    return { ...defaultHotkeys, ...JSON.parse(localStorage.getItem('hotkeys') || '{}') };
+  } catch {
+    return { ...defaultHotkeys };
+  }
+}
+
+let hotkeys = getHotkeys();
+window.addEventListener('storage', (e) => {
+  if (e.key === 'hotkeys') hotkeys = getHotkeys();
+});
+
 document.addEventListener('keydown', (e) => {
   if (isTyping(document.activeElement)) return;
   const k = e.key.toLowerCase();
   const click = (id) => document.getElementById(id)?.click();
 
-  if (k === 'h') { e.preventDefault(); window.openHelp?.(); }
-  if (k === 'n') { e.preventDefault(); click('btnNewConsumer'); }
-  if (k === 'u') { e.preventDefault(); click('btnUpload'); }
-  if (k === 'e') { e.preventDefault(); click('btnEditConsumer'); }
-  if (k === 'g') { e.preventDefault(); click('btnGenerate'); }
-  if (k === 'r') { e.preventDefault(); document.querySelector('.tl-remove')?.click(); }
-  if (k === 'd') window.__crm_helpers?.setMode?.('breach');
-  if (k === 's') window.__crm_helpers?.setMode?.('assault');
-  if (k === 'i') window.__crm_helpers?.setMode?.('identity');
+  if (k === hotkeys.help) { e.preventDefault(); window.openHelp?.(); }
+  if (k === hotkeys.newConsumer) { e.preventDefault(); click('btnNewConsumer'); }
+  if (k === hotkeys.upload) { e.preventDefault(); click('btnUpload'); }
+  if (k === hotkeys.editConsumer) { e.preventDefault(); click('btnEditConsumer'); }
+  if (k === hotkeys.generate) { e.preventDefault(); click('btnGenerate'); }
+  if (k === hotkeys.remove) { e.preventDefault(); document.querySelector('.tl-remove')?.click(); }
+  if (k === hotkeys.modeBreach) window.__crm_helpers?.setMode?.('breach');
+  if (k === hotkeys.modeAssault) window.__crm_helpers?.setMode?.('assault');
+  if (k === hotkeys.modeIdentity) window.__crm_helpers?.setMode?.('identity');
 });

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -76,6 +76,23 @@
     <div class="font-medium">User Permissions</div>
     <div id="userList" class="space-y-2 text-sm"></div>
   </div>
+
+  <div id="hotkeyPanel" class="glass card space-y-2">
+    <div class="font-medium">Keyboard Shortcuts</div>
+    <div class="grid grid-cols-2 gap-2 text-sm">
+      <label class="flex items-center gap-2">Help <input id="hotkeyHelp" class="w-12 border rounded px-2 py-1 text-sm" maxlength="1" /></label>
+      <label class="flex items-center gap-2">New Consumer <input id="hotkeyNewConsumer" class="w-12 border rounded px-2 py-1 text-sm" maxlength="1" /></label>
+      <label class="flex items-center gap-2">Upload <input id="hotkeyUpload" class="w-12 border rounded px-2 py-1 text-sm" maxlength="1" /></label>
+      <label class="flex items-center gap-2">Edit Consumer <input id="hotkeyEditConsumer" class="w-12 border rounded px-2 py-1 text-sm" maxlength="1" /></label>
+      <label class="flex items-center gap-2">Generate <input id="hotkeyGenerate" class="w-12 border rounded px-2 py-1 text-sm" maxlength="1" /></label>
+      <label class="flex items-center gap-2">Remove Tradeline <input id="hotkeyRemove" class="w-12 border rounded px-2 py-1 text-sm" maxlength="1" /></label>
+      <label class="flex items-center gap-2">Mode: Breach <input id="hotkeyModeBreach" class="w-12 border rounded px-2 py-1 text-sm" maxlength="1" /></label>
+      <label class="flex items-center gap-2">Mode: Assault <input id="hotkeyModeAssault" class="w-12 border rounded px-2 py-1 text-sm" maxlength="1" /></label>
+      <label class="flex items-center gap-2">Mode: Identity <input id="hotkeyModeIdentity" class="w-12 border rounded px-2 py-1 text-sm" maxlength="1" /></label>
+    </div>
+    <button id="saveHotkeys" class="btn text-sm">Save Hotkeys</button>
+    <div id="hotkeyMsg" class="text-sm muted hidden">Saved!</div>
+  </div>
 </main>
 <script type="module" src="/common.js"></script>
 <script src="/hotkeys.js"></script>

--- a/metro2 (copy 1)/crm/public/settings.js
+++ b/metro2 (copy 1)/crm/public/settings.js
@@ -12,6 +12,52 @@ document.addEventListener('DOMContentLoaded', () => {
   const saveBtn = document.getElementById('saveSettings');
   const msgEl = document.getElementById('saveMsg');
 
+  const hotkeyEls = {
+    help: document.getElementById('hotkeyHelp'),
+    newConsumer: document.getElementById('hotkeyNewConsumer'),
+    upload: document.getElementById('hotkeyUpload'),
+    editConsumer: document.getElementById('hotkeyEditConsumer'),
+    generate: document.getElementById('hotkeyGenerate'),
+    remove: document.getElementById('hotkeyRemove'),
+    modeBreach: document.getElementById('hotkeyModeBreach'),
+    modeAssault: document.getElementById('hotkeyModeAssault'),
+    modeIdentity: document.getElementById('hotkeyModeIdentity')
+  };
+  const saveHotkeysBtn = document.getElementById('saveHotkeys');
+  const hotkeyMsgEl = document.getElementById('hotkeyMsg');
+  const defaultHotkeys = {
+    help: 'h',
+    newConsumer: 'n',
+    upload: 'u',
+    editConsumer: 'e',
+    generate: 'g',
+    remove: 'r',
+    modeBreach: 'd',
+    modeAssault: 's',
+    modeIdentity: 'i'
+  };
+
+  function loadHotkeys() {
+    let stored = {};
+    try { stored = JSON.parse(localStorage.getItem('hotkeys')) || {}; } catch {}
+    const hk = { ...defaultHotkeys, ...stored };
+    for (const k in hotkeyEls) if (hotkeyEls[k]) hotkeyEls[k].value = hk[k] || '';
+  }
+
+  loadHotkeys();
+
+  if (saveHotkeysBtn) {
+    saveHotkeysBtn.addEventListener('click', () => {
+      const hk = {};
+      for (const k in hotkeyEls) hk[k] = (hotkeyEls[k].value || '').trim().toLowerCase().slice(0,1);
+      localStorage.setItem('hotkeys', JSON.stringify(hk));
+      if (hotkeyMsgEl) {
+        hotkeyMsgEl.classList.remove('hidden');
+        setTimeout(() => hotkeyMsgEl.classList.add('hidden'), 2000);
+      }
+    });
+  }
+
   async function load() {
     try {
       const resp = await fetch('/api/settings');


### PR DESCRIPTION
## Summary
- add keyboard shortcuts panel in settings to define hotkeys
- persist and apply user-defined hotkeys in browser via localStorage

## Testing
- `npm test` (fails: TypeError in authorization.test.js)
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5814311288323b38fcf72a8f6c802