### PR TITLE
feat: show template editor on demand

### DIFF
--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -88,7 +88,7 @@
           <div id="mainList" class="space-y-1 text-sm"></div>
         </div>
       </div>
-      <div class="flex-1 space-y-2">
+      <div id="tplEditor" class="flex-1 space-y-2 hidden">
         <input id="tplHeading" class="input w-full text-sm" placeholder="Heading" />
         <textarea id="tplIntro" class="input w-full text-sm" placeholder="Intro"></textarea>
         <textarea id="tplAsk" class="input w-full text-sm" placeholder="Ask"></textarea>
@@ -98,6 +98,7 @@
         <div class="flex justify-end gap-2">
           <button id="saveTemplate" class="btn text-sm">Save Template</button>
           <button id="saveTemplateCopy" class="btn text-sm">Save As New</button>
+          <button id="cancelTemplate" class="btn text-sm">Cancel</button>
         </div>
       </div>
       <div class="w-1/3 space-y-4">
@@ -123,26 +124,6 @@
     </div>
   </div>
 </main>
-<!-- New Template Modal -->
-<div id="tplModal" class="modal-backdrop">
-  <div class="modal">
-    <header>
-      <div class="font-medium">New Template</div>
-      <button id="tplModalClose" class="btn text-sm">Close</button>
-    </header>
-    <div class="body space-y-2">
-      <input id="modalTplHeading" class="input w-full text-sm" placeholder="Heading" />
-      <textarea id="modalTplIntro" class="input w-full text-sm" placeholder="Intro"></textarea>
-      <textarea id="modalTplAsk" class="input w-full text-sm" placeholder="Ask"></textarea>
-      <textarea id="modalTplAfter" class="input w-full text-sm" placeholder="After Issues"></textarea>
-      <textarea id="modalTplEvidence" class="input w-full text-sm" placeholder="Evidence"></textarea>
-      <div class="flex justify-end gap-2">
-        <button id="modalSaveTemplate" class="btn text-sm">Save Template</button>
-        <button id="modalSaveTemplateCopy" class="btn text-sm">Save As New</button>
-      </div>
-    </div>
-  </div>
-</div>
 <script type="module" src="/common.js"></script>
 <script src="/library.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/library.js
+++ b/metro2 (copy 1)/crm/public/library.js
@@ -52,9 +52,26 @@ function renderMainTemplates(){
   renderList(mainTemplates, 'mainList', useMainTemplate, assignMainTemplate);
 }
 
+function showTemplateEditor(){
+  const editor = document.getElementById('tplEditor');
+  if(editor) editor.classList.remove('hidden');
+}
+
+function hideTemplateEditor(){
+  const editor = document.getElementById('tplEditor');
+  if(editor) editor.classList.add('hidden');
+  currentTemplateId = null;
+  ['tplHeading','tplIntro','tplAsk','tplAfter','tplEvidence'].forEach(id => {
+    const el = document.getElementById(id);
+    if(el) el.value = '';
+  });
+  updatePreview();
+}
+
 function editTemplate(id){
   const tpl = templates.find(t => t.id === id) || {};
   currentTemplateId = id;
+  showTemplateEditor();
   document.getElementById('tplHeading').value = tpl.heading || '';
   document.getElementById('tplIntro').value = tpl.intro || '';
   document.getElementById('tplAsk').value = tpl.ask || '';
@@ -67,6 +84,7 @@ function useMainTemplate(id){
   const tpl = mainTemplates.find(t => t.id === id);
   if(!tpl) return;
   currentTemplateId = id;
+  showTemplateEditor();
   document.getElementById('tplHeading').value = tpl.heading || '';
   document.getElementById('tplIntro').value = tpl.intro || '';
   document.getElementById('tplAsk').value = tpl.ask || '';
@@ -88,16 +106,14 @@ async function assignMainTemplate(slotId, templateId){
   }
 }
 
-function openTemplateModal(){
+function openTemplateEditor(){
   currentTemplateId = null;
-  document.getElementById('tplModal').style.display='flex';
-  ['modalTplHeading','modalTplIntro','modalTplAsk','modalTplAfter','modalTplEvidence'].forEach(id=>{
-    document.getElementById(id).value='';
+  showTemplateEditor();
+  ['tplHeading','tplIntro','tplAsk','tplAfter','tplEvidence'].forEach(id=>{
+    const el = document.getElementById(id);
+    if(el) el.value='';
   });
-}
-
-function closeTemplateModal(){
-  document.getElementById('tplModal').style.display='none';
+  updatePreview();
 }
 
 async function upsertTemplate(payload){
@@ -134,19 +150,6 @@ async function saveTemplate(){
 function saveTemplateAsNew(){
   currentTemplateId = null;
   saveTemplate();
-}
-
-async function saveTemplateFromModal(){
-  const payload = {
-    heading: document.getElementById('modalTplHeading').value,
-    intro: document.getElementById('modalTplIntro').value,
-    ask: document.getElementById('modalTplAsk').value,
-    afterIssues: document.getElementById('modalTplAfter').value,
-    evidence: document.getElementById('modalTplEvidence').value
-  };
-  const id = await upsertTemplate(payload);
-  if(id) editTemplate(id);
-  closeTemplateModal();
 }
 
 function updatePreview(){
@@ -225,10 +228,8 @@ async function saveSequence(){
 
 document.getElementById('saveTemplate').onclick = saveTemplate;
 document.getElementById('saveTemplateCopy').onclick = saveTemplateAsNew;
-document.getElementById('newTemplate').onclick = openTemplateModal;
-document.getElementById('tplModalClose').onclick = closeTemplateModal;
-document.getElementById('modalSaveTemplate').onclick = saveTemplateFromModal;
-document.getElementById('modalSaveTemplateCopy').onclick = saveTemplateFromModal;
+document.getElementById('newTemplate').onclick = openTemplateEditor;
+document.getElementById('cancelTemplate').onclick = hideTemplateEditor;
 document.getElementById('saveSequence').onclick = saveSequence;
 document.getElementById('newSequence').onclick = newSequence;
 


### PR DESCRIPTION
## Summary
- hide template editor initially and reveal when creating or editing a template
- remove obsolete modal and add cancel button

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'id'))*

------
https://chatgpt.com/codex/tasks/task_e_68c57ef8d40c832391db11dfde8bc904