### PR TITLE
feat: categorize schedule events with availability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Data is stored in a local SQLite file `crm.sqlite` in the CRM directory, replaci
 npm start
 ```
 
+## Schedule
+
+The `/schedule` page hooks into Google Calendar. Click any date to add a booking, meeting, phone call, or availability note. The page checks Google Calendar's free/busy API to prevent double‑booking.
+
 Generate a shareable audit (converts a credit report HTML to JSON and renders it):
 ```bash
 cd "metro2 (copy 1)/crm"


### PR DESCRIPTION
## Summary
- allow calendar entries to include type (booking, meeting, phone, availability)
- check Google Calendar free/busy API before adding events
- document schedule features in README

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'id'))*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c58273e8f88323a5c4fee0caed53c7