### PR TITLE
feat: per-card letter template selection

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -211,12 +211,6 @@
         <div class="flex items-center justify-between">
           <div class="font-semibold">Tradelines</div>
           <div class="flex flex-wrap items-center gap-3">
-            <label class="text-sm flex items-center gap-2" title="Generate correction letters">
-              <input type="radio" name="rtype" value="correct" checked /> Correct
-            </label>
-            <label class="text-sm flex items-center gap-2" title="Generate deletion letters">
-              <input type="radio" name="rtype" value="delete" /> Delete
-            </label>
             <label class="text-sm flex items-center gap-2" title="Generate debt collector letters">
               <input type="checkbox" id="cbCollectors" /> Collectors
             </label>
@@ -295,6 +289,7 @@
       </div>
       <div class="flex items-center gap-2">
         <div class="special-badges flex gap-1"></div>
+        <select class="tl-letter-select text-sm border rounded"></select>
         <select class="tl-playbook-select hidden text-sm border rounded"></select>
         <button class="tl-playbook btn" title="Select playbook">Playbook</button>
         <button class="tl-remove btn" title="Hide this card" data-tip="Remove Card (R when focused)">×</button>

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -1610,7 +1610,7 @@ app.post("/api/generate", authenticate, requirePermission("letters"), async (req
       consumerId,
       reportId,
       selections,
-      requestType,
+      requestType = 'correct',
       personalInfo,
       inquiries,
       collectors,
@@ -1636,7 +1636,8 @@ app.post("/api/generate", authenticate, requirePermission("letters"), async (req
       }
     }
 
-    const letters = generateLetters({ report: reportWrap.data, selections, consumer: consumerForLetter, requestType });
+    const lettersDb = await loadLettersDB();
+    const letters = generateLetters({ report: reportWrap.data, selections, consumer: consumerForLetter, requestType, templates: lettersDb.templates || [] });
     if (Array.isArray(personalInfo) && personalInfo.length) {
       letters.push(
         ...generatePersonalInfoLetters({

--- a/metro2 (copy 1)/crm/tests/authorization.test.js
+++ b/metro2 (copy 1)/crm/tests/authorization.test.js
@@ -6,7 +6,14 @@ import jwt from 'jsonwebtoken';
 import { readKey, writeKey } from '../kvdb.js';
 
 const originalUsers = await readKey('users', null);
-const consumerId = (await readKey('consumers', { consumers: [] })).consumers[0].id;
+let consumerId;
+const consumersDb = await readKey('consumers', null);
+if (consumersDb?.consumers?.length) {
+  consumerId = consumersDb.consumers[0].id;
+} else {
+  consumerId = 'test-consumer';
+  await writeKey('consumers', { consumers: [{ id: consumerId, name: 'Test', reports: [] }] });
+}
 
 
 const admin = { id: 'a1', username: 'admin', password: bcrypt.hashSync('secret', 10), role: 'admin', permissions: [] };


### PR DESCRIPTION
## Summary
- add dropdown on each tradeline card to select Correct/Delete or any custom template
- extend selection state and backend to honor per-card letter types
- cover custom template usage with a new integration test

## Testing
- `npm test` *(fails: only authorization tests run; other suites need seeded data)*
- `node --test tests/generate.test.js` *(fails: missing auth for /api/consumers)*
- `../../python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5820c7f3c8323879d01a7e8a5fb92