### PR TITLE
Return consumers with ok flag

### DIFF
--- a/metro2 (copy 1)/crm/__tests__/api.test.js
+++ b/metro2 (copy 1)/crm/__tests__/api.test.js
@@ -5,6 +5,7 @@ describe("API endpoints", () => {
   test("GET /api/consumers returns list", async () => {
     const res = await request(app).get("/api/consumers");
     expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
     expect(Array.isArray(res.body.consumers)).toBe(true);
   });
 

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -20,7 +20,7 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
   });
 }
 
-let DB = { consumers: [] };
+let DB = [];
 let currentConsumerId = null;
 let currentReportId = null;
 let CURRENT_REPORT = null;
@@ -151,8 +151,8 @@ let consPage = 1;
 
 function filteredConsumers(){
   const q = consQuery.trim().toLowerCase();
-  if (!q) return DB.consumers.slice();
-  return DB.consumers.filter(c=>{
+  if (!q) return DB.slice();
+  return DB.filter(c=>{
     return [c.name,c.email,c.phone,c.addr1,c.city,c.state,c.zip].some(v=> (v||"").toLowerCase().includes(q));
   });
 }
@@ -177,7 +177,7 @@ async function loadConsumers(restore = true){
     showErr(data.error || 'Could not load consumers.');
     return;
   }
-  DB = data;
+  DB = data.consumers;
   renderConsumers();
   if (restore) restoreSelectedConsumer();
 }
@@ -265,7 +265,7 @@ $("#btnSelectNegative")?.addEventListener("click", ()=>{
 
 async function selectConsumer(id){
   currentConsumerId = id;
-  const c = DB.consumers.find(x=>x.id===id);
+  const c = DB.find(x=>x.id===id);
   $("#selConsumer").textContent = c ? c.name : "—";
    setSelectedConsumerId(id);
 
@@ -278,7 +278,7 @@ async function selectConsumer(id){
 
 function restoreSelectedConsumer(){
   const stored = getSelectedConsumerId();
-  if(stored && DB.consumers.find(c=>c.id===stored)){
+  if(stored && DB.find(c=>c.id===stored)){
     selectConsumer(stored);
   }
 }
@@ -1023,7 +1023,7 @@ $("#newForm").addEventListener("submit", async (e)=>{
 $("#btnEditClient").addEventListener("click", ()=>{
   const m = $("#editModal");
   if(!currentConsumerId){ showErr("Select a consumer first."); return; }
-  const c = DB.consumers.find(x=>x.id===currentConsumerId);
+  const c = DB.find(x=>x.id===currentConsumerId);
   if(!c){ showErr("Consumer not found."); return; }
   const f = $("#editForm");
   f.name.value = c.name || "";
@@ -1061,7 +1061,7 @@ $("#editForm").addEventListener("submit", async (e)=>{
   if(!res?.ok) return showErr(res?.error || "Failed to save.");
   closeEdit();
   await loadConsumers(false);
-  const c = DB.consumers.find(x=>x.id===currentConsumerId);
+  const c = DB.find(x=>x.id===currentConsumerId);
   $("#selConsumer").textContent = c ? c.name : "—";
 });
 
@@ -1118,7 +1118,7 @@ $("#fileInput").addEventListener("change", async (e)=>{
 // Data breach lookup
 $("#btnDataBreach").addEventListener("click", async ()=>{
   if(!currentConsumerId) return showErr("Select a consumer first.");
-  const c = DB.consumers.find(x=>x.id===currentConsumerId);
+  const c = DB.find(x=>x.id===currentConsumerId);
   if(!c?.email) return showErr("Selected consumer has no email.");
   const btn = $("#btnDataBreach");
   const old = btn.textContent;

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -624,7 +624,9 @@ function extractCreditScores(html){
 }
 
 // =================== Consumers ===================
-app.get("/api/consumers", authenticate, requirePermission("consumers"), async (_req,res)=> res.json(await loadDB()));
+app.get("/api/consumers", authenticate, requirePermission("consumers"), async (_req, res) => {
+  res.json({ ok: true, consumers: (await loadDB()).consumers });
+});
 app.post("/api/consumers", authenticate, requirePermission("consumers"), async (req,res)=>{
 
   const db = await loadDB();

--- a/metro2 (copy 1)/crm/tests/consumersAllowed.test.js
+++ b/metro2 (copy 1)/crm/tests/consumersAllowed.test.js
@@ -29,6 +29,8 @@ test('member with consumers permission can access /api/consumers', async () => {
 
   const res = await request(app).get('/api/consumers').set('Authorization', 'Bearer ' + memberToken);
   assert.equal(res.status, 200);
+  assert.equal(res.body.ok, true);
+  assert.equal(Array.isArray(res.body.consumers), true);
 
   if (original) await writeKey('users', original); else await writeKey('users', { users: [] });
 });


### PR DESCRIPTION
## Summary
- ensure `/api/consumers` responds with `{ ok: true, consumers: [...] }`
- adjust client script to handle consumers array
- update tests for new consumers response

## Testing
- `node --test tests/consumersAllowed.test.js` *(fails to exit, manual termination after passing)*
- `npx jest __tests__/api.test.js` *(fails: Cannot use import statement outside a module)*


------
https://chatgpt.com/codex/tasks/task_e_68c58eee0368832399d84a0f80b0494c