### PR TITLE
fix: validate auth before redirecting from login

### DIFF
--- a/metro2 (copy 1)/crm/public/login.js
+++ b/metro2 (copy 1)/crm/public/login.js
@@ -1,4 +1,18 @@
 /* public/login.js */
+
+// If a user already has valid auth, skip the login form
+(async () => {
+  const headers = authHeader();
+  if (!headers.Authorization) return; // nothing saved
+  try {
+    const res = await fetch('/api/me', { headers });
+    if (res.ok) {
+      location.href = '/clients';
+    }
+  } catch {
+    /* ignore network or auth errors and show login */
+  }
+})();
 async function handleAuth(endpoint, body, role){
   try{
     const res = await fetch(endpoint,{


### PR DESCRIPTION
## Summary
- Ensure login page only redirects when stored auth token is valid

## Testing
- `npm test` *(fails: process hung, partial output shown)*

------
https://chatgpt.com/codex/tasks/task_e_68c59e20b4048323840fa077722b2e27