### PR TITLE
fix: clear token on auth failure and delay login check

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -170,6 +170,8 @@ async function loadConsumers(restore = true){
   const data = await api("/api/consumers");
   if (data.status === 401 || data.status === 403 || data.error === 'Forbidden') {
     alert('Please log in');
+    localStorage.removeItem('token');
+    localStorage.removeItem('auth');
     location.href = '/login.html';
     return;
   }

--- a/metro2 (copy 1)/crm/public/login.js
+++ b/metro2 (copy 1)/crm/public/login.js
@@ -1,4 +1,18 @@
 /* public/login.js */
+
+// If a user already has valid auth, skip the login form
+document.addEventListener('DOMContentLoaded', async () => {
+  const headers = authHeader();
+  if (!headers.Authorization) return; // nothing saved
+  try {
+    const res = await fetch('/api/me', { headers });
+    if (res.ok) {
+      location.href = '/clients';
+    }
+  } catch {
+    /* ignore network or auth errors and show login */
+  }
+});
 async function handleAuth(endpoint, body, role){
   try{
     const res = await fetch(endpoint,{


### PR DESCRIPTION
## Summary
- Ensure login auto-redirect runs after DOM load so `authHeader` is ready
- Clear stored auth when `/api/consumers` returns 401 to break login loop

## Testing
- `npm test` *(partial output, process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c59e20b4048323840fa077722b2e27