### PR TITLE
Handle forbidden consumer access and role-based redirects

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -168,11 +168,15 @@ function currentPageItems(){
 async function loadConsumers(restore = true){
   clearErr();
   const data = await api("/api/consumers");
-  if (data.status === 401 || data.status === 403 || data.error === 'Forbidden') {
+  if (data.status === 401) {
     alert('Please log in');
     localStorage.removeItem('token');
     localStorage.removeItem('auth');
     location.href = '/login.html';
+    return;
+  }
+  if (data.status === 403 || data.error === 'Forbidden') {
+    alert('Forbidden / ask admin for access');
     return;
   }
   if (data.ok === false || !data.consumers) {


### PR DESCRIPTION
## Summary
- show a forbidden message instead of redirecting on 403 errors when loading consumers
- determine user role after login via `/api/me` and redirect to appropriate portal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b45676988323ae843959eb9dae60