### PR TITLE
Seed default admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ npm install
 
 Data is stored in a local SQLite file `crm.sqlite` in the CRM directory, replacing the old JSON-based storage.
 
+On first run, the server seeds an admin user with username `ducky` and password `duck`.
+
 ## Environment
 - `PORT` (optional, defaults to 3000)
 

--- a/metro2 (copy 1)/crm/README.md
+++ b/metro2 (copy 1)/crm/README.md
@@ -59,6 +59,8 @@ Without them, letter generation will fail with errors like `libnspr4.so: cannot 
    npm start
    ```
 
+   The server seeds a default admin account (`ducky` / `duck`) for first-time access.
+
 4. **Full pipeline demo** – create tradeline cards and a sample dispute letter from the bundled sample report.
 
    ```bash

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -498,11 +498,20 @@ async function loadContactsDB(){
 async function saveContactsDB(db){ await writeKey('contacts', db); }
 
 async function loadUsersDB(){
-  const db = await readKey('users', null);
-  if(db) return db;
-  const def = { users: [] };
-  await writeKey('users', def);
-  return def;
+  let db = await readKey('users', null);
+  if(!db) db = { users: [] };
+  if(!db.users.some(u => u.username === 'ducky')){
+    db.users.push({
+      id: nanoid(10),
+      username: 'ducky',
+      name: 'ducky',
+      password: bcrypt.hashSync('duck', 10),
+      role: 'admin',
+      permissions: []
+    });
+    await writeKey('users', db);
+  }
+  return db;
 }
 async function saveUsersDB(db){ await writeKey('users', db); }
 

--- a/metro2 (copy 1)/crm/tests/consumersAllowed.test.js
+++ b/metro2 (copy 1)/crm/tests/consumersAllowed.test.js
@@ -9,8 +9,7 @@ test('member with consumers permission can access /api/consumers', async () => {
   process.env.NODE_ENV = 'test';
   const { default: app } = await import('../server.js');
 
-  await request(app).post('/api/users').send({ username: 'admin', password: 'secret' });
-  const adminLogin = await request(app).post('/api/login').send({ username: 'admin', password: 'secret' });
+  const adminLogin = await request(app).post('/api/login').send({ username: 'ducky', password: 'duck' });
   const adminToken = adminLogin.body.token;
 
   const memberRes = await request(app)

--- a/metro2 (copy 1)/crm/tests/teamRole.test.js
+++ b/metro2 (copy 1)/crm/tests/teamRole.test.js
@@ -24,8 +24,7 @@ test('team member login issues team role token', async () => {
   process.env.NODE_ENV = 'test';
   const { default: app } = await import('../server.js');
 
-  await request(app).post('/api/users').send({ username: 'admin', password: 'secret' });
-  const adminLogin = await request(app).post('/api/login').send({ username: 'admin', password: 'secret' });
+  const adminLogin = await request(app).post('/api/login').send({ username: 'ducky', password: 'duck' });
   const adminToken = adminLogin.body.token;
 
   const created = await request(app)


### PR DESCRIPTION
## Summary
- seed default admin account `ducky`/`duck`
- adjust tests to authenticate with new default admin
- document default admin credentials in READMEs

## Testing
- `node --test --test-concurrency=1 tests/*.test.js` *(fails: hangs after first test)*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5c19bfcd48323bbfe24830ce7c185