### PR TITLE
Move letter type bar below bureau checkboxes

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -289,7 +289,6 @@
       </div>
       <div class="flex items-center gap-2">
         <div class="special-badges flex gap-1"></div>
-        <select class="tl-letter-select text-sm border rounded"></select>
         <select class="tl-playbook-select hidden text-sm border rounded"></select>
         <button class="tl-playbook btn" title="Select playbook">Playbook</button>
         <button class="tl-remove btn" title="Hide this card" data-tip="Remove Card (R when focused)">×</button>
@@ -301,6 +300,8 @@
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="Experian" /> Experian</label>
       <label class="flex items-center gap-2"><input type="checkbox" class="bureau" value="Equifax" /> Equifax</label>
     </div>
+
+    <select class="tl-letter-select text-sm border rounded w-full mt-2"></select>
 
     <div class="tl-tags flex gap-2 mt-2 flex-wrap"></div>
     <div class="mt-3">


### PR DESCRIPTION
## Summary
- Move letter type selector below TransUnion/Experian/Equifax checkboxes so bar sits underneath bureaus

## Testing
- `npm test`
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5c53d1fb48323a2499feb21ff1acc