### PR TITLE
Expose analyzer errors in upload response

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -1105,6 +1105,13 @@ $("#fileInput").addEventListener("change", async (e)=>{
     });
     const data = await res.json().catch(()=> ({}));
     if(!data?.ok) throw new Error(data?.error || `Upload failed (HTTP ${res.status})`);
+    if (Array.isArray(data.errors) && data.errors.length) {
+      console.warn('Upload completed with errors:', data.errors);
+      const pyErr = data.errors.find(e => e.step === 'python_analyzer');
+      if (pyErr) {
+        alert(`Python analyzer failed: ${pyErr.message}`);
+      }
+    }
     if (data.creditScore) {
       localStorage.setItem("creditScore", JSON.stringify(data.creditScore));
       window.dispatchEvent(new StorageEvent("storage", { key: "creditScore" }));

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -1199,9 +1199,9 @@ app.post("/api/consumers/:id/upload", upload.single("file"), async (req,res)=>{
   if(!consumer) return res.status(404).json({ ok:false, error:"Consumer not found" });
   if(!req.file) return res.status(400).json({ ok:false, error:"No file uploaded" });
 
+  const errors = [];
   try{
     const htmlText = req.file.buffer.toString("utf-8");
-    const errors = [];
     let analyzed = {};
 
     try {
@@ -1308,7 +1308,7 @@ app.post("/api/consumers/:id/upload", upload.single("file"), async (req,res)=>{
     res.json({ ok:true, reportId: rid, creditScore: consumer.creditScore, errors });
   }catch(e){
     logError("UPLOAD_PROCESSING_FAILED", "Analyzer error", e);
-    res.status(500).json({ ok:false, error: "Failed to process uploaded report" });
+    res.status(500).json({ ok:false, error: "Failed to process uploaded report", errors });
   }
 });
 


### PR DESCRIPTION
## Summary
- return analysis errors from `/api/consumers/:id/upload`
- warn UI when `python_analyzer` errors occur during upload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d260cc60832380f5614315e0f410