### PR TITLE
Resolve metro2 violations path dynamically

### DIFF
--- a/shared/violations.js
+++ b/shared/violations.js
@@ -3,14 +3,19 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const METRO2_VIOLATIONS_PATH = path.join(
-  __dirname,
-  '..',
-  'metro2 (copy 1)',
-  'crm',
-  'data',
-  'metro2Violations.json'
-);
+
+function resolveViolationsPath() {
+  const rootDir = path.resolve(__dirname, '..');
+  for (const entry of fs.readdirSync(rootDir)) {
+    const candidate = path.join(rootDir, entry, 'crm', 'data', 'metro2Violations.json');
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error('metro2Violations.json not found');
+}
+
+const METRO2_VIOLATIONS_PATH = resolveViolationsPath();
 
 export function loadMetro2Violations() {
   return JSON.parse(fs.readFileSync(METRO2_VIOLATIONS_PATH, 'utf-8'));


### PR DESCRIPTION
## Summary
- remove hard-coded `metro2 (copy 1)` reference and dynamically locate `metro2Violations.json`

## Testing
- `npm test` (metro2-parser)
- `npm test` (metro2-crm)
- `bash python-tests/run.sh`
- `npm start` (server startup)


------
https://chatgpt.com/codex/tasks/task_e_68c5d2651c688323851ddacd5f6b4b98