### PR TITLE
feat: expand basic rule audit

### DIFF
--- a/metro2 (copy 1)/crm/tests/basicRuleAudit.test.js
+++ b/metro2 (copy 1)/crm/tests/basicRuleAudit.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.NODE_ENV = 'test';
+const { runBasicRuleAudit } = await import('../server.js');
+
+test('flags missing DOFD on charge-off or collection', () => {
+  const report = {
+    tradelines: [
+      {
+        per_bureau: {
+          TransUnion: { account_status: 'Collection' }
+        }
+      }
+    ]
+  };
+  runBasicRuleAudit(report);
+  const viols = report.tradelines[0].violations || [];
+  assert.ok(viols.some(v => v.id === 'MISSING_DOFD'));
+});
+
+test('flags balance mismatch across bureaus', () => {
+  const report = {
+    tradelines: [
+      {
+        per_bureau: {
+          TransUnion: { balance: '$100' },
+          Experian: { balance: '$200' }
+        }
+      }
+    ]
+  };
+  runBasicRuleAudit(report);
+  const viols = report.tradelines[0].violations || [];
+  assert.ok(viols.some(v => v.id === 'BALANCE_MISMATCH'));
+});


### PR DESCRIPTION
## Summary
- add missing DOFD and balance mismatch checks to basic rule audit
- cover rule audit cases with unit tests

## Testing
- `node --test tests/basicRuleAudit.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c5d26e02a08323ac633e6dcd91fc43