### PR TITLE
feat: surface violation debug info in reports

### DIFF
--- a/metro2 (copy 1)/crm/creditAuditTool.js
+++ b/metro2 (copy 1)/crm/creditAuditTool.js
@@ -84,7 +84,8 @@ function buildIssues(tl, idxs = null){
         bureau: v.evidence?.bureau || 'All Bureaus',
         severity: v.severity,
         fcra: legal.fcra,
-        fdcpa: legal.fdcpa
+        fdcpa: legal.fdcpa,
+        debug: v.debug
       };
     });
 }
@@ -188,7 +189,8 @@ export function renderHtml(report, consumerName = "Consumer"){
         const action = recommendAction(i.title);
         const code = i.code ? `[${escapeHtml(i.code)}] ` : "";
         const sev = i.severity ? ` (Severity ${escapeHtml(String(i.severity))})` : "";
-        return `<li><strong>${escapeHtml(i.bureau)}</strong>: ${code}${escapeHtml(i.title)}${sev} - This violates Metro 2 standard because ${escapeHtml(i.detail || "")}. It also violates FCRA ${escapeHtml(i.fcra)} and FDCPA ${escapeHtml(i.fdcpa)}. ${escapeHtml(action)}</li>`;
+        const debugBlock = i.debug ? `<pre class="debug">${escapeHtml(i.debug)}</pre>` : "";
+        return `<li><strong>${escapeHtml(i.bureau)}</strong>: ${code}${escapeHtml(i.title)}${sev} - This violates Metro 2 standard because ${escapeHtml(i.detail || "")}. It also violates FCRA ${escapeHtml(i.fcra)} and FDCPA ${escapeHtml(i.fdcpa)}. ${escapeHtml(action)}${debugBlock}</li>`;
 
       }).filter(Boolean).join('');
     const issueBlock = issueItems ? `<p><strong>Audit Reasons:</strong></p><ul>${issueItems}</ul>` : "";
@@ -213,6 +215,7 @@ export function renderHtml(report, consumerName = "Consumer"){
   th.bureau{text-align:center;background:#f5f5f5;}
   tr.diff td{background:#fff3cd;}
   .neg{background:#fee2e2;color:#b91c1c;}
+  pre.debug{background:#f3f4f6;border:1px solid #ddd;padding:4px;white-space:pre-wrap;font-size:0.8em;margin-top:4px;}
   footer{margin-top:40px;font-size:0.8em;color:#555;}
   </style></head>
   <body>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -504,10 +504,11 @@ export function mergeBureauViolations(vs){
     const id = v.id || v.code || "";
     const bureaus = v.bureaus || [v.evidence?.bureau || v.bureau || m[1]].filter(Boolean);
     const key = `${id}|${v.category||""}|${base}|${evKey}`;
-    if(!map.has(key)) map.set(key,{category:v.category,title:base,bureaus:new Set(),details:new Set(),severity:v.severity||0});
+    if(!map.has(key)) map.set(key,{category:v.category,title:base,bureaus:new Set(),details:new Set(),debugs:new Set(),severity:v.severity||0});
     const entry = map.get(key);
     bureaus.forEach(bureau => entry.bureaus.add(bureau));
     if(detailClean) entry.details.add(detailClean);
+    if(v.debug) entry.debugs.add(v.debug);
     if((v.severity||0) > entry.severity) entry.severity = v.severity||0;
 
   });
@@ -516,7 +517,8 @@ export function mergeBureauViolations(vs){
     title: e.title,
     detail: Array.from(e.details).join(' '),
     severity: e.severity,
-    bureaus: Array.from(e.bureaus)
+    bureaus: Array.from(e.bureaus),
+    debug: Array.from(e.debugs).join('\n')
   }));
 }
 
@@ -744,6 +746,7 @@ function renderTradelines(tradelines){
             <div class="font-medium text-sm wrap-anywhere">${escapeHtml(v.category || "")} – ${escapeHtml(v.title || "")}${v.severity ? `<span class="severity-tag severity-${v.severity}">S${v.severity}</span>` : ""}</div>
             ${v.bureaus && v.bureaus.length ? `<div class="text-xs mt-1">${v.bureaus.map(b=>'<span class="badge badge-bureau">'+escapeHtml(b)+'</span>').join(' ')}</div>` : ""}
             ${v.detail ? `<div class="text-sm text-gray-600 wrap-anywhere">${escapeHtml(v.detail)}</div>` : ""}
+            ${v.debug ? `<pre class="debug">${escapeHtml(v.debug)}</pre>` : ""}
           </div>
         </label>`).join("");
 
@@ -887,6 +890,7 @@ function buildZoomHTML(tl){
     <li class="mb-2">
       <div class="font-medium">${escapeHtml(v.category||"")} – ${escapeHtml(v.title||"")}${v.bureaus && v.bureaus.length ? ' '+v.bureaus.map(b=>'<span class="badge badge-bureau">'+escapeHtml(b)+'</span>').join(' ') : ''}</div>
       ${v.detail? `<div class="text-gray-600">${escapeHtml(v.detail)}</div>` : ""}
+      ${v.debug ? `<pre class="debug">${escapeHtml(v.debug)}</pre>` : ""}
     </li>`).join("") || "<div class='text-sm muted'>No violations detected.</div>";
 
   return `

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -269,4 +269,14 @@ header .group > div.absolute {
   z-index: 100 !important;
 }
 
+pre.debug {
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  padding: 4px;
+  margin-top: 4px;
+  white-space: pre-wrap;
+  font-size: 0.75rem;
+  color: #374151;
+}
+
 

--- a/metro2 (copy 1)/crm/tests/violationMapping.test.js
+++ b/metro2 (copy 1)/crm/tests/violationMapping.test.js
@@ -35,6 +35,7 @@ test('mergeBureauViolations merges same violation across bureaus', async () => {
   globalThis.window = {};
   globalThis.MutationObserver = class { observe(){} disconnect(){} };
   globalThis.localStorage = { getItem: () => null, setItem: () => {} };
+  globalThis.location = { search: '', pathname: '/' };
 
   const { mergeBureauViolations } = await import('../public/index.js');
   const input = [
@@ -82,6 +83,7 @@ test('mergeBureauViolations merges bureaus array into single violation', async (
   globalThis.window = {};
   globalThis.MutationObserver = class { observe(){} disconnect(){} };
   globalThis.localStorage = { getItem: () => null, setItem: () => {} };
+  globalThis.location = { search: '', pathname: '/' };
 
   const { mergeBureauViolations } = await import('../public/index.js');
   const merged = mergeBureauViolations([


### PR DESCRIPTION
## Summary
- preserve `debug` field when normalizing audit issues
- show debug blocks in HTML/PDF reports and tradeline UI
- style debug `<pre>` blocks and update tests for new globals

## Testing
- `node --test tests/violationMapping.test.js`
- `node --test tests/dedupeTradelines.test.js`
- `node creditAuditTool.js /tmp/report-debug.json` *(fails: missing Chromium libs; saved HTML fallback)*


------
https://chatgpt.com/codex/tasks/task_e_68c5e3e6b7e08323a1d5b9681268fc5f