### PR TITLE
Guard report parsing against empty data

### DIFF
--- a/metro2 (copy 1)/crm/creditAuditTool.js
+++ b/metro2 (copy 1)/crm/creditAuditTool.js
@@ -32,7 +32,8 @@ async function fetchCreditReport(srcPath){
         });
       });
     } catch(err) {
-      throw new Error(`Failed to convert HTML report: ${err.message}`);
+      console.error(`Failed to convert HTML report: ${err.message}`);
+      return {};
     }
     reportPath = outPath;
   }
@@ -41,13 +42,15 @@ async function fetchCreditReport(srcPath){
   try {
     raw = await fs.readFile(reportPath, 'utf-8');
   } catch(err) {
-    throw new Error(`Failed to read report: ${err.message}`);
+    console.error(`Failed to read report: ${err.message}`);
+    return {};
   }
 
   try {
     return JSON.parse(raw);
   } catch(err) {
-    throw new Error(`Invalid report JSON: ${err.message}`);
+    console.error(`Invalid report JSON: ${err.message}`);
+    return {};
   }
 }
 

--- a/metro2 (copy 1)/crm/parser.js
+++ b/metro2 (copy 1)/crm/parser.js
@@ -17,6 +17,9 @@ function parseCreditReportHTML(doc) {
   const tlTables = Array.from(
     doc.querySelectorAll("table.rpt_content_table.rpt_content_header.rpt_table4column")
   );
+  if (!tlTables.length) {
+    throw new Error("No tradeline tables found");
+  }
 
   // Parse each tradeline table block
   for (const table of tlTables) {
@@ -140,7 +143,10 @@ function parseCreditReportHTML(doc) {
       tl.history_summary = hist.summary;
     }
 
-    results.tradelines.push(tl);
+    const hasData = Object.values(tl.per_bureau).some((pb) => Object.keys(pb).length);
+    if (hasData) {
+      results.tradelines.push(tl);
+    }
   }
 
   // ---- F) Inquiries (hard pulls) ----


### PR DESCRIPTION
## Summary
- throw explicit error when tradeline tables are absent and skip empty tradeline blocks
- harden credit report ingestion against HTML conversion and JSON parse failures

## Testing
- `npm test`
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5e59f1e2483238cb249fa2e127ee9