### PR TITLE
Add Date Closed parsing and normalization

### DIFF
--- a/metro2 (copy 1)/crm/parser.js
+++ b/metro2 (copy 1)/crm/parser.js
@@ -74,6 +74,7 @@ function parseCreditReportHTML(doc) {
       rule("Last Reported", ["last_reported"]),
       rule(/(Date\s*of\s*)?Last Payment(?:\s*Date)?/i, ["date_last_payment"]),
       rule("Date Last Active", ["date_last_active"]),
+      rule("Date Closed", ["date_closed"]),
       rule(/Date(?: of)? First Delinquency/i, ["date_first_delinquency"]),
       rule("No. of Months (terms)", ["months_terms"]),
 
@@ -300,7 +301,7 @@ function parseCreditReportHTML(doc) {
     }
 
     // dates -> output as MM/DD/YYYY when possible
-    if (["date_opened", "last_reported", "date_last_payment", "date_last_active"].includes(field)) {
+    if (["date_opened", "last_reported", "date_last_payment", "date_last_active", "date_closed"].includes(field)) {
       const d = coerceDateMDY(v);
       return d || v;
     }


### PR DESCRIPTION
## Summary
- parse `Date Closed` rows in credit report tables
- normalize `date_closed` field as a date for consistent formatting

## Testing
- `node --test tests/parser*.test.js` (fails: No tradeline tables found)

------
https://chatgpt.com/codex/tasks/task_e_68c5f896f8848323b30faab8cad9e1ab