### PR TITLE
Add New Event button to schedule page

### DIFF
--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -59,6 +59,7 @@
 </header>
 <main class="max-w-7xl mx-auto p-4">
   <h1 class="text-2xl font-bold mb-4">Schedule</h1>
+  <button id="newEvent" class="btn mb-4">New Event</button>
   <div class="grid md:grid-cols-3 gap-4">
     <div id="appointmentList" class="glass card md:col-span-1"></div>
     <div class="md:col-span-2">

--- a/metro2 (copy 1)/crm/public/schedule.js
+++ b/metro2 (copy 1)/crm/public/schedule.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const saveBtn = document.getElementById('saveEvent');
   const deleteBtn = document.getElementById('deleteEvent');
   const cancelBtn = document.getElementById('cancelEvent');
+  const newBtn = document.getElementById('newEvent');
 
   let current = new Date();
   let events = [];
@@ -175,6 +176,7 @@ document.addEventListener('DOMContentLoaded', () => {
       await addEvent(dateStr, type, text);
     }
     closeModal();
+    render();
   });
 
   deleteBtn.addEventListener('click', async () => {
@@ -185,6 +187,11 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   cancelBtn.addEventListener('click', closeModal);
+
+  newBtn.addEventListener('click', () => {
+    const today = new Date().toISOString().split('T')[0];
+    openModal(today);
+  });
 
   prevBtn.addEventListener('click', () => { current.setMonth(current.getMonth() - 1); render(); });
   nextBtn.addEventListener('click', () => { current.setMonth(current.getMonth() + 1); render(); });


### PR DESCRIPTION
## Summary
- add a "New Event" button to the schedule page
- wire the button to open the modal with today's date
- re-render calendar and close modal after saving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5fc09d7c88323820103d52660f9da