### PR TITLE
Handle violation-only violations in UI

### DIFF
--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -495,9 +495,11 @@ export function dedupeTradelines(lines){
 export function mergeBureauViolations(vs){
   const map = new Map();
   (vs || []).forEach(v => {
-    const m = v.title?.match(/\((TransUnion|Experian|Equifax)\)/) || [];
-    const base = (v.title || "").replace(/\s*\((TransUnion|Experian|Equifax)\)/g, "").trim();
-    const detailClean = (v.detail || "").replace(/\s*\((TransUnion|Experian|Equifax)\)/g, "").trim();
+    const text = v.title || v.violation || "";
+    const m = text.match(/\((TransUnion|Experian|Equifax)\)/) || [];
+    const base = text.replace(/\s*\((TransUnion|Experian|Equifax)\)/g, "").trim();
+    const detailSrc = v.title ? (v.detail || "") : (v.detail || v.violation || "");
+    const detailClean = detailSrc.replace(/\s*\((TransUnion|Experian|Equifax)\)/g, "").trim();
     const evCopy = v.evidence ? JSON.parse(JSON.stringify(v.evidence)) : {};
     delete evCopy.bureau;
     const evKey = detailClean || JSON.stringify(evCopy);
@@ -743,7 +745,7 @@ function renderTradelines(tradelines){
         <label class="violation-item flex items-start gap-2 p-2 rounded hover:bg-gray-50 cursor-pointer severity-${v.severity || 1}">
           <input type="checkbox" class="violation" value="${vidx + vStart}"/>
           <div>
-            <div class="font-medium text-sm wrap-anywhere">${escapeHtml(v.category || "")} – ${escapeHtml(v.title || "")}${v.severity ? `<span class="severity-tag severity-${v.severity}">S${v.severity}</span>` : ""}</div>
+            <div class="font-medium text-sm wrap-anywhere">${escapeHtml(v.category || "")} – ${escapeHtml(v.title || v.violation || "")}${v.severity ? `<span class="severity-tag severity-${v.severity}">S${v.severity}</span>` : ""}</div>
             ${v.bureaus && v.bureaus.length ? `<div class="text-xs mt-1">${v.bureaus.map(b=>'<span class="badge badge-bureau">'+escapeHtml(b)+'</span>').join(' ')}</div>` : ""}
             ${v.detail ? `<div class="text-sm text-gray-600 wrap-anywhere">${escapeHtml(v.detail)}</div>` : ""}
             ${v.debug ? `<pre class="debug">${escapeHtml(v.debug)}</pre>` : ""}

--- a/metro2 (copy 1)/crm/tests/violationMapping.test.js
+++ b/metro2 (copy 1)/crm/tests/violationMapping.test.js
@@ -93,3 +93,38 @@ test('mergeBureauViolations merges bureaus array into single violation', async (
   assert.deepEqual(merged[0].bureaus.sort(), ['Experian','TransUnion']);
 
 });
+
+test('renderViolations shows violation text when title missing', async () => {
+  const stubEl = {};
+  stubEl.addEventListener = () => {};
+  stubEl.classList = { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} };
+  stubEl.querySelector = () => stubEl;
+  stubEl.querySelectorAll = () => [];
+  stubEl.appendChild = () => {};
+  stubEl.innerHTML = '';
+  stubEl.textContent = '';
+  stubEl.style = {};
+  stubEl.dataset = {};
+  globalThis.document = {
+    querySelector: () => stubEl,
+    querySelectorAll: () => [],
+    getElementById: () => stubEl,
+    addEventListener: () => {},
+    createElement: () => stubEl,
+    body: { style: {} }
+  };
+  globalThis.window = {};
+  globalThis.MutationObserver = class { observe(){} disconnect(){} };
+  globalThis.localStorage = { getItem: () => null, setItem: () => {} };
+  globalThis.location = { search: '', pathname: '/' };
+
+  const { mergeBureauViolations } = await import('../public/index.js');
+  const merged = mergeBureauViolations([
+    { category: 'cat', violation: 'Only violation field', severity: 1 }
+  ]);
+
+  const html = merged.map(v => `
+    <div class="font-medium text-sm wrap-anywhere">${v.category || ''} – ${v.title || v.violation || ''}</div>
+  `).join('');
+  assert.ok(html.includes('Only violation field'));
+});


### PR DESCRIPTION
## Summary
- Fall back to `violation` text when `title` is missing during bureau violation merge
- Show `${v.title || v.violation}` in tradeline violation rendering
- Add unit test for violation-only entries

## Testing
- `npm test` *(hangs after initial suite)*
- `node --test tests/violationMapping.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6086fd60c8323beffbee14471bb36