### PR TITLE
docs: explain google calendar setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ npm start
 
 The `/schedule` page hooks into Google Calendar. Click any date to add a booking, meeting, phone call, or availability note. The page checks Google Calendar's free/busy API to prevent double‑booking.
 
+### Google Calendar setup
+
+1. Visit the [Google Cloud Console](https://console.cloud.google.com/) and create a project.
+2. Enable the **Google Calendar API** for the project and generate an OAuth access token or service account.
+3. In Google Calendar, open **Settings → Integrate calendar** to copy the calendar's **Calendar ID**.
+4. Paste the token and Calendar ID into the Settings page under **Google Calendar Token** and **Google Calendar ID**, then save.
+
 Generate a shareable audit (converts a credit report HTML to JSON and renders it):
 ```bash
 cd "metro2 (copy 1)/crm"

--- a/metro2 (copy 1)/crm/public/settings.js
+++ b/metro2 (copy 1)/crm/public/settings.js
@@ -12,6 +12,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const saveBtn = document.getElementById('saveSettings');
   const msgEl = document.getElementById('saveMsg');
 
+  if (gcalIdEl) {
+    const help = document.createElement('div');
+    help.className = 'text-xs text-gray-600';
+    help.innerHTML = `
+      <p>Google Calendar setup / Configuración:</p>
+      <ol class="list-decimal list-inside">
+        <li><a href="https://console.cloud.google.com/" class="underline" target="_blank" rel="noopener">Google Cloud Console</a>: create project & enable Calendar API / crea un proyecto y habilita la API de Calendar.</li>
+        <li>Generate an OAuth token or service account and share it with your calendar / Genera un token OAuth o una cuenta de servicio y compártelo con tu calendario.</li>
+        <li>From Google Calendar settings &gt; Integrate calendar, copy the <em>Calendar ID</em> / En Configuración &gt; Integrar calendario, copia el <em>ID del calendario</em>.</li>
+        <li>Paste the token & ID above and save / Pega el token y el ID arriba y guarda.</li>
+      </ol>`;
+    gcalIdEl.insertAdjacentElement('afterend', help);
+  }
+
   const hotkeyEls = {
     help: document.getElementById('hotkeyHelp'),
     newConsumer: document.getElementById('hotkeyNewConsumer'),

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -269,7 +269,13 @@ const TEAM_TEMPLATE = (()=>{
 app.get("/dashboard", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "dashboard.html")));
 app.get("/clients", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "index.html")));
 app.get("/leads", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "leads.html")));
-app.get("/schedule", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "schedule.html")));
+app.get("/schedule", async (_req, res) => {
+  const settings = await loadSettings();
+  if (!settings.googleCalendarToken || !settings.googleCalendarId) {
+    return res.status(400).send("Google Calendar token or ID missing. Add them in Settings before using the schedule.");
+  }
+  res.sendFile(path.join(PUBLIC_DIR, "schedule.html"));
+});
 app.get("/my-company", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "my-company.html")));
 app.get("/billing", (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "billing.html")));
 app.get(["/letters", "/letters/:jobId"], optionalAuth, forbidMember, (_req, res) =>


### PR DESCRIPTION
## Summary
- document how to fetch a Google Calendar token and calendar ID
- show inline help on the settings page for Calendar setup
- block schedule access until token and calendar ID are provided

## Testing
- `npm test` *(fails: process hung, logs show all tests passing)*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c60b6ef6c083239e6887f191139e63