### PR TITLE
Add fallback detail for Metro 2 violations missing snippets

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -25,7 +25,7 @@ function filterViolationsBySeverity(violations = [], minSeverity = 1, locale = '
       return {
         ...v,
         ...meta,
-        detail: meta.snippets?.[locale] || v.detail,
+        detail: meta.snippets?.[locale] || v.detail || meta.violation,
         severity: getSeverity(v),
       };
     });

--- a/metro2 (copy 1)/crm/tests/violationDetails.test.js
+++ b/metro2 (copy 1)/crm/tests/violationDetails.test.js
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { filterViolationsBySeverity } from '../letterEngine.js';
+
+test('filterViolationsBySeverity falls back to violation text when snippet missing', () => {
+  const result = filterViolationsBySeverity([
+    { code: 'CURRENT_BUT_PASTDUE' }
+  ]);
+  assert.equal(result[0].detail, 'Past due amount reported on current account');
+});


### PR DESCRIPTION
## Summary
- default violation detail to base text when snippets are absent
- test that filterViolationsBySeverity provides fallback detail

## Testing
- `node --test tests/violationDetails.test.js`
- `npm test` *(fails: hung after several tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c6103f50d0832388de22a28760ae21