### PR TITLE
Skip generating letters for empty bureaus

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -791,9 +791,12 @@ function generateLetters({ report, selections, consumer, requestType = "correct"
     }
 
     // Auto-flag: negative appears on one bureau only => incomplete/misleading
-    const bureausPresent = Object.entries(tl.per_bureau || {})
-      .filter(([_, pb]) => hasAnyData(pb))
-      .map(([b]) => b);
+    const bureausWithData = new Set(
+      Object.entries(tl.per_bureau || {})
+        .filter(([_, pb]) => hasAnyData(pb))
+        .map(([b]) => b)
+    );
+    const bureausPresent = Array.from(bureausWithData);
 
     if (
       bureausPresent.length === 1 &&
@@ -828,6 +831,7 @@ function generateLetters({ report, selections, consumer, requestType = "correct"
       const dateOverride = play ? futureISO(stepIdx * 30) : undefined;
       for (const bureau of sel.bureaus || []) {
         if (!ALL_BUREAUS.includes(bureau)) continue;
+        if (!bureausWithData.has(bureau)) continue;
 
         const req = sel.requestType || requestType;
         const tpl = sel.templateId ? templateMap[sel.templateId] : null;

--- a/metro2 (copy 1)/crm/tests/letterEngine.test.js
+++ b/metro2 (copy 1)/crm/tests/letterEngine.test.js
@@ -4,6 +4,7 @@ import {
   generatePersonalInfoLetters,
   generateInquiryLetters,
   generateDebtCollectorLetters,
+  generateLetters,
 } from '../letterEngine.js';
 
 const consumer = {
@@ -42,5 +43,23 @@ test('collector letter includes collector name', () => {
   });
   assert.match(letter.html, /Debt Validation Request/);
   assert.match(letter.html, /Collection Co/);
+});
+
+test('generateLetters skips bureaus with no data', () => {
+  const report = {
+    tradelines: [
+      {
+        meta: { creditor: 'Cred' },
+        per_bureau: {
+          TransUnion: { account_number: '123', balance: 100 },
+          Equifax: {},
+        },
+      },
+    ],
+  };
+  const selections = [{ tradelineIndex: 0, bureaus: ['TransUnion', 'Equifax'] }];
+  const letters = generateLetters({ report, selections, consumer });
+  assert.equal(letters.length, 1);
+  assert.equal(letters[0].bureau, 'TransUnion');
 });
 


### PR DESCRIPTION
## Summary
- avoid generating dispute letters for bureaus without data
- test letter engine skips blank bureaus

## Testing
- `node --test tests/letterEngine.test.js`
- `npm test` *(fails: hung during execution)*

------
https://chatgpt.com/codex/tasks/task_e_68c612d0d7608323ab81fe06b5f6b01c