### PR TITLE
Add rule engine for Metro-2 tradeline validation

### DIFF
--- a/metro2 (copy 1)/crm/data/metro2Violations.json
+++ b/metro2 (copy 1)/crm/data/metro2Violations.json
@@ -6,7 +6,13 @@
       "Date of First Delinquency"
     ],
     "severity": 5,
-    "fcraSection": "§ 623(a)(5)"
+    "fcraSection": "§ 623(a)(5)",
+    "rule": {
+      "all": [
+        { "field": "account_status", "eq": "Charge-off" },
+        { "field": "date_first_delinquency", "exists": false }
+      ]
+    }
   },
   "LATE_STATUS_NO_PASTDUE": {
     "id": 2,
@@ -115,7 +121,13 @@
       "Account Status"
     ],
     "severity": 4,
-    "fcraSection": "§ 623(a)(1)"
+    "fcraSection": "§ 623(a)(1)",
+    "rule": {
+      "all": [
+        { "field": "account_status", "eq": "Current" },
+        { "field": "past_due", "gt": 0 }
+      ]
+    }
   },
   "13": {
     "id": 13,

--- a/metro2-parser/src/ruleEngine.js
+++ b/metro2-parser/src/ruleEngine.js
@@ -1,0 +1,42 @@
+import { loadMetro2Violations } from './utils.js';
+
+const definitions = loadMetro2Violations();
+
+function compare(cond, value) {
+  if ('eq' in cond) return value === cond.eq;
+  if ('ne' in cond) return value !== cond.ne;
+  if ('gt' in cond) return Number(value) > cond.gt;
+  if ('gte' in cond) return Number(value) >= cond.gte;
+  if ('lt' in cond) return Number(value) < cond.lt;
+  if ('lte' in cond) return Number(value) <= cond.lte;
+  if ('exists' in cond) {
+    const exists = value !== undefined && value !== null && value !== '';
+    return cond.exists ? exists : !exists;
+  }
+  return false;
+}
+
+function evalRule(rule, tl) {
+  if (rule.all) return rule.all.every(r => evalRule(r, tl));
+  if (rule.any) return rule.any.some(r => evalRule(r, tl));
+  return compare(rule, tl[rule.field]);
+}
+
+export function runRules(tl) {
+  const out = [];
+  for (const [code, def] of Object.entries(definitions)) {
+    if (!def.rule) continue;
+    if (evalRule(def.rule, tl)) {
+      const { id, violation, severity, fcraSection } = def;
+      out.push({ id, code, violation, severity, fcraSection });
+    }
+  }
+  return out;
+}
+
+export function enrich(code, extra = {}) {
+  const key = code.toUpperCase();
+  const base = definitions[key] || { violation: 'Unknown violation code' };
+  return { code: key, ...base, ...extra };
+}
+

--- a/metro2-parser/src/validators.js
+++ b/metro2-parser/src/validators.js
@@ -1,21 +1,2 @@
-import { loadMetro2Violations } from './utils.js';
+export { enrich, runRules as validateTradeline } from './ruleEngine.js';
 
-const metadata = loadMetro2Violations();
-
-export function enrich(code, extra = {}) {
-  const key = code.toUpperCase();
-  const base = metadata[key] || { violation: 'Unknown violation code' };
-  return { code: key, ...base, ...extra };
-
-}
-
-export function validateTradeline(t){
-  const violations = [];
-  if(t.account_status === "Current" && t.past_due > 0){
-    violations.push(enrich("CURRENT_BUT_PASTDUE"));
-  }
-  if(t.account_status === "Charge-off" && !t.date_first_delinquency){
-    violations.push(enrich("MISSING_DOFD"));
-  }
-  return violations;
-}


### PR DESCRIPTION
## Summary
- add optional rule definitions to metro2 violations metadata
- implement generic rule engine to evaluate tradelines
- replace validateTradeline with dynamic rules and expand tests

## Testing
- `cd metro2-parser && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6165f20408323966430c83354e1d7