### PR TITLE
feat: allow custom Metro-2 violations path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ On first run, the server seeds an admin user with username `ducky` and password 
 
 ## Environment
 - `PORT` (optional, defaults to 3000)
+- `METRO2_VIOLATIONS_PATH` (optional; path to `metro2Violations.json`. If unset, the app searches the repo.)
+
+Copy `.env.sample` to `.env` and adjust values as needed.
 
 ## Run
 ```bash

--- a/metro2 (copy 1)/crm/.env.sample
+++ b/metro2 (copy 1)/crm/.env.sample
@@ -1,0 +1,3 @@
+PORT=3000
+# Path to metro2Violations.json
+METRO2_VIOLATIONS_PATH=./data/metro2Violations.json

--- a/shared/violations.js
+++ b/shared/violations.js
@@ -5,6 +5,15 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function resolveViolationsPath() {
+  const envPath = process.env.METRO2_VIOLATIONS_PATH;
+  if (envPath) {
+    const absoluteEnvPath = path.resolve(envPath);
+    if (fs.existsSync(absoluteEnvPath)) {
+      return absoluteEnvPath;
+    }
+    throw new Error(`METRO2_VIOLATIONS_PATH not found at ${absoluteEnvPath}`);
+  }
+
   const rootDir = path.resolve(__dirname, '..');
   for (const entry of fs.readdirSync(rootDir)) {
     const candidate = path.join(rootDir, entry, 'crm', 'data', 'metro2Violations.json');
@@ -12,11 +21,16 @@ function resolveViolationsPath() {
       return candidate;
     }
   }
-  throw new Error('metro2Violations.json not found');
+  throw new Error(
+    'metro2Violations.json not found. Set METRO2_VIOLATIONS_PATH to override the default search.'
+  );
 }
 
 const METRO2_VIOLATIONS_PATH = resolveViolationsPath();
 
 export function loadMetro2Violations() {
+  if (!fs.existsSync(METRO2_VIOLATIONS_PATH)) {
+    throw new Error(`metro2Violations.json missing at ${METRO2_VIOLATIONS_PATH}`);
+  }
   return JSON.parse(fs.readFileSync(METRO2_VIOLATIONS_PATH, 'utf-8'));
 }


### PR DESCRIPTION
## Summary
- allow overriding `metro2Violations.json` location with `METRO2_VIOLATIONS_PATH`
- add missing-file validation and clearer errors
- document `METRO2_VIOLATIONS_PATH` and provide `.env.sample`

## Testing
- `npm test`
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6166b33b083238df6b69bb4d01a7c