### PR TITLE
Fix violation merging and display per tradeline

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -1246,8 +1246,14 @@ app.post("/api/consumers/:id/upload", upload.single("file"), async (req,res)=>{
         const base = analyzed.tradelines[idx] || (analyzed.tradelines[idx] = {});
         base.meta = deepMerge(base.meta, tl.meta);
         base.per_bureau = deepMerge(base.per_bureau, tl.per_bureau);
-        base.violations = tl.violations || base.violations || [];
-        base.violations_grouped = tl.violations_grouped || base.violations_grouped || {};
+        base.violations = [
+          ...(base.violations || []),
+          ...(tl.violations || []),
+        ];
+        base.violations_grouped = deepMerge(
+          base.violations_grouped || {},
+          tl.violations_grouped || {}
+        );
       });
       if (!analyzed.personalInfo && py?.personalInfo) {
         analyzed.personalInfo = py.personalInfo;

--- a/metro2 (copy 1)/crm/tests/violationMapping.test.js
+++ b/metro2 (copy 1)/crm/tests/violationMapping.test.js
@@ -94,6 +94,38 @@ test('mergeBureauViolations merges bureaus array into single violation', async (
 
 });
 
+test('mergeBureauViolations preserves first violation index', async () => {
+  const stubEl = {};
+  stubEl.addEventListener = () => {};
+  stubEl.classList = { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} };
+  stubEl.querySelector = () => stubEl;
+  stubEl.querySelectorAll = () => [];
+  stubEl.appendChild = () => {};
+  stubEl.innerHTML = '';
+  stubEl.textContent = '';
+  stubEl.style = {};
+  stubEl.dataset = {};
+  globalThis.document = {
+    querySelector: () => stubEl,
+    querySelectorAll: () => [],
+    getElementById: () => stubEl,
+    addEventListener: () => {},
+    createElement: () => stubEl,
+    body: { style: {} }
+  };
+  globalThis.window = {};
+  globalThis.MutationObserver = class { observe(){} disconnect(){} };
+  globalThis.localStorage = { getItem: () => null, setItem: () => {} };
+  globalThis.location = { search: '', pathname: '/' };
+
+  const { mergeBureauViolations } = await import('../public/index.js');
+  const merged = mergeBureauViolations([
+    { id: 'A1', category: 'cat', title: 'Same Title', detail: 'Same Detail', evidence: { bureau: 'TransUnion' } },
+    { id: 'A1', category: 'cat', title: 'Same Title', detail: 'Same Detail', evidence: { bureau: 'Experian' } },
+  ]);
+  assert.equal(merged[0].idx, 0);
+});
+
 test('renderViolations shows violation text when title missing', async () => {
   const stubEl = {};
   stubEl.addEventListener = () => {};


### PR DESCRIPTION
## Summary
- merge Python and JS analyzer violations instead of overriding
- track original violation indexes when merging for accurate card rendering
- add regression test for index preservation

## Testing
- `node --test tests/violationMapping.test.js`
- `npm test` *(fails: process terminated due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c61f6fc9d48323b41c92a38a5c6e6b