### PR TITLE
Skip Risk Factors tables and add parser regression test

### DIFF
--- a/metro2 (copy 1)/crm/parser.js
+++ b/metro2 (copy 1)/crm/parser.js
@@ -12,6 +12,7 @@
 
 function parseCreditReportHTML(doc) {
   const results = { tradelines: [], inquiries: [], inquiry_summary: {} };
+  const NON_CREDITOR_HEADERS = new Set(["risk factors"]);
 
   // ---- Locate all tradeline comparison tables ----
   const tlTables = Array.from(
@@ -46,7 +47,11 @@ function parseCreditReportHTML(doc) {
 
     // ---- A) Creditor (header above the table) ----
     const creditorEl = container.querySelector("div.sub_header");
-    tl.meta.creditor = text(creditorEl) || "Unknown";
+    const creditorName = (text(creditorEl) || "").trim();
+    if (NON_CREDITOR_HEADERS.has(creditorName.toLowerCase())) {
+      continue; // skip non-creditor sections like "Risk Factors"
+    }
+    tl.meta.creditor = creditorName || "Unknown";
 
     // ---- B) Bureau order from the header row ----
     const trs = rows(table);

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -466,7 +466,7 @@ export function dedupeTradelines(lines){
   const result = [];
   (lines || []).forEach(tl => {
     const name = (tl.meta?.creditor || "").trim();
-    if (!name || name.toLowerCase() === "risk factors") return;
+    if (!name) return;
     const per = tl.per_bureau || {};
     const hasData = ["TransUnion","Experian","Equifax"].some(b => Object.keys(per[b] || {}).length);
     const hasViolations = (tl.violations || []).length > 0;

--- a/metro2 (copy 1)/crm/tests/parserRiskFactors.test.js
+++ b/metro2 (copy 1)/crm/tests/parserRiskFactors.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { parseCreditReportHTML } from '../parser.js';
+
+test("skips 'Risk Factors' section when parsing tradelines", () => {
+  const html = `
+    <div>
+      <div class="sub_header">Risk Factors</div>
+      <table class="rpt_content_table rpt_content_header rpt_table4column">
+        <tr>
+          <th></th><th>TransUnion</th><th>Experian</th><th>Equifax</th>
+        </tr>
+        <tr>
+          <td class="label">Account #</td>
+          <td class="info">0000</td>
+          <td class="info"></td>
+          <td class="info"></td>
+        </tr>
+      </table>
+    </div>
+    <div>
+      <div class="sub_header">Acme Bank</div>
+      <table class="rpt_content_table rpt_content_header rpt_table4column">
+        <tr>
+          <th></th><th>TransUnion</th><th>Experian</th><th>Equifax</th>
+        </tr>
+        <tr>
+          <td class="label">Account #</td>
+          <td class="info">12345</td>
+          <td class="info"></td>
+          <td class="info"></td>
+        </tr>
+      </table>
+    </div>
+  `;
+  const dom = new JSDOM(html);
+  const { tradelines } = parseCreditReportHTML(dom.window.document);
+  assert.equal(tradelines.length, 1);
+  assert.equal(tradelines[0].meta.creditor, 'Acme Bank');
+});


### PR DESCRIPTION
## Summary
- ignore non-creditor sections like "Risk Factors" when parsing tradelines
- drop hard-coded filter against "Risk Factors" in `dedupeTradelines`
- add regression test to ensure risk sections aren't parsed as tradelines

## Testing
- `node --test tests/parserRiskFactors.test.js`
- `node --test tests/dedupeTradelines.test.js`
- `npm test` *(fails: hung during full suite execution)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b364001483239dce68e76ddb88cd