### PR TITLE
feat: allow editing tradeline cards

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -852,7 +852,7 @@ function generateLetters({ report, selections, consumer, requestType = "correct"
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, "_")
             .replace(/^_+|_+$/g, "");
-          filename = filename.replace("_dispute_", `_${safeStep}_`);
+        filename = filename.replace("_dispute_", `_${safeStep}_`);
         }
         filename = `${namePrefix(consumer)}_${filename}`;
         letters.push({
@@ -860,6 +860,7 @@ function generateLetters({ report, selections, consumer, requestType = "correct"
           tradelineIndex: sel.tradelineIndex,
           creditor: tl.meta.creditor,
           requestType: req,
+          specificDisputeReason: sel.specificDisputeReason,
           ...letter,
           filename,
         });

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -286,11 +286,13 @@
           EXP: <span class="tl-exp-acct"></span> •
           EQF: <span class="tl-eqf-acct"></span>
         </div>
+        <div class="text-xs text-purple-700 tl-manual-reason"></div>
       </div>
       <div class="flex items-center gap-2">
         <div class="special-badges flex gap-1"></div>
         <select class="tl-playbook-select hidden text-sm border rounded"></select>
         <button class="tl-playbook btn" title="Select playbook">Playbook</button>
+        <button class="tl-edit btn" title="Edit this card">✎</button>
         <button class="tl-remove btn" title="Hide this card" data-tip="Remove Card (R when focused)">×</button>
       </div>
     </div>
@@ -413,6 +415,26 @@
     </div>
     <div id="zoomBody" class="text-sm"></div>
   </div>
+</div>
+
+<!-- Edit Tradeline Modal -->
+<div id="tlEditModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)] z-[999]">
+  <form id="tlEditForm" class="glass card w-[min(560px,92vw)] space-y-3">
+    <div class="flex items-center justify-between">
+      <div class="font-semibold">Edit Tradeline</div>
+      <div class="flex gap-2">
+        <button type="button" id="tlEditCancel" class="btn">Cancel</button>
+        <button type="submit" class="btn">Save</button>
+      </div>
+    </div>
+    <div class="grid gap-2 text-sm">
+      <label class="flex flex-col">Creditor<input name="creditor" class="border rounded px-2 py-1" /></label>
+      <label class="flex flex-col">TransUnion Account #<input name="tu_account_number" class="border rounded px-2 py-1" /></label>
+      <label class="flex flex-col">Experian Account #<input name="exp_account_number" class="border rounded px-2 py-1" /></label>
+      <label class="flex flex-col">Equifax Account #<input name="eqf_account_number" class="border rounded px-2 py-1" /></label>
+      <label class="flex flex-col">Dispute Reason<textarea name="manual_reason" class="border rounded px-2 py-1" rows="3"></textarea></label>
+    </div>
+  </form>
 </div>
 
 <!-- Data Breach Results Modal -->

--- a/metro2 (copy 1)/crm/tests/editTradeline.test.js
+++ b/metro2 (copy 1)/crm/tests/editTradeline.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import request from 'supertest';
+import fs from 'node:fs/promises';
+
+process.env.NODE_ENV = 'test';
+const { default: app } = await import('../server.js');
+
+const reportPath = new URL('../data/report.html', import.meta.url);
+
+test('editing a tradeline updates stored report', async () => {
+  const reportHtml = await fs.readFile(reportPath);
+  const login = await request(app).post('/api/login').send({ username: 'ducky', password: 'duck' });
+  assert.equal(login.status, 200);
+  const token = login.body.token;
+  const auth = { Authorization: `Bearer ${token}` };
+
+  const create = await request(app).post('/api/consumers').set(auth).send({ name: 'Edit TL' });
+  assert.equal(create.status, 200);
+  const id = create.body.consumer.id;
+
+  const upload = await request(app)
+    .post(`/api/consumers/${id}/upload`)
+    .set(auth)
+    .attach('file', reportHtml, 'report.html');
+  assert.equal(upload.status, 200);
+  const rid = upload.body.reportId;
+
+    const newCreditor = 'Edited Creditor';
+    const manualReason = 'Incorrect balance';
+    const put = await request(app)
+      .put(`/api/consumers/${id}/report/${rid}/tradeline/0`)
+      .set(auth)
+      .send({ creditor: newCreditor, manual_reason: manualReason, per_bureau: { TransUnion: { account_number: '0000' } } });
+    assert.equal(put.status, 200);
+    assert.equal(put.body.ok, true);
+    assert.equal(put.body.tradeline.meta.creditor, newCreditor);
+    assert.equal(put.body.tradeline.per_bureau.TransUnion.account_number, '0000');
+    assert.equal(put.body.tradeline.meta.manual_reason, manualReason);
+
+  const fetched = await request(app).get(`/api/consumers/${id}/report/${rid}`).set(auth);
+  assert.equal(fetched.status, 200);
+    assert.equal(fetched.body.report.tradelines[0].meta.creditor, newCreditor);
+    assert.equal(fetched.body.report.tradelines[0].per_bureau.TransUnion.account_number, '0000');
+    assert.equal(fetched.body.report.tradelines[0].meta.manual_reason, manualReason);
+  });


### PR DESCRIPTION
## Summary
- add manual dispute reason field to tradeline edit modal
- persist custom reasons through API and letter generation
- test manual reason save and letter inclusion

## Testing
- `node --test tests/collectSelections.test.js tests/editTradeline.test.js`
- `node --test tests/generate.test.js` *(fails: Cannot read properties of undefined (reading 'id'))*

------
https://chatgpt.com/codex/tasks/task_e_68c6be3687dc83238bf556aef0f08ad0