### PR TITLE
feat: convert credit report HTML to dispute PDFs on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ node creditAuditTool.js path/to/report.html
 node creditAuditTool.js data/report.json
 ```
 
+Convert a raw credit report HTML directly into dispute-ready PDF letters:
+```bash
+cd "metro2 (copy 1)/crm"
+node htmlToDisputePdf.js path/to/report.html output/dir
+```
+
+
 ## Test
 
 ### Node tests

--- a/metro2 (copy 1)/crm/htmlToDisputePdf.js
+++ b/metro2 (copy 1)/crm/htmlToDisputePdf.js
@@ -1,0 +1,47 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { JSDOM } from 'jsdom';
+import parseCreditReportHTML from './parser.js';
+import { generateLetters } from './letterEngine.js';
+import { htmlToPdfBuffer } from './pdfUtils.js';
+
+/**
+ * Convert raw credit-report HTML into dispute letter PDFs.
+ * @param {string} html raw report markup
+ * @param {object} consumer {firstName,lastName,address1,city,state,zip}
+ * @returns {Promise<Array<{filename:string,pdf:Buffer}>>}
+ */
+export async function htmlReportToDisputePdfs(html, consumer){
+  if(!html) throw new Error('html required');
+  const dom = new JSDOM(html);
+  const { tradelines } = parseCreditReportHTML(dom.window.document);
+  const report = { tradelines };
+  const selections = report.tradelines.map((tl, idx)=>({
+    tradelineIndex: idx,
+    bureaus: Object.keys(tl.per_bureau||{}).filter(b=>Object.keys(tl.per_bureau[b]||{}).length),
+    violationIdxs: (tl.violations||[]).map((_,i)=>i)
+  }));
+  const letters = generateLetters({ report, selections, consumer });
+  const out = [];
+  for(const L of letters){
+    const pdf = await htmlToPdfBuffer(L.html);
+    out.push({ filename: L.filename.replace(/\.html?$/i,'.pdf'), pdf });
+  }
+  return out;
+}
+
+if(import.meta.url===`file://${process.argv[1]}`){
+  const [input, outDir='.'] = process.argv.slice(2);
+  if(!input){
+    console.error('Usage: node htmlToDisputePdf.js <report.html> [outDir]');
+    process.exit(1);
+  }
+  const html = await fs.readFile(input,'utf-8');
+  const consumer = { firstName:'John', lastName:'Doe', address1:'123 Main St', city:'Anytown', state:'CA', zip:'00000' };
+  const pdfs = await htmlReportToDisputePdfs(html, consumer);
+  await fs.mkdir(outDir,{ recursive:true });
+  await Promise.all(pdfs.map(async ({filename,pdf})=>{
+    await fs.writeFile(path.join(outDir, filename), pdf);
+    console.log('saved', filename);
+  }));
+}

--- a/metro2 (copy 1)/crm/tests/htmlToDisputePdf.test.js
+++ b/metro2 (copy 1)/crm/tests/htmlToDisputePdf.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { htmlReportToDisputePdfs } from '../htmlToDisputePdf.js';
+import { detectChromium } from '../pdfUtils.js';
+
+await test('html report converts to dispute PDF', async (t) => {
+  const execPath = await detectChromium();
+  if(!execPath){
+    t.skip('chromium not installed');
+    return;
+  }
+  const html = `<!DOCTYPE html><html><body>
+  <div class="sub_header">Test Creditor</div>
+  <table class="rpt_content_table rpt_content_header rpt_table4column">
+    <tr><th></th><th>TransUnion</th><th>Experian</th><th>Equifax</th></tr>
+    <tr><td class="label">Account #</td><td class="info">123</td><td class="info">456</td><td class="info">789</td></tr>
+    <tr><td class="label">Account Status</td><td class="info">Open</td><td class="info">Open</td><td class="info">Open</td></tr>
+  </table>
+  </body></html>`;
+  const consumer = { firstName:'Ana', lastName:'Lopez', address1:'123 Main', city:'Phoenix', state:'AZ', zip:'85001' };
+  const pdfs = await htmlReportToDisputePdfs(html, consumer);
+  assert.ok(pdfs.length > 0);
+  assert.ok(pdfs[0].pdf.length > 1000);
+});


### PR DESCRIPTION
## Summary
- add htmlReportToDisputePdfs to turn raw credit report HTML into letter PDFs
- document CLI usage for HTML-to-PDF conversion
- cover pipeline with integration test (skips when chromium missing)

## Testing
- `node --test tests/htmlToDisputePdf.test.js` *(fails: chromium not installed; test skipped)*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6c1c60b0c8323a31f29e97890b3e0