### PR TITLE
feat: add PDF preview for tradeline edits

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -419,7 +419,7 @@
 
 <!-- Edit Tradeline Modal -->
 <div id="tlEditModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)] z-[999]">
-  <form id="tlEditForm" class="glass card w-[min(560px,92vw)] space-y-3">
+  <form id="tlEditForm" class="glass card w-[min(900px,95vw)] space-y-3">
     <div class="flex items-center justify-between">
       <div class="font-semibold">Edit Tradeline</div>
       <div class="flex gap-2">
@@ -427,13 +427,20 @@
         <button type="submit" class="btn">Save</button>
       </div>
     </div>
-    <div class="grid gap-2 text-sm">
-      <label class="flex flex-col">Creditor<input name="creditor" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">TransUnion Account #<input name="tu_account_number" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">Experian Account #<input name="exp_account_number" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">Equifax Account #<input name="eqf_account_number" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">Dispute Reason<textarea name="manual_reason" class="border rounded px-2 py-1" rows="3"></textarea></label>
-
+    <div class="flex gap-4 text-sm">
+      <div class="flex-1 space-y-2">
+        <div id="tlPdfContainer" class="hidden border rounded h-[400px]">
+          <iframe id="tlPdfPreview" class="w-full h-full"></iframe>
+        </div>
+        <input type="file" id="tlPdfInput" accept="application/pdf" class="border rounded px-2 py-1 w-full" />
+      </div>
+      <div class="flex-1 grid gap-2">
+        <label class="flex flex-col">Creditor<input name="creditor" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">TransUnion Account #<input name="tu_account_number" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">Experian Account #<input name="exp_account_number" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">Equifax Account #<input name="eqf_account_number" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">Dispute Reason<textarea name="manual_reason" class="border rounded px-2 py-1" rows="3"></textarea></label>
+      </div>
     </div>
   </form>
 </div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -33,6 +33,8 @@ let trackerData = {};
 
 let trackerSteps = [];
 
+let tlPdfUrl;
+
 const ocrCb = $("#cbUseOcr");
 
 let CUSTOM_TEMPLATES = [];
@@ -1115,13 +1117,30 @@ function openTlEdit(idx){
   f.eqf_account_number.value = tl.per_bureau?.Equifax?.account_number || "";
   f.manual_reason.value = tl.meta?.manual_reason || "";
 
+  $("#tlPdfInput").value = "";
+  if(tlPdfUrl){ URL.revokeObjectURL(tlPdfUrl); tlPdfUrl = null; }
+  $("#tlPdfContainer").classList.add("hidden");
+  $("#tlPdfPreview").src = "";
+
   $("#tlEditModal").classList.remove("hidden");
   document.body.style.overflow = "hidden";
 }
 function closeTlEdit(){
   $("#tlEditModal").classList.add("hidden");
   document.body.style.overflow = "";
+  if(tlPdfUrl){ URL.revokeObjectURL(tlPdfUrl); tlPdfUrl = null; }
+  $("#tlPdfContainer").classList.add("hidden");
+  $("#tlPdfInput").value = "";
+  $("#tlPdfPreview").src = "";
 }
+$("#tlPdfInput")?.addEventListener("change", e=>{
+  const file = e.target.files?.[0];
+  if(!file) return;
+  if(tlPdfUrl){ URL.revokeObjectURL(tlPdfUrl); }
+  tlPdfUrl = URL.createObjectURL(file);
+  $("#tlPdfPreview").src = tlPdfUrl;
+  $("#tlPdfContainer").classList.remove("hidden");
+});
 $("#tlEditCancel").addEventListener("click", ()=> closeTlEdit());
 $("#tlEditForm").addEventListener("submit", async (e)=>{
   e.preventDefault();


### PR DESCRIPTION
## Summary
- show an uploaded PDF side-by-side when editing a tradeline
- handle PDF preview lifecycle in the front-end

## Testing
- `npm test` *(fails: process hung, partial output shows some tests ran)*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6ca338b208323b64e028fa86a2b58