### PR TITLE
feat: add HTML preview for tradeline edits

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -419,7 +419,7 @@
 
 <!-- Edit Tradeline Modal -->
 <div id="tlEditModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)] z-[999]">
-  <form id="tlEditForm" class="glass card w-[min(560px,92vw)] space-y-3">
+  <form id="tlEditForm" class="glass card w-[min(900px,95vw)] space-y-3">
     <div class="flex items-center justify-between">
       <div class="font-semibold">Edit Tradeline</div>
       <div class="flex gap-2">
@@ -427,13 +427,19 @@
         <button type="submit" class="btn">Save</button>
       </div>
     </div>
-    <div class="grid gap-2 text-sm">
-      <label class="flex flex-col">Creditor<input name="creditor" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">TransUnion Account #<input name="tu_account_number" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">Experian Account #<input name="exp_account_number" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">Equifax Account #<input name="eqf_account_number" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">Dispute Reason<textarea name="manual_reason" class="border rounded px-2 py-1" rows="3"></textarea></label>
-
+    <div class="flex gap-4 text-sm">
+      <div class="flex-1 space-y-2">
+        <div id="tlHtmlContainer" class="hidden border rounded h-[400px]">
+          <iframe id="tlHtmlPreview" class="w-full h-full"></iframe>
+        </div>
+      </div>
+      <div class="flex-1 grid gap-2">
+        <label class="flex flex-col">Creditor<input name="creditor" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">TransUnion Account #<input name="tu_account_number" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">Experian Account #<input name="exp_account_number" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">Equifax Account #<input name="eqf_account_number" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">Dispute Reason<textarea name="manual_reason" class="border rounded px-2 py-1" rows="3"></textarea></label>
+      </div>
     </div>
   </form>
 </div>

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -33,6 +33,8 @@ let trackerData = {};
 
 let trackerSteps = [];
 
+let CONSUMER_FILES = [];
+
 const ocrCb = $("#cbUseOcr");
 
 let CUSTOM_TEMPLATES = [];
@@ -1115,12 +1117,24 @@ function openTlEdit(idx){
   f.eqf_account_number.value = tl.per_bureau?.Equifax?.account_number || "";
   f.manual_reason.value = tl.meta?.manual_reason || "";
 
+  const fileRec = CONSUMER_FILES.find(f => f.id === currentReportId);
+  if(fileRec){
+    const url = `/api/consumers/${currentConsumerId}/state/files/${encodeURIComponent(fileRec.storedName)}`;
+    $("#tlHtmlPreview").src = url;
+    $("#tlHtmlContainer").classList.remove("hidden");
+  }else{
+    $("#tlHtmlPreview").src = "";
+    $("#tlHtmlContainer").classList.add("hidden");
+  }
+
   $("#tlEditModal").classList.remove("hidden");
   document.body.style.overflow = "hidden";
 }
 function closeTlEdit(){
   $("#tlEditModal").classList.add("hidden");
   document.body.style.overflow = "";
+  $("#tlHtmlPreview").src = "";
+  $("#tlHtmlContainer").classList.add("hidden");
 }
 $("#tlEditCancel").addEventListener("click", ()=> closeTlEdit());
 $("#tlEditForm").addEventListener("submit", async (e)=>{
@@ -1323,6 +1337,7 @@ async function loadConsumerState(){
   const allEvents = resp.state?.events || [];
   const events = allEvents.filter(ev => ev.type !== "message");
   const files = resp.state?.files || [];
+  CONSUMER_FILES = files;
   const list = [];
 
   if (files.length){


### PR DESCRIPTION
## Summary
- show an uploaded HTML report side-by-side when editing a tradeline
- handle HTML preview lifecycle in the front-end
- reuse uploaded report file instead of asking for re-upload in editor

## Testing
- `npm test` *(fails: process hung after consumer permission tests)*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6ca338b208323b64e028fa86a2b58