### PR TITLE
feat: add HTML preview for tradeline edits

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -419,7 +419,7 @@
 
 <!-- Edit Tradeline Modal -->
 <div id="tlEditModal" class="fixed inset-0 hidden items-center justify-center bg-[rgba(0,0,0,.45)] z-[999]">
-  <form id="tlEditForm" class="glass card w-[min(560px,92vw)] space-y-3">
+  <form id="tlEditForm" class="glass card w-[min(900px,95vw)] space-y-3">
     <div class="flex items-center justify-between">
       <div class="font-semibold">Edit Tradeline</div>
       <div class="flex gap-2">
@@ -427,13 +427,22 @@
         <button type="submit" class="btn">Save</button>
       </div>
     </div>
-    <div class="grid gap-2 text-sm">
-      <label class="flex flex-col">Creditor<input name="creditor" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">TransUnion Account #<input name="tu_account_number" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">Experian Account #<input name="exp_account_number" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">Equifax Account #<input name="eqf_account_number" class="border rounded px-2 py-1" /></label>
-      <label class="flex flex-col">Dispute Reason<textarea name="manual_reason" class="border rounded px-2 py-1" rows="3"></textarea></label>
-
+    <div class="flex gap-4 text-sm">
+      <div class="flex-1 space-y-2">
+        <div id="tlHtmlContainer" class="hidden border rounded h-[400px]">
+          <iframe id="tlHtmlPreview" class="w-full h-full"></iframe>
+        </div>
+      </div>
+      <div class="flex-1 grid gap-2">
+        <label class="flex flex-col">Creditor<input name="creditor" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">TransUnion Account #<input name="tu_account_number" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">Experian Account #<input name="exp_account_number" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">Equifax Account #<input name="eqf_account_number" class="border rounded px-2 py-1" /></label>
+        <label class="flex flex-col">Dispute Reason
+          <select id="tlReasonSelect" class="border rounded px-2 py-1"></select>
+          <textarea id="tlReasonText" name="manual_reason" class="border rounded px-2 py-1 mt-1" rows="3"></textarea>
+        </label>
+      </div>
     </div>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- auto-scroll HTML report preview to the matching account number when editing
- add dispute reason dropdown prefilled from Metro 2 violations
- load chosen reason into the existing textarea

## Testing
- `npm test` *(hangs after member permission tests)*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6ca338b208323b64e028fa86a2b58