### PR TITLE
feat: add correct and delete default templates

### DIFF
--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -1142,7 +1142,8 @@ function defaultTemplates(){
     { id: "identity", requestType:"delete", ...modeCopy("identity", "delete", true) },
     { id: "breach",   requestType:"delete", ...modeCopy("breach", "delete", true) },
     { id: "assault",  requestType:"delete", ...modeCopy("assault", "delete", true) },
-    { id: "standard", requestType:"delete", ...modeCopy(null, "delete", true) }
+    { id: "correct",  requestType:"correct", ...modeCopy(null, "correct", true) },
+    { id: "delete",   requestType:"delete", ...modeCopy(null, "delete", true) }
   ];
 }
 app.get("/api/templates/defaults", async (_req,res)=>{


### PR DESCRIPTION
## Summary
- expose `correct` and `delete` letter templates as default main letters

## Testing
- `npm test` *(fails: process terminated early)*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6dd25aa30832393a1d3bebe013ea3