### PR TITLE
feat: add correct and delete default templates

### DIFF
--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -90,10 +90,6 @@
       </div>
       <div id="tplEditor" class="flex-1 space-y-2 hidden">
         <input id="tplHeading" class="input w-full text-sm" placeholder="Heading" />
-        <select id="tplType" class="input w-full text-sm">
-          <option value="correct">Correct</option>
-          <option value="delete">Delete</option>
-        </select>
         <textarea id="tplIntro" class="input w-full text-sm" placeholder="Intro"></textarea>
         <textarea id="tplAsk" class="input w-full text-sm" placeholder="Ask"></textarea>
         <textarea id="tplAfter" class="input w-full text-sm" placeholder="After Issues"></textarea>

--- a/metro2 (copy 1)/crm/public/library.js
+++ b/metro2 (copy 1)/crm/public/library.js
@@ -3,6 +3,7 @@ let sequences = [];
 let mainTemplates = [];
 let currentTemplateId = null;
 let currentSequenceId = null;
+let currentRequestType = 'correct';
 
 async function loadLibrary(){
   const res = await fetch('/api/templates');
@@ -65,8 +66,7 @@ function hideTemplateEditor(){
     const el = document.getElementById(id);
     if(el) el.value = '';
   });
-  const typeEl = document.getElementById('tplType');
-  if(typeEl) typeEl.value = 'correct';
+  currentRequestType = 'correct';
   updatePreview();
 }
 
@@ -75,7 +75,7 @@ function editTemplate(id){
   currentTemplateId = id;
   showTemplateEditor();
   document.getElementById('tplHeading').value = tpl.heading || '';
-  document.getElementById('tplType').value = tpl.requestType || 'correct';
+  currentRequestType = tpl.requestType || 'correct';
   document.getElementById('tplIntro').value = tpl.intro || '';
   document.getElementById('tplAsk').value = tpl.ask || '';
   document.getElementById('tplAfter').value = tpl.afterIssues || '';
@@ -89,7 +89,7 @@ function useMainTemplate(id){
   currentTemplateId = id;
   showTemplateEditor();
   document.getElementById('tplHeading').value = tpl.heading || '';
-  document.getElementById('tplType').value = tpl.requestType || 'correct';
+  currentRequestType = tpl.requestType || 'correct';
   document.getElementById('tplIntro').value = tpl.intro || '';
   document.getElementById('tplAsk').value = tpl.ask || '';
   document.getElementById('tplAfter').value = tpl.afterIssues || '';
@@ -117,8 +117,7 @@ function openTemplateEditor(){
     const el = document.getElementById(id);
     if(el) el.value='';
   });
-  const typeEl = document.getElementById('tplType');
-  if(typeEl) typeEl.value = 'correct';
+  currentRequestType = 'correct';
   updatePreview();
 }
 
@@ -143,7 +142,7 @@ async function upsertTemplate(payload){
 async function saveTemplate(){
   const payload = {
     heading: document.getElementById('tplHeading').value,
-    requestType: document.getElementById('tplType').value,
+    requestType: currentRequestType,
     intro: document.getElementById('tplIntro').value,
     ask: document.getElementById('tplAsk').value,
     afterIssues: document.getElementById('tplAfter').value,

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -1142,7 +1142,8 @@ function defaultTemplates(){
     { id: "identity", requestType:"delete", ...modeCopy("identity", "delete", true) },
     { id: "breach",   requestType:"delete", ...modeCopy("breach", "delete", true) },
     { id: "assault",  requestType:"delete", ...modeCopy("assault", "delete", true) },
-    { id: "standard", requestType:"delete", ...modeCopy(null, "delete", true) }
+    { id: "correct",  requestType:"correct", ...modeCopy(null, "correct", true) },
+    { id: "delete",   requestType:"delete", ...modeCopy(null, "delete", true) }
   ];
 }
 app.get("/api/templates/defaults", async (_req,res)=>{


### PR DESCRIPTION
## Summary
- expose `correct` and `delete` letter templates as default main letters
- remove request type dropdown; track template type internally

## Testing
- `npm test` *(fails: terminated early)*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6dd25aa30832393a1d3bebe013ea3