### PR TITLE
feat: open template editor in modal

### DIFF
--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -88,23 +88,6 @@
           <div id="mainList" class="space-y-1 text-sm"></div>
         </div>
       </div>
-      <div id="tplEditor" class="flex-1 space-y-2 hidden">
-        <input id="tplHeading" class="input w-full text-sm" placeholder="Heading" />
-        <select id="tplType" class="input w-full text-sm">
-          <option value="correct">Correct</option>
-          <option value="delete">Delete</option>
-        </select>
-        <textarea id="tplIntro" class="input w-full text-sm" placeholder="Intro"></textarea>
-        <textarea id="tplAsk" class="input w-full text-sm" placeholder="Ask"></textarea>
-        <textarea id="tplAfter" class="input w-full text-sm" placeholder="After Issues"></textarea>
-        <textarea id="tplEvidence" class="input w-full text-sm" placeholder="Evidence"></textarea>
-        <div id="tplPreview" class="input w-full text-sm whitespace-pre-line h-48 overflow-y-auto" title="Drop a template here to load it"></div>
-        <div class="flex justify-end gap-2">
-          <button id="saveTemplate" class="btn text-sm">Save Template</button>
-          <button id="saveTemplateCopy" class="btn text-sm">Save As New</button>
-          <button id="cancelTemplate" class="btn text-sm">Cancel</button>
-        </div>
-      </div>
       <div class="w-1/3 space-y-4">
         <button id="newTemplate" class="btn w-full mb-2">New Template</button>
         <div class="font-medium text-sm">Letter Templates</div>
@@ -128,6 +111,31 @@
     </div>
   </div>
 </main>
+<!-- Template Editor Modal -->
+<div id="templateModal" class="modal-backdrop">
+  <div class="modal">
+    <header>
+      <div class="font-medium">Template Editor</div>
+      <div class="flex gap-2">
+        <button id="saveTemplate" class="btn text-sm">Save Template</button>
+        <button id="saveTemplateCopy" class="btn text-sm">Save As New</button>
+        <button id="cancelTemplate" class="btn text-sm">Close</button>
+      </div>
+    </header>
+    <div id="tplEditor" class="body space-y-2">
+      <input id="tplHeading" class="input w-full text-sm" placeholder="Heading" />
+      <select id="tplType" class="input w-full text-sm">
+        <option value="correct">Correct</option>
+        <option value="delete">Delete</option>
+      </select>
+      <textarea id="tplIntro" class="input w-full text-sm" placeholder="Intro"></textarea>
+      <textarea id="tplAsk" class="input w-full text-sm" placeholder="Ask"></textarea>
+      <textarea id="tplAfter" class="input w-full text-sm" placeholder="After Issues"></textarea>
+      <textarea id="tplEvidence" class="input w-full text-sm" placeholder="Evidence"></textarea>
+      <div id="tplPreview" class="input w-full text-sm whitespace-pre-line h-48 overflow-y-auto" title="Drop a template here to load it"></div>
+    </div>
+  </div>
+</div>
 <script type="module" src="/common.js"></script>
 <script src="/library.js"></script>
 </body>

--- a/metro2 (copy 1)/crm/public/library.js
+++ b/metro2 (copy 1)/crm/public/library.js
@@ -53,13 +53,15 @@ function renderMainTemplates(){
 }
 
 function showTemplateEditor(){
-  const editor = document.getElementById('tplEditor');
-  if(editor) editor.classList.remove('hidden');
+  const modal = document.getElementById('templateModal');
+  if(modal) modal.style.display = 'flex';
+  document.body.style.overflow = 'hidden';
 }
 
 function hideTemplateEditor(){
-  const editor = document.getElementById('tplEditor');
-  if(editor) editor.classList.add('hidden');
+  const modal = document.getElementById('templateModal');
+  if(modal) modal.style.display = 'none';
+  document.body.style.overflow = '';
   currentTemplateId = null;
   ['tplHeading','tplIntro','tplAsk','tplAfter','tplEvidence'].forEach(id => {
     const el = document.getElementById(id);
@@ -239,6 +241,13 @@ document.getElementById('newTemplate').onclick = openTemplateEditor;
 document.getElementById('cancelTemplate').onclick = hideTemplateEditor;
 document.getElementById('saveSequence').onclick = saveSequence;
 document.getElementById('newSequence').onclick = newSequence;
+
+const templateModal = document.getElementById('templateModal');
+if(templateModal){
+  templateModal.addEventListener('click', e => {
+    if(e.target.id === 'templateModal') hideTemplateEditor();
+  });
+}
 
 ['tplHeading','tplIntro','tplAsk','tplAfter','tplEvidence'].forEach(id => {
   document.getElementById(id).addEventListener('input', updatePreview);


### PR DESCRIPTION
## Summary
- open letter template editor in a modal dialog
- allow closing the editor by clicking outside the modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6eb96acd48323bf05e95da97e3acb