### PR TITLE
Rename dispute timeline to items in dispute

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -108,12 +108,12 @@
   </div>
 
   <div class="glass card">
-    <div class="font-medium mb-2">Dispute Timeline</div>
-    <div id="timeline" class="text-sm space-y-1 flex flex-col items-center justify-center">
-      <div id="timelineEmpty" class="w-32 h-32"></div>
-      <div id="timelineText" class="mt-2">No disputes yet.</div>
+    <div class="font-medium mb-2">Items in Dispute</div>
+    <div id="itemsInDispute" class="text-sm space-y-1 flex flex-col items-center justify-center">
+      <div id="itemsInDisputeEmpty" class="w-32 h-32"></div>
+      <div id="itemsInDisputeText" class="mt-2">No items in dispute.</div>
     </div>
-    <div id="disputeSummary" class="text-sm mt-2"></div>
+    <div id="itemsSummary" class="text-sm mt-2"></div>
   </div>
 
   <div class="glass card">

--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -189,11 +189,11 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
 
-  const timeline = JSON.parse(localStorage.getItem('disputeTimeline') || '[]');
-  const timelineEl = document.getElementById('timeline');
-  if (timelineEl) {
-    if (!timeline.length) {
-      const empty = document.getElementById('timelineEmpty');
+  const items = JSON.parse(localStorage.getItem('itemsInDispute') || localStorage.getItem('disputeTimeline') || '[]');
+  const itemsEl = document.getElementById('itemsInDispute');
+  if (itemsEl) {
+    if (!items.length) {
+      const empty = document.getElementById('itemsInDisputeEmpty');
       if (empty && window.lottie) {
         lottie.loadAnimation({
           container: empty,
@@ -204,22 +204,22 @@ document.addEventListener('DOMContentLoaded', () => {
         });
       }
     } else {
-      const tt = document.getElementById('timelineText');
+      const tt = document.getElementById('itemsInDisputeText');
       if (tt) tt.remove();
-      const te = document.getElementById('timelineEmpty');
+      const te = document.getElementById('itemsInDisputeEmpty');
       if (te) te.remove();
-      timelineEl.innerHTML = timeline.map(t => `<div class="timeline-item"><span class="font-medium">${t.account}</span> - ${t.stage}</div>`).join('');
+      itemsEl.innerHTML = items.map(t => `<div class="timeline-item"><span class="font-medium">${t.account}</span> - ${t.stage}</div>`).join('');
     }
   }
 
-  const summaryEl = document.getElementById('disputeSummary');
+  const summaryEl = document.getElementById('itemsSummary');
   if(summaryEl){
     const perRound = 10;
-    if(timeline.length){
-      const rounds = Math.ceil(timeline.length / perRound);
-      summaryEl.textContent = `${timeline.length} items across ${rounds} round${rounds===1?'':'s'} (${perRound} per round)`;
+    if(items.length){
+      const rounds = Math.ceil(items.length / perRound);
+      summaryEl.textContent = `${items.length} items across ${rounds} round${rounds===1?'':'s'} (${perRound} per round)`;
     } else {
-      summaryEl.textContent = 'No disputes yet.';
+      summaryEl.textContent = 'No items in dispute.';
     }
   }
 


### PR DESCRIPTION
## Summary
- rename Dispute Timeline section to Items in Dispute on client portal
- track items in localStorage under `itemsInDispute` with legacy fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6f118a4348323a54f3b79d3b2f82a