### PR TITLE
Deduplicate template list when loading library

### DIFF
--- a/metro2 (copy 1)/crm/public/library.js
+++ b/metro2 (copy 1)/crm/public/library.js
@@ -18,6 +18,12 @@ async function loadLibrary(){
     spanish: t.spanish
   }));
   templates = [...templates, ...sampleTemplates];
+  const seenIds = new Set();
+  templates = templates.filter(t => {
+    if(seenIds.has(t.id)) return false;
+    seenIds.add(t.id);
+    return true;
+  });
   sequences = data.sequences || [];
   renderTemplates();
   renderSequences();


### PR DESCRIPTION
## Summary
- Filter out duplicate templates by id after merging templates with sample letters
- Re-render library template list to remove duplicate entries

## Testing
- `npm test` *(fails: test run hung, manual interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68c7366f46fc832396ec80b260fde3d0