### PR TITLE
Deduplicate template list and streamline library UI

### DIFF
--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -80,21 +80,11 @@
 
 <main class="max-w-5xl mx-auto p-4 space-y-4">
   <div id="templatePanel" class="glass card space-y-4">
-    <div class="font-medium">Letter Templates</div>
-    <div class="flex gap-4">
-      <div class="w-1/3 space-y-4">
-        <div>
-          <div class="font-medium text-sm">Main Letters</div>
-          <div id="mainList" class="space-y-1 text-sm"></div>
-        </div>
-      </div>
-
-      <div class="w-1/3 space-y-4">
-        <button id="newTemplate" class="btn w-full mb-2">New Template</button>
-        <div class="font-medium text-sm">Letter Templates</div>
-        <div id="templateList" class="space-y-1 text-sm max-h-96 overflow-y-auto"></div>
-      </div>
+    <div class="flex items-center justify-between">
+      <div class="font-medium">Letter Templates</div>
+      <button id="newTemplate" class="btn text-sm">New Template</button>
     </div>
+    <div id="templateList" class="space-y-1 text-sm max-h-96 overflow-y-auto"></div>
   </div>
 
   <div class="glass card space-y-4">


### PR DESCRIPTION
## Summary
- Filter out duplicate templates by id after merging templates with sample letters
- Remove "Main Letters" section and simplify template panel styling

## Testing
- `npm test` *(hangs: last output "member cannot delete consumer")*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c7366f46fc832396ec80b260fde3d0