### PR TITLE
Deduplicate template list and wire sequences into playbooks

### DIFF
--- a/metro2 (copy 1)/crm/letterEngine.js
+++ b/metro2 (copy 1)/crm/letterEngine.js
@@ -1,6 +1,4 @@
 // letterEngine.js
-
-import { PLAYBOOKS } from './playbook.js';
 import { enrichTradeline } from './pullTradelineData.js';
 import { loadMetro2Violations } from './utils.js';
 
@@ -785,7 +783,7 @@ function generateDebtCollectorLetters({ consumer, collectors = [] }) {
   return letters;
 }
 
-function generateLetters({ report, selections, consumer, requestType = "correct", templates = [] }) {
+function generateLetters({ report, selections, consumer, requestType = "correct", templates = [], playbooks = {} }) {
   const SPECIAL_ONE_BUREAU = new Set(["identity", "breach", "assault"]);
   const letters = [];
   const templateMap = Object.fromEntries((templates || []).map(t => [t.id, t]));
@@ -843,7 +841,7 @@ function generateLetters({ report, selections, consumer, requestType = "correct"
     const isSpecial = SPECIAL_ONE_BUREAU.has(sel.specialMode);
     const comparisonBureaus = isSpecial ? [sel.bureaus[0]] : ALL_BUREAUS;
 
-    const play = sel.playbook && PLAYBOOKS[sel.playbook];
+    const play = sel.playbook && playbooks[sel.playbook];
     const steps = play ? play.letters : [null];
 
     steps.forEach((stepTitle, stepIdx) => {

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -80,21 +80,11 @@
 
 <main class="max-w-5xl mx-auto p-4 space-y-4">
   <div id="templatePanel" class="glass card space-y-4">
-    <div class="font-medium">Letter Templates</div>
-    <div class="flex gap-4">
-      <div class="w-1/3 space-y-4">
-        <div>
-          <div class="font-medium text-sm">Main Letters</div>
-          <div id="mainList" class="space-y-1 text-sm"></div>
-        </div>
-      </div>
-
-      <div class="w-1/3 space-y-4">
-        <button id="newTemplate" class="btn w-full mb-2">New Template</button>
-        <div class="font-medium text-sm">Letter Templates</div>
-        <div id="templateList" class="space-y-1 text-sm max-h-96 overflow-y-auto"></div>
-      </div>
+    <div class="flex items-center justify-between">
+      <div class="font-medium">Letter Templates</div>
+      <button id="newTemplate" class="btn text-sm">New Template</button>
     </div>
+    <div id="templateList" class="space-y-1 text-sm max-h-96 overflow-y-auto"></div>
   </div>
 
   <div class="glass card space-y-4">

--- a/metro2 (copy 1)/crm/public/playbooks.js
+++ b/metro2 (copy 1)/crm/public/playbooks.js
@@ -1,7 +1,8 @@
 // public/playbooks.js
-// Exposes available dispute letter playbooks to the browser
+// Exposes available dispute letter playbooks to the browser,
+// including user-defined sequences saved in the library.
 
-export const PLAYBOOKS = {
+const STATIC_PLAYBOOKS = {
   metro2ComplianceSequence: {
     name: 'Metro 2 compliance sequence',
     letters: [
@@ -12,4 +13,23 @@ export const PLAYBOOKS = {
   }
 };
 
+async function loadPlaybooks(){
+  try{
+    const res = await fetch('/api/templates');
+    const data = await res.json();
+    const templateMap = Object.fromEntries((data.templates || []).map(t => [t.id, t.heading]));
+    const seqPlaybooks = {};
+    for (const seq of data.sequences || []){
+      seqPlaybooks[seq.id] = {
+        name: seq.name,
+        letters: (seq.templates || []).map(id => templateMap[id] || id)
+      };
+    }
+    return { ...STATIC_PLAYBOOKS, ...seqPlaybooks };
+  }catch{
+    return STATIC_PLAYBOOKS;
+  }
+}
+
+export const PLAYBOOKS = await loadPlaybooks();
 export default PLAYBOOKS;


### PR DESCRIPTION
## Summary
- Filter out duplicate templates by id after merging templates with sample letters
- Remove "Main Letters" section and simplify template panel styling
- Load custom sequences into playbook engine so saved sequences become playbook steps

## Testing
- `npm test` *(hangs after "member cannot delete consumer")*
- `./python-tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c7366f46fc832396ec80b260fde3d0