### PR TITLE
Add credit report insights to dashboard

### DIFF
--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -168,12 +168,55 @@
       <div id="dashDeletion" class="text-sm muted">No data</div>
     </div>
 
-    <div class="glass card md:col-span-2 lg:col-span-3">
-      <div class="font-medium mb-2">Client Locations</div>
-      <div id="clientMap" class="w-full h-64 rounded-lg"></div>
+  </div>
+
+  <section id="creditReportInsights" class="mt-6 space-y-4">
+    <div id="creditScoresSection" class="glass card border-l-4 border-blue-500 bg-[rgba(59,130,246,0.12)]">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <h3 class="text-lg font-semibold text-blue-700">Credit Scores</h3>
+        <span id="creditScoreMeta" class="text-xs text-blue-600"></span>
+      </div>
+      <div id="creditScoreGrid" class="mt-4 grid gap-3 sm:grid-cols-3"></div>
     </div>
 
+    <div id="personalInfoSection" class="glass card border-l-4 border-green-500 bg-[rgba(16,185,129,0.12)]">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <h3 class="text-lg font-semibold text-green-700">Personal Information</h3>
+        <span class="text-xs text-green-600">Synced per bureau · Sincronizado por buró</span>
+      </div>
+      <div id="personalInfoGrid" class="mt-4 grid gap-3 md:grid-cols-3"></div>
+    </div>
+
+    <div id="paymentHistorySection" class="glass card border-l-4 border-yellow-400 bg-[rgba(250,204,21,0.12)]">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <h3 class="text-lg font-semibold text-yellow-700">Payment History</h3>
+        <span class="text-xs text-yellow-600">Highlights by bureau · Resumen por buró</span>
+      </div>
+      <div id="paymentHistoryGrid" class="mt-4 grid gap-3 md:grid-cols-3"></div>
+    </div>
+
+    <div id="accountDetailsSection" class="glass card border-l-4 border-purple-500 bg-[rgba(168,85,247,0.12)]">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <h3 class="text-lg font-semibold text-purple-700">Account Details</h3>
+        <span class="text-xs text-purple-500">Balances, limits &amp; status · Saldos y estatus</span>
+      </div>
+      <div id="accountDetailsList" class="mt-4 space-y-4"></div>
+    </div>
+
+    <div id="recentInquiriesSection" class="glass card border-l-4 border-red-500 bg-[rgba(239,68,68,0.12)]">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <h3 class="text-lg font-semibold text-red-700">Recent Inquiries</h3>
+        <span class="text-xs text-red-600">Last 5 hard pulls · Últimas 5 consultas</span>
+      </div>
+      <div id="recentInquiriesList" class="mt-4 space-y-3"></div>
+    </div>
+  </section>
+
+  <div class="glass card mt-4">
+    <div class="font-medium mb-2">Client Locations</div>
+    <div id="clientMap" class="w-full h-64 rounded-lg"></div>
   </div>
+
   </main>
   <script type="module" src="/common.js"></script>
   <script src="/hotkeys.js"></script>

--- a/metro2 (copy 1)/crm/public/dashboard.js
+++ b/metro2 (copy 1)/crm/public/dashboard.js
@@ -33,6 +33,390 @@ function getStateCode(st){
   const entry = Object.entries(stateNames).find(([,name]) => name.toUpperCase() === st);
   return entry ? entry[0] : null;
 }
+
+const BUREAUS = ['TransUnion','Experian','Equifax'];
+const SCORE_BUCKETS = [
+  { min: 760, label: 'Excellent · Excelente' },
+  { min: 720, label: 'Very good · Muy bueno' },
+  { min: 680, label: 'Good · Bueno' },
+  { min: 620, label: 'Fair · Regular' },
+  { min: 0, label: 'Needs attention · Necesita atención' }
+];
+
+function bilingual(en, es){
+  return `${en} · ${es}`;
+}
+
+const DEFAULT_FALLBACK = bilingual('Not reported', 'No informado');
+let cachedSnapshotRaw = null;
+let cachedSnapshot = null;
+
+function getStoredScores(){
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem('creditScore');
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Invalid creditScore payload', err);
+    return {};
+  }
+}
+
+function getReportSnapshot(){
+  if (typeof localStorage === 'undefined') return null;
+  const raw = localStorage.getItem('reportSnapshot');
+  if (!raw) {
+    cachedSnapshotRaw = null;
+    cachedSnapshot = null;
+    return null;
+  }
+  if (raw === cachedSnapshotRaw) return cachedSnapshot;
+  try {
+    const parsed = JSON.parse(raw);
+    cachedSnapshotRaw = raw;
+    cachedSnapshot = parsed && typeof parsed === 'object' ? parsed : null;
+    return cachedSnapshot;
+  } catch (err) {
+    console.warn('Invalid report snapshot', err);
+    cachedSnapshotRaw = raw;
+    cachedSnapshot = null;
+    return null;
+  }
+}
+
+function categorizeScore(score){
+  if (!Number.isFinite(score)) return bilingual('No data', 'Sin datos');
+  for (const bucket of SCORE_BUCKETS){
+    if (score >= bucket.min) return bucket.label;
+  }
+  return SCORE_BUCKETS[SCORE_BUCKETS.length - 1].label;
+}
+
+function valueOrFallback(value, fallback = DEFAULT_FALLBACK){
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === 'string' && value.trim() === '') return fallback;
+  return String(value);
+}
+
+function formatDateDisplay(value){
+  if (!value) return '';
+  const raw = String(value).trim();
+  if (!raw) return '';
+  let dt = new Date(raw);
+  if (Number.isNaN(dt) && /^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    dt = new Date(`${raw}T00:00:00`);
+  }
+  if (!Number.isNaN(dt)) {
+    return dt.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+  return raw;
+}
+
+function formatMoneyDisplay(raw, numeric){
+  if (raw !== undefined && raw !== null){
+    const txt = String(raw).trim();
+    if (txt) return txt;
+  }
+  if (typeof numeric === 'number' && !Number.isNaN(numeric)) {
+    return formatCurrency(numeric);
+  }
+  return '';
+}
+
+function readScore(scores, bureau){
+  if (!scores) return null;
+  const keyMap = {
+    TransUnion: ['transunion','tu','current'],
+    Experian: ['experian','exp'],
+    Equifax: ['equifax','eq','eqf']
+  }[bureau];
+  for (const key of keyMap || []){
+    if (scores[key] !== undefined && scores[key] !== null){
+      const val = Number(scores[key]);
+      if (!Number.isNaN(val) && val > 0) return Math.round(val);
+    }
+  }
+  return null;
+}
+
+function renderCreditScores(){
+  const grid = document.getElementById('creditScoreGrid');
+  if (!grid) return;
+  const meta = document.getElementById('creditScoreMeta');
+  const scores = getStoredScores();
+  const baseline = Number(scores.start || scores.baseline || 0) || null;
+  const data = BUREAUS.map(bureau => {
+    const value = readScore(scores, bureau);
+    const delta = baseline && value ? value - baseline : null;
+    return { bureau, value, delta, label: categorizeScore(value ?? NaN) };
+  });
+  const available = data.filter(item => Number.isFinite(item.value));
+  if (!available.length){
+    grid.innerHTML = `<div class="text-sm text-blue-700/80">${escapeHtml(bilingual('No credit scores saved yet. Upload a report to sync them.', 'Aún no hay puntajes guardados. Sube un reporte para sincronizarlos.'))}</div>`;
+    if (meta) meta.textContent = '';
+    return;
+  }
+  grid.innerHTML = data.map(item => {
+    const valueTxt = Number.isFinite(item.value) ? String(item.value) : '—';
+    const deltaTxt = Number.isFinite(item.delta) && item.delta !== 0
+      ? `<span class="text-xs font-semibold ${item.delta > 0 ? 'text-emerald-600' : 'text-red-600'}">${item.delta > 0 ? '+' : ''}${item.delta}</span>`
+      : '';
+    return `<div class="rounded-xl border border-blue-200 bg-white/80 p-4 shadow-inner flex flex-col gap-1">
+        <div class="flex items-center justify-between">
+          <span class="text-xs font-semibold uppercase tracking-wide text-blue-500">${escapeHtml(item.bureau)}</span>
+          ${deltaTxt}
+        </div>
+        <div class="text-3xl font-bold text-slate-900">${escapeHtml(valueTxt)}</div>
+        <div class="text-[11px] text-blue-600">${escapeHtml(item.label)}</div>
+      </div>`;
+  }).join('');
+  if (meta){
+    const avg = Math.round(available.reduce((sum, item) => sum + item.value, 0) / available.length);
+    const snapshot = getReportSnapshot();
+    const updated = snapshot?.capturedAt ? new Date(snapshot.capturedAt) : null;
+    const updatedTxt = updated && !Number.isNaN(updated)
+      ? `Updated ${updated.toLocaleString()}`
+      : bilingual('Awaiting latest report', 'Esperando último reporte');
+    meta.textContent = `Avg ${avg} • ${categorizeScore(avg)} • ${updatedTxt}`;
+  }
+}
+
+function renderPersonalInfoSection(){
+  const grid = document.getElementById('personalInfoGrid');
+  if (!grid) return;
+  const snapshot = getReportSnapshot();
+  const info = snapshot?.personalInfo || {};
+  const hasAny = BUREAUS.some(b => info[b]);
+  if (!hasAny){
+    grid.innerHTML = `<div class="text-sm text-green-700/80">${escapeHtml(bilingual('No personal data synced yet. Generate a report to populate this section.', 'Aún no se sincroniza información personal. Genera un reporte para ver datos aquí.'))}</div>`;
+    return;
+  }
+  grid.innerHTML = BUREAUS.map(bureau => {
+    const data = info[bureau];
+    if (!data){
+      return `<div class="rounded-xl border border-green-200 bg-white/70 p-4 text-sm text-green-700/80 shadow-inner">
+        <div class="font-semibold">${escapeHtml(bureau)}</div>
+        <p class="mt-2 text-xs text-green-600/80">${escapeHtml(bilingual('No data reported by this bureau.', 'Este buró no reportó datos.'))}</p>
+      </div>`;
+    }
+    const addresses = Array.isArray(data.addresses) && data.addresses.length
+      ? data.addresses.map(addr => `<li class="leading-tight">${escapeHtml(addr)}</li>`).join('')
+      : `<li class="text-xs text-green-600/80">${escapeHtml(bilingual('No address reported', 'Sin dirección reportada'))}</li>`;
+    const nameTxt = valueOrFallback(data.name);
+    const dobTxt = valueOrFallback(formatDateDisplay(data.dob));
+    const addressBadge = data.addresses && data.addresses.length
+      ? `<span class="text-[11px] text-green-500">${escapeHtml(String(data.addresses.length))} ${data.addresses.length === 1 ? 'address' : 'addresses'}</span>`
+      : '';
+    return `<div class="rounded-xl border border-green-200 bg-white/70 p-4 space-y-2 shadow-inner">
+      <div class="flex items-center justify-between text-sm font-semibold text-green-700">
+        <span>${escapeHtml(bureau)}</span>
+        ${addressBadge}
+      </div>
+      <div class="text-xs text-green-900"><span class="font-semibold uppercase tracking-wide text-green-500">Name</span> <span class="ml-1">${escapeHtml(nameTxt)}</span></div>
+      <div class="text-xs text-green-900"><span class="font-semibold uppercase tracking-wide text-green-500">DOB</span> <span class="ml-1">${escapeHtml(dobTxt)}</span></div>
+      <div>
+        <div class="text-[11px] font-semibold uppercase tracking-wide text-green-500 mb-1">Addresses</div>
+        <ul class="space-y-1 text-xs text-green-900">${addresses}</ul>
+      </div>
+    </div>`;
+  }).join('');
+}
+
+function normalizeHistoryEntries(entries){
+  if (!Array.isArray(entries)) return [];
+  return entries.map(entry => {
+    if (typeof entry === 'string') return entry;
+    if (entry && typeof entry === 'object'){
+      return entry.status_class || entry.status_text || '';
+    }
+    return '';
+  }).filter(Boolean);
+}
+
+function describeHistory(code){
+  if (!code) return bilingual('Review history', 'Revisar historial');
+  const raw = String(code).toLowerCase();
+  const clean = raw.replace(/[^a-z0-9-]/g, '');
+  if (clean.startsWith('hstry-')){
+    const suffix = clean.slice(6);
+    if (/^\d+$/.test(suffix)) return bilingual(`${suffix} days late`, `${suffix} días tarde`);
+    if (suffix === 'ok') return bilingual('On time', 'Al corriente');
+    if (suffix === 'unknown') return bilingual('No data reported', 'Sin datos reportados');
+    if (suffix === 'late') return bilingual('Late payment reported', 'Pago tardío reportado');
+    if (suffix === 'derog') return bilingual('Severe derogatory', 'Severo derogatorio');
+    if (suffix === 'neg') return bilingual('Negative mark', 'Marca negativa');
+    if (suffix === 'co') return bilingual('Charge-off reported', 'Cargo castigado reportado');
+    if (suffix === 'collection') return bilingual('Collection reported', 'Cuenta en cobranza');
+  }
+  if (/^\d+$/.test(clean)) return bilingual(`${clean} days late`, `${clean} días tarde`);
+  if (clean.includes('ok')) return bilingual('On time', 'Al corriente');
+  if (clean.includes('unknown') || clean === '?') return bilingual('No data reported', 'Sin datos reportados');
+  if (clean.includes('late') || clean.includes('delinquent')) return bilingual('Late payment reported', 'Pago tardío reportado');
+  return bilingual('Review history', 'Revisar historial');
+}
+
+function renderPaymentHistory(){
+  const grid = document.getElementById('paymentHistoryGrid');
+  if (!grid) return;
+  const snapshot = getReportSnapshot();
+  const tradelines = snapshot?.tradelines || [];
+  if (!tradelines.length){
+    grid.innerHTML = `<div class="text-sm text-yellow-700/80">${escapeHtml(bilingual('No payment history available. Upload a report to analyze trends.', 'No hay historial de pagos disponible. Sube un reporte para analizar tendencias.'))}</div>`;
+    return;
+  }
+  const summary = {};
+  BUREAUS.forEach(b => summary[b] = new Map());
+  tradelines.forEach(tl => {
+    const history = tl.history || {};
+    BUREAUS.forEach(bureau => {
+      const entries = normalizeHistoryEntries(history[bureau]);
+      if (!entries.length) return;
+      const map = summary[bureau];
+      entries.forEach(code => {
+        const label = describeHistory(code);
+        const record = map.get(label) || { count: 0 };
+        record.count += 1;
+        map.set(label, record);
+      });
+    });
+  });
+  grid.innerHTML = BUREAUS.map(bureau => {
+    const entries = Array.from(summary[bureau].entries())
+      .sort((a,b) => b[1].count - a[1].count)
+      .slice(0,4);
+    if (!entries.length){
+      return `<div class="rounded-xl border border-yellow-200 bg-white/70 p-4 text-sm text-yellow-700/80 shadow-inner">
+        <div class="font-semibold">${escapeHtml(bureau)}</div>
+        <p class="mt-2 text-xs text-yellow-600/80">${escapeHtml(bilingual('No payment history captured for this bureau.', 'No se capturó historial de pagos para este buró.'))}</p>
+      </div>`;
+    }
+    const list = entries.map(([label,data]) => `<li class="flex items-center justify-between gap-2"><span class="text-xs text-yellow-900">${escapeHtml(label)}</span><span class="text-xs font-semibold text-yellow-700">${escapeHtml(String(data.count))}</span></li>`).join('');
+    return `<div class="rounded-xl border border-yellow-200 bg-white/70 p-4 shadow-inner">
+      <div class="text-sm font-semibold text-yellow-700">${escapeHtml(bureau)}</div>
+      <ul class="mt-2 space-y-1">${list}</ul>
+      <p class="mt-3 text-[11px] text-yellow-600/80">${escapeHtml(bilingual('Most frequent marks shown above.', 'Marcas más frecuentes mostradas arriba.'))}</p>
+    </div>`;
+  }).join('');
+}
+
+function renderAccountBureau(bureau, data, accountNumber){
+  if (!data || !Object.keys(data).length){
+    return `<div class="rounded-lg border border-purple-100 bg-purple-50/60 p-3 text-xs text-purple-600/80 shadow-inner">${escapeHtml(bilingual('No data reported', 'Sin datos reportados'))}</div>`;
+  }
+  const fields = [
+    { label: 'Account Status', value: data.account_status },
+    { label: 'Payment Status', value: data.payment_status },
+    { label: 'Balance', value: formatMoneyDisplay(data.balance_raw, data.balance) },
+    { label: 'Credit Limit', value: formatMoneyDisplay(data.credit_limit_raw, data.credit_limit) },
+    { label: 'Monthly Payment', value: formatMoneyDisplay(data.monthly_payment_raw, data.monthly_payment) },
+    { label: 'Past Due', value: formatMoneyDisplay(data.past_due_raw, data.past_due) },
+    { label: 'Opened', value: formatDateDisplay(data.date_opened_raw || data.date_opened) },
+    { label: 'Closed', value: formatDateDisplay(data.date_closed_raw || data.date_closed), optional: true },
+    { label: 'Last Reported', value: formatDateDisplay(data.last_reported_raw || data.last_reported) }
+  ];
+  const rows = fields.map(field => {
+    if ((!field.value || field.value === '') && field.optional) return '';
+    const display = valueOrFallback(field.value);
+    return `<div class="flex justify-between gap-2 text-xs text-purple-900"><span class="font-semibold uppercase tracking-wide text-[11px] text-purple-500">${escapeHtml(field.label)}</span><span class="text-right">${escapeHtml(display)}</span></div>`;
+  }).join('');
+  const acct = accountNumber || data.account_number;
+  return `<div class="rounded-lg border border-purple-200 bg-white/80 p-3 shadow-sm">
+    <div class="mb-2 flex items-center justify-between">
+      <span class="text-sm font-semibold text-purple-600">${escapeHtml(bureau)}</span>
+      ${acct ? `<span class="text-[11px] text-purple-400">#${escapeHtml(String(acct))}</span>` : ''}
+    </div>
+    ${rows || `<p class="text-xs text-purple-500/80">${escapeHtml(bilingual('No details reported', 'Sin detalles reportados'))}</p>`}
+  </div>`;
+}
+
+function renderAccountDetailsSection(){
+  const list = document.getElementById('accountDetailsList');
+  if (!list) return;
+  const snapshot = getReportSnapshot();
+  const tradelines = snapshot?.tradelines || [];
+  if (!tradelines.length){
+    list.innerHTML = `<p class="text-sm text-purple-700/80">${escapeHtml(bilingual('No accounts available yet. Upload a report to review balances and limits.', 'No hay cuentas disponibles. Sube un reporte para revisar saldos y límites.'))}</p>`;
+    return;
+  }
+  const displayed = tradelines.slice(0, 3);
+  const cards = displayed.map((tl, idx) => {
+    const title = tl.meta?.creditor ? tl.meta.creditor : `Account ${idx + 1}`;
+    const accountNumbers = tl.meta?.accountNumbers || {};
+    const utilization = tl.metrics?.avg_utilization ?? tl.metrics?.avgUtilization;
+    const utilText = typeof utilization === 'number' && !Number.isNaN(utilization)
+      ? `Utilization ${utilization.toFixed(1)}%`
+      : '';
+    const sections = BUREAUS.map(bureau => renderAccountBureau(bureau, tl.per_bureau?.[bureau], accountNumbers[bureau])).join('');
+    return `<article class="rounded-xl bg-white/70 p-4 shadow-inner border border-purple-200">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <h4 class="text-base font-semibold text-purple-700">${escapeHtml(title)}</h4>
+        ${utilText ? `<span class="text-xs text-purple-500">${escapeHtml(utilText)}</span>` : ''}
+      </div>
+      <div class="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">${sections}</div>
+    </article>`;
+  }).join('');
+  const extra = tradelines.length > displayed.length
+    ? `<p class="text-[11px] text-purple-500/80">${escapeHtml(bilingual(`Showing ${displayed.length} of ${tradelines.length} tradelines`, `Mostrando ${displayed.length} de ${tradelines.length} cuentas`))}</p>`
+    : '';
+  list.innerHTML = cards + extra;
+}
+
+function canonicalBureau(name){
+  const key = String(name || '').toLowerCase().replace(/[^a-z]/g,'');
+  const map = {
+    transunion: 'TransUnion',
+    tu: 'TransUnion',
+    experian: 'Experian',
+    exp: 'Experian',
+    equifax: 'Equifax',
+    eq: 'Equifax',
+    eqf: 'Equifax'
+  };
+  return map[key] || (name ? String(name) : '');
+}
+
+function formatInquiryDate(value){
+  if (!value) return '';
+  const dt = new Date(value);
+  if (!Number.isNaN(dt)) {
+    return dt.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+  if (typeof value === 'string') return value;
+  return '';
+}
+
+function renderRecentInquiries(){
+  const list = document.getElementById('recentInquiriesList');
+  if (!list) return;
+  const snapshot = getReportSnapshot();
+  const inquiries = Array.isArray(snapshot?.inquiries) ? snapshot.inquiries : [];
+  if (!inquiries.length){
+    list.innerHTML = `<p class="text-sm text-red-700/80">${escapeHtml(bilingual('No hard pulls captured in the last report.', 'No se capturaron consultas duras en el último reporte.'))}</p>`;
+    return;
+  }
+  const sorted = inquiries.slice().sort((a,b) => {
+    const aTime = Date.parse(a?.date || '') || 0;
+    const bTime = Date.parse(b?.date || '') || 0;
+    return bTime - aTime;
+  });
+  const limited = sorted.slice(0, 5);
+  const cards = limited.map(inq => {
+    const creditor = valueOrFallback(inq.creditor, bilingual('Unknown creditor', 'Acreedor desconocido'));
+    const bureau = canonicalBureau(inq.bureau) || bilingual('Unknown bureau', 'Buró desconocido');
+    const dateTxt = valueOrFallback(formatInquiryDate(inq.date), bilingual('Date unavailable', 'Fecha no disponible'));
+    return `<div class="flex items-center justify-between gap-3 rounded-lg border border-red-200 bg-white/80 px-3 py-2 shadow-sm">
+      <div>
+        <div class="font-semibold text-sm text-red-700">${escapeHtml(creditor)}</div>
+        <div class="text-[11px] text-red-500">${escapeHtml(bureau)}</div>
+      </div>
+      <div class="text-xs text-red-600">${escapeHtml(dateTxt)}</div>
+    </div>`;
+  }).join('');
+  const extra = inquiries.length > limited.length
+    ? `<p class="text-[11px] text-red-500/80">${escapeHtml(bilingual(`Showing ${limited.length} of ${inquiries.length} inquiries`, `Mostrando ${limited.length} de ${inquiries.length} consultas`))}</p>`
+    : '';
+  list.innerHTML = cards + extra;
+}
 function renderClientMap(consumers){
   const mapEl = document.getElementById('clientMap');
   if(!mapEl || typeof L === 'undefined') return;
@@ -244,4 +628,40 @@ document.addEventListener('DOMContentLoaded', () => {
       renderClientMap(consumers);
     })
     .catch(err=> console.error('Failed to load dashboard stats', err));
+
+  renderCreditScores();
+  renderPersonalInfoSection();
+  renderPaymentHistory();
+  renderAccountDetailsSection();
+  renderRecentInquiries();
+
+  window.addEventListener('storage', (evt) => {
+    if (evt.key === 'creditScore') renderCreditScores();
+    if (evt.key === 'reportSnapshot') {
+      cachedSnapshotRaw = null;
+      cachedSnapshot = null;
+      renderPersonalInfoSection();
+      renderPaymentHistory();
+      renderAccountDetailsSection();
+      renderRecentInquiries();
+    }
+  });
+
+  try {
+    const originalSetItem = localStorage.setItem;
+    localStorage.setItem = function(key, value){
+      originalSetItem.apply(this, arguments);
+      if (key === 'creditScore') renderCreditScores();
+      if (key === 'reportSnapshot') {
+        cachedSnapshotRaw = null;
+        cachedSnapshot = null;
+        renderPersonalInfoSection();
+        renderPaymentHistory();
+        renderAccountDetailsSection();
+        renderRecentInquiries();
+      }
+    };
+  } catch (err) {
+    console.warn('Unable to hook localStorage updates', err);
+  }
 });

--- a/metro2 (copy 1)/crm/public/index.js
+++ b/metro2 (copy 1)/crm/public/index.js
@@ -36,6 +36,161 @@ let trackerSteps = [];
 let consumerFiles = [];
 
 let metro2Violations = [];
+
+function cleanString(value, max = 300) {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  return str.length > max ? str.slice(0, max) : str;
+}
+
+function normalizePersonalInfoSnapshot(infoRaw) {
+  const result = {};
+  if (!infoRaw || typeof infoRaw !== "object") return result;
+  const bureaus = ["TransUnion", "Experian", "Equifax"];
+  for (const bureau of bureaus) {
+    const info = infoRaw[bureau] || infoRaw[bureau?.toLowerCase?.()] || null;
+    if (!info) continue;
+    const entry = {};
+    if (info.name) entry.name = cleanString(info.name, 200);
+    if (info.dob) entry.dob = cleanString(info.dob, 40);
+    const addresses = new Set();
+    if (Array.isArray(info.addresses)) {
+      info.addresses.forEach(addr => {
+        const val = cleanString(addr, 200);
+        if (val) addresses.add(val);
+      });
+    }
+    if (Array.isArray(info.address)) {
+      info.address.forEach(addr => {
+        const val = cleanString(addr, 200);
+        if (val) addresses.add(val);
+      });
+    }
+    if (info.address && typeof info.address === "object" && !Array.isArray(info.address)) {
+      const parts = ["addr1", "addr2", "city", "state", "zip"].map(k => cleanString(info.address[k], 60)).filter(Boolean);
+      if (parts.length) addresses.add(parts.join(", "));
+    }
+    if (info.address && typeof info.address === "string") {
+      const val = cleanString(info.address, 200);
+      if (val) addresses.add(val);
+    }
+    if (!entry.name && !entry.dob && !addresses.size) continue;
+    entry.addresses = Array.from(addresses);
+    result[bureau] = entry;
+  }
+  return result;
+}
+
+function normalizeTradelineSnapshot(tl) {
+  if (!tl || typeof tl !== "object") return null;
+  const safe = { meta: {}, per_bureau: {}, history: {} };
+  if (tl.meta) {
+    const accountNums = tl.meta.account_numbers || tl.meta.accountNumbers || {};
+    safe.meta = {
+      creditor: cleanString(tl.meta.creditor || tl.meta.furnisher || "", 200),
+      accountNumbers: {}
+    };
+    ["TransUnion", "Experian", "Equifax"].forEach(b => {
+      if (accountNums && accountNums[b]) {
+        safe.meta.accountNumbers[b] = cleanString(accountNums[b], 120);
+      }
+    });
+  }
+  const perBureauSrc = tl.per_bureau || tl.perBureau || {};
+  const fields = [
+    "account_status", "payment_status", "balance", "balance_raw",
+    "credit_limit", "credit_limit_raw", "monthly_payment", "monthly_payment_raw",
+    "past_due", "past_due_raw", "high_credit", "high_credit_raw",
+    "date_opened", "date_opened_raw", "date_closed", "date_closed_raw",
+    "date_last_payment", "date_last_payment_raw", "last_reported", "last_reported_raw",
+    "account_number"
+  ];
+  ["TransUnion", "Experian", "Equifax"].forEach(bureau => {
+    const data = perBureauSrc[bureau];
+    if (!data || typeof data !== "object") return;
+    const dest = {};
+    fields.forEach(field => {
+      if (data[field] === undefined || data[field] === null || data[field] === "") return;
+      const val = data[field];
+      dest[field] = typeof val === "number" ? val : cleanString(val, 200);
+    });
+    if (Object.keys(dest).length) safe.per_bureau[bureau] = dest;
+  });
+  if (tl.metrics && typeof tl.metrics === "object") {
+    const metrics = {};
+    if (tl.metrics.avg_utilization !== undefined) {
+      const util = Number(tl.metrics.avg_utilization);
+      if (!Number.isNaN(util)) metrics.avg_utilization = util;
+    }
+    if (Object.keys(metrics).length) safe.metrics = metrics;
+  }
+  const historySrc = tl.history || {};
+  ["TransUnion", "Experian", "Equifax"].forEach(bureau => {
+    const h = historySrc[bureau];
+    if (!h) return;
+    if (Array.isArray(h)) {
+      safe.history[bureau] = h.slice(0, 120).map(entry => {
+        if (entry && typeof entry === "object") {
+          const item = {};
+          if (entry.status_class) item.status_class = cleanString(entry.status_class, 60);
+          if (entry.status_text) item.status_text = cleanString(entry.status_text, 60);
+          if (entry.col) item.col = cleanString(entry.col, 40);
+          return item;
+        }
+        return cleanString(entry, 60);
+      });
+    }
+  });
+  if (tl.history_summary && typeof tl.history_summary === "object") {
+    safe.history_summary = tl.history_summary;
+  }
+  if (!Object.keys(safe.per_bureau).length && !Object.keys(safe.history).length && !safe.meta.creditor) {
+    return null;
+  }
+  return safe;
+}
+
+function normalizeInquirySnapshot(inq) {
+  if (!inq || typeof inq !== "object") return null;
+  const entry = {};
+  if (inq.creditor) entry.creditor = cleanString(inq.creditor, 200);
+  if (inq.bureau) entry.bureau = cleanString(inq.bureau, 60);
+  if (inq.date) entry.date = cleanString(inq.date, 60);
+  if (inq.reason) entry.reason = cleanString(inq.reason, 120);
+  return Object.keys(entry).length ? entry : null;
+}
+
+function storeReportSnapshot(report) {
+  if (typeof localStorage === "undefined") return;
+  try {
+    if (!report || typeof report !== "object") {
+      localStorage.removeItem("reportSnapshot");
+      return;
+    }
+    const personalInfoSrc = report.personalInfo || report.personal_info || {};
+    const personalInfo = normalizePersonalInfoSnapshot(personalInfoSrc);
+    const tradelinesSrc = Array.isArray(report.tradelines) ? report.tradelines : [];
+    const tradelines = tradelinesSrc
+      .map(normalizeTradelineSnapshot)
+      .filter(Boolean)
+      .slice(0, 30);
+    const inquiriesSrc = Array.isArray(report.inquiries) ? report.inquiries : [];
+    const inquiries = inquiriesSrc
+      .map(normalizeInquirySnapshot)
+      .filter(Boolean)
+      .slice(0, 25);
+    const snapshot = {
+      version: 1,
+      capturedAt: new Date().toISOString(),
+      personalInfo,
+      tradelines,
+      inquiries
+    };
+    localStorage.setItem("reportSnapshot", JSON.stringify(snapshot));
+  } catch (err) {
+    console.warn("Failed to persist report snapshot", err);
+  }
+}
 function renderReasonOptions(filter=""){
   const sel = $("#tlReasonSelect");
   if(!sel) return;
@@ -490,6 +645,7 @@ async function loadReportJSON(){
   renderFilterBar();
   renderTradelines(CURRENT_REPORT.tradelines);
   renderCollectors(CURRENT_REPORT.creditor_contacts || []);
+  storeReportSnapshot(CURRENT_REPORT);
 
 }
 


### PR DESCRIPTION
## Summary
- persist a sanitized credit report snapshot in localStorage after loading a report
- add color-coded credit report sections (scores, personal info, payment history, accounts, inquiries) to the dashboard layout
- render dashboard insights from the snapshot with bureau-specific formatting and resilient fallbacks

## Testing
- node --test tests/dedupeTradelines.test.js
- node --test tests/collectSelections.test.js
- node --test tests/parserInquiries.test.js *(fails: No tradeline tables found)*
- node --test tests/uploadReport.test.js *(fails: API responded 403 during standalone run)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ac3882c48323aee2a7d058534a0b