### PR TITLE
Fix rule 10 duplicate tracking and add test

### DIFF
--- a/metro2 (copy 1)/crm/metro2_audit_multi.py
+++ b/metro2 (copy 1)/crm/metro2_audit_multi.py
@@ -655,7 +655,10 @@ def r_10(ctx, bureau, data, add):
     acct = data.get("account_number")
     if not acct:
         return
-    seen = ctx.setdefault("_seen_accounts", set())
+    seen = getattr(ctx, "_seen_accounts", None)
+    if seen is None:
+        seen = set()
+        setattr(ctx, "_seen_accounts", seen)
     key = (bureau, acct)
     if key in seen:
         add(make_violation(
@@ -691,6 +694,7 @@ def run_rules_for_tradeline(creditor, per_bureau, rule_profile):
     violations = []
     furnisher_type = detect_furnisher_type(per_bureau)
     ctx = RuleContext(creditor, per_bureau, furnisher_type, rule_profile)
+    setattr(ctx, "_seen_accounts", set())
 
     def add(v):
         violations.append(v)


### PR DESCRIPTION
## Summary
- persist the rule 10 `_seen_accounts` set on the rule context and initialize it once per tradeline
- add a regression test that runs `run_rules_for_tradeline` with rule 10 enabled and verifies the duplicate violation is emitted

## Testing
- python -m unittest python-tests/test_metro2_audit_multi.py
- python metro2_audit_multi.py -i data/report.html -o tmp.json
- python metro2_audit_multi.py -i /tmp/duplicate_sample.html -o /tmp/duplicate_out.json


------
https://chatgpt.com/codex/tasks/task_e_68c9c8ace9e083238e6cb701f8a18639