### PR TITLE
Handle unauthorized /api/me access

### DIFF
--- a/metro2 (copy 1)/crm/public/settings.js
+++ b/metro2 (copy 1)/crm/public/settings.js
@@ -90,6 +90,9 @@ document.addEventListener('DOMContentLoaded', () => {
   async function init() {
     try {
       const resp = await fetch('/api/me');
+      if (!resp.ok) {
+        return;
+      }
       const data = await resp.json();
       if (data.user?.role === 'admin') {
         panelEl?.classList.remove('hidden');

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -966,6 +966,9 @@ app.put("/api/users/:id", authenticate, requireRole("admin"), async (req,res)=>{
 });
 
 app.get("/api/me", authenticate, (req,res)=>{
+  if(!req.user){
+    return res.status(401).json({ ok:false, error:"Unauthorized" });
+  }
   res.json({ ok:true, user: { id: req.user.id, username: req.user.username, name: req.user.name, role: req.user.role, permissions: req.user.permissions || [] } });
 });
 

--- a/metro2 (copy 1)/crm/tests/meEndpoint.test.js
+++ b/metro2 (copy 1)/crm/tests/meEndpoint.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import bcrypt from 'bcryptjs';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { readKey, writeKey } from '../kvdb.js';
+
+const originalUsers = await readKey('users', null);
+
+const adminUser = {
+  id: 'me-admin',
+  username: 'me-admin',
+  password: bcrypt.hashSync('secret', 10),
+  role: 'admin',
+  permissions: ['consumers']
+};
+
+await writeKey('users', { users: [adminUser] });
+
+process.env.NODE_ENV = 'test';
+const { default: app } = await import('../server.js');
+
+function tokenFor(user) {
+  return jwt.sign(
+    {
+      id: user.id,
+      username: user.username,
+      role: user.role,
+      permissions: user.permissions || []
+    },
+    'dev-secret',
+    { expiresIn: '1h' }
+  );
+}
+
+test('GET /api/me without credentials returns 401', async () => {
+  const res = await request(app).get('/api/me');
+  assert.equal(res.status, 401);
+  assert.equal(res.body.ok, false);
+  assert.match(res.body.error, /unauthorized/i);
+});
+
+test('GET /api/me with valid token returns the current user', async () => {
+  const res = await request(app)
+    .get('/api/me')
+    .set('Authorization', `Bearer ${tokenFor(adminUser)}`);
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.ok, true);
+  assert.equal(res.body.user.id, adminUser.id);
+  assert.equal(res.body.user.username, adminUser.username);
+});
+
+test.after(async () => {
+  if (originalUsers) {
+    await writeKey('users', originalUsers);
+  } else {
+    await writeKey('users', { users: [] });
+  }
+});
+


### PR DESCRIPTION
## Summary
- return an explicit 401 Unauthorized response from `/api/me` when no authenticated user is present
- guard the settings dashboard session check so it safely ignores unauthorized `/api/me` responses
- add integration coverage ensuring `/api/me` rejects anonymous requests while succeeding with a valid token

## Testing
- node --test --test-force-exit tests/meEndpoint.test.js
- node --test --test-force-exit tests/authorization.test.js
- node --test --test-force-exit tests/clientLogin.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cbde970654832388295cb8eb1d4f8f