### PR TITLE
feat(settings): allow managing environment overrides

### DIFF
--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -68,6 +68,14 @@
     <input id="gcalId" class="w-full border rounded px-2 py-1 text-sm" placeholder="Google Calendar ID" />
     <input id="stripeKey" class="w-full border rounded px-2 py-1 text-sm" placeholder="Stripe API Key" />
 
+    <div class="border-t border-white/10 pt-3 space-y-2">
+      <div class="font-medium">Environment Overrides <span class="text-xs text-gray-500">/ Variables de entorno</span></div>
+      <p class="text-xs text-gray-600">Store API keys & tokens for integrations. Valores se guardan en la base local del CRM y sincronizan con el servidor activo.</p>
+      <p class="text-xs text-gray-500">Use uppercase letters, numbers, and underscores for the key. Usa mayúsculas, números y guiones bajos para la clave.</p>
+      <div id="envList" class="space-y-2 text-sm"></div>
+      <button id="addEnvRow" type="button" class="btn text-xs">Add Variable / Añadir variable</button>
+    </div>
+
     <button id="saveSettings" class="btn text-sm">Save</button>
     <div id="saveMsg" class="text-sm muted hidden">Saved!</div>
   </div>


### PR DESCRIPTION
## Summary
- add an Environment Overrides editor to the admin Settings screen so ops can enter API keys without redeploys
- persist env overrides in the settings store and expose them via the API while normalizing/sanitizing keys
- hydrate process.env from saved overrides and ensure JWT secret lookups respect runtime updates

## Testing
- node --test --test-concurrency=1 tests/*.test.js *(hangs after initial cases; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdeb98fe48323a401924c74f02216