### PR TITLE
fix(settings): harden environment override inputs

### DIFF
--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -68,6 +68,14 @@
     <input id="gcalId" class="w-full border rounded px-2 py-1 text-sm" placeholder="Google Calendar ID" />
     <input id="stripeKey" class="w-full border rounded px-2 py-1 text-sm" placeholder="Stripe API Key" />
 
+    <div class="border-t border-white/10 pt-3 space-y-2">
+      <div class="font-medium">Environment Overrides <span class="text-xs text-gray-500">/ Variables de entorno</span></div>
+      <p class="text-xs text-gray-600">Store API keys & tokens for integrations. Valores se guardan en la base local del CRM y sincronizan con el servidor activo.</p>
+      <p class="text-xs text-gray-500">Use uppercase letters, numbers, and underscores for the key. Usa mayúsculas, números y guiones bajos para la clave.</p>
+      <div id="envList" class="space-y-2 text-sm"></div>
+      <button id="addEnvRow" type="button" class="btn text-xs">Add Variable / Añadir variable</button>
+    </div>
+
     <button id="saveSettings" class="btn text-sm">Save</button>
     <div id="saveMsg" class="text-sm muted hidden">Saved!</div>
   </div>

--- a/metro2 (copy 1)/crm/public/settings.js
+++ b/metro2 (copy 1)/crm/public/settings.js
@@ -8,9 +8,105 @@ document.addEventListener('DOMContentLoaded', () => {
   const gcalTokenEl = document.getElementById('gcalToken');
   const gcalIdEl = document.getElementById('gcalId');
   const stripeEl = document.getElementById('stripeKey');
+  const envListEl = document.getElementById('envList');
+  const addEnvBtn = document.getElementById('addEnvRow');
 
   const saveBtn = document.getElementById('saveSettings');
   const msgEl = document.getElementById('saveMsg');
+
+  const MAX_ENV_KEY_LEN = 64;
+
+  function sanitizeEnvKey(raw = '') {
+    let key = raw.toString().trim().toUpperCase();
+    key = key.replace(/[^A-Z0-9_]/g, '_');
+    if (key && !/^[A-Z_]/.test(key)) {
+      key = `VAR_${key}`;
+    }
+    key = key.replace(/^[^A-Z_]+/, '');
+    return key.slice(0, MAX_ENV_KEY_LEN);
+  }
+
+  function createEnvRow(key = '', value = '') {
+    if (!envListEl) return null;
+    const row = document.createElement('div');
+    row.className = 'env-row flex flex-wrap md:flex-nowrap items-center gap-2';
+
+    const keyInput = document.createElement('input');
+    keyInput.className = 'flex-1 border rounded px-2 py-1 text-xs uppercase tracking-wide';
+    keyInput.placeholder = 'ENV_KEY';
+    keyInput.value = sanitizeEnvKey(key);
+    keyInput.dataset.field = 'key';
+    keyInput.maxLength = 64;
+    keyInput.autocomplete = 'off';
+    keyInput.spellcheck = false;
+    keyInput.addEventListener('input', () => {
+      const sanitized = sanitizeEnvKey(keyInput.value);
+      if (sanitized !== keyInput.value) keyInput.value = sanitized;
+    });
+    keyInput.addEventListener('blur', () => {
+      const sanitized = sanitizeEnvKey(keyInput.value);
+      if (sanitized !== keyInput.value) keyInput.value = sanitized;
+    });
+
+    const valueInput = document.createElement('input');
+    valueInput.className = 'flex-1 border rounded px-2 py-1 text-xs';
+    valueInput.placeholder = 'Value / Valor';
+    valueInput.value = value;
+    valueInput.dataset.field = 'value';
+    valueInput.autocomplete = 'off';
+    valueInput.spellcheck = false;
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'btn text-xs px-3';
+    removeBtn.textContent = 'Remove / Quitar';
+    removeBtn.addEventListener('click', () => row.remove());
+
+    row.append(keyInput, valueInput, removeBtn);
+    return row;
+  }
+
+  function renderEnvOverrides(overrides = {}) {
+    if (!envListEl) return;
+    envListEl.innerHTML = '';
+    const entries = Object.entries(overrides || {});
+    if (entries.length === 0) {
+      const blank = createEnvRow();
+      if (blank) envListEl.appendChild(blank);
+      return;
+    }
+    entries.forEach(([key, value]) => {
+      const row = createEnvRow(key, value);
+      if (row) envListEl.appendChild(row);
+    });
+  }
+
+  function collectEnvOverrides() {
+    if (!envListEl) return {};
+    const overrides = {};
+    envListEl.querySelectorAll('.env-row').forEach(row => {
+      const keyEl = row.querySelector('input[data-field="key"]');
+      const valEl = row.querySelector('input[data-field="value"]');
+      const key = sanitizeEnvKey(keyEl?.value || '');
+      const value = (valEl?.value || '').trim();
+      if (keyEl && key !== keyEl.value) {
+        keyEl.value = key;
+      }
+      if (key && value) {
+        overrides[key] = value;
+      }
+    });
+    return overrides;
+  }
+
+  if (addEnvBtn) {
+    addEnvBtn.addEventListener('click', () => {
+      const row = createEnvRow();
+      if (row && envListEl) envListEl.appendChild(row);
+    });
+  }
+
+  renderEnvOverrides();
 
   if (gcalIdEl) {
     const help = document.createElement('div');
@@ -81,6 +177,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (gcalTokenEl) gcalTokenEl.value = data.settings?.googleCalendarToken || '';
       if (gcalIdEl) gcalIdEl.value = data.settings?.googleCalendarId || '';
       if (stripeEl) stripeEl.value = data.settings?.stripeApiKey || '';
+      renderEnvOverrides(data.settings?.envOverrides || {});
 
     } catch (e) {
       console.error('Failed to load settings', e);
@@ -109,20 +206,46 @@ document.addEventListener('DOMContentLoaded', () => {
         googleCalendarToken: gcalTokenEl.value.trim(),
         googleCalendarId: gcalIdEl.value.trim(),
         stripeApiKey: stripeEl.value.trim(),
+        envOverrides: collectEnvOverrides(),
 
       };
+      const originalLabel = saveBtn.textContent;
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving…';
       try {
-        await fetch('/api/settings', {
+        const resp = await fetch('/api/settings', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body)
         });
+        const result = await resp.json().catch(() => ({}));
+        if (!resp.ok || !result.ok) {
+          throw new Error(result?.error || 'Failed to save settings');
+        }
+        if (hibpEl) hibpEl.value = result.settings?.hibpApiKey || '';
+        if (rssEl) rssEl.value = result.settings?.rssFeedUrl || '';
+        if (gcalTokenEl) gcalTokenEl.value = result.settings?.googleCalendarToken || '';
+        if (gcalIdEl) gcalIdEl.value = result.settings?.googleCalendarId || '';
+        if (stripeEl) stripeEl.value = result.settings?.stripeApiKey || '';
+        renderEnvOverrides(result.settings?.envOverrides || {});
         if (msgEl) {
+          msgEl.textContent = 'Saved!';
           msgEl.classList.remove('hidden');
+          msgEl.classList.remove('text-red-500');
           setTimeout(() => msgEl.classList.add('hidden'), 2000);
         }
       } catch (e) {
         console.error('Failed to save settings', e);
+        if (msgEl) {
+          msgEl.textContent = 'Save failed. Check the fields and try again.';
+          msgEl.classList.remove('hidden');
+          msgEl.classList.add('text-red-500');
+          setTimeout(() => msgEl.classList.add('hidden'), 4000);
+        }
+      }
+      finally {
+        saveBtn.disabled = false;
+        saveBtn.textContent = originalLabel;
       }
     });
   }

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -28,11 +28,59 @@ import { listEvents as listCalendarEvents, createEvent as createCalendarEvent, u
 
 import { fetchFn } from "./fetchUtil.js";
 
-const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
+const MAX_ENV_KEY_LENGTH = 64;
+
+const DEFAULT_SETTINGS = {
+  hibpApiKey: "",
+  rssFeedUrl: "https://hnrss.org/frontpage",
+  googleCalendarToken: "",
+  googleCalendarId: "",
+  stripeApiKey: "",
+  envOverrides: {}
+};
+
+function normalizeEnvOverrides(raw){
+  const result = {};
+  if(!raw) return result;
+  const entries = Array.isArray(raw)
+    ? raw
+    : Object.entries(raw).map(([key, value]) => ({ key, value }));
+  for(const entry of entries){
+    if(!entry) continue;
+    let key = (entry.key ?? entry.name ?? "").toString().trim();
+    if(!key) continue;
+    key = key.toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+    if(key && !/^[A-Z_]/.test(key)){
+      key = `VAR_${key}`;
+    }
+    key = key.replace(/^[^A-Z_]+/, "").slice(0, MAX_ENV_KEY_LENGTH);
+    if(!key) continue;
+    const value = (entry.value ?? entry.val ?? "").toString();
+    result[key.toUpperCase()] = value;
+  }
+  return result;
+}
+
+function applyEnvOverrides(overrides = {}){
+  for(const [key, value] of Object.entries(overrides)){
+    process.env[key] = value;
+  }
+}
+
+function normalizeSettings(raw){
+  const base = { ...DEFAULT_SETTINGS, ...(raw || {}) };
+  base.envOverrides = normalizeEnvOverrides((raw && raw.envOverrides) ?? base.envOverrides);
+  return base;
+}
+
+function getJwtSecret(){
+  return process.env.JWT_SECRET || "dev-secret";
+}
+
 const TOKEN_EXPIRES_IN = "1h";
 
 function generateToken(user){
-  return jwt.sign({ id: user.id, username: user.username, name: user.name, role: user.role, permissions: user.permissions || [] }, JWT_SECRET, { expiresIn: TOKEN_EXPIRES_IN });
+  return jwt.sign({ id: user.id, username: user.username, name: user.name, role: user.role, permissions: user.permissions || [] }, getJwtSecret(), { expiresIn: TOKEN_EXPIRES_IN });
 }
 
 
@@ -86,21 +134,31 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 async function loadSettings(){
-  const data = await readKey('settings', null);
-  if(data) return data;
-  const def = {
-    hibpApiKey: "",
-    rssFeedUrl: "https://hnrss.org/frontpage",
-    googleCalendarToken: "",
-    googleCalendarId: "",
-    stripeApiKey: "",
-  };
-  await writeKey('settings', def);
-  return def;
+  const raw = await readKey('settings', null);
+  if(raw){
+    const settings = normalizeSettings(raw);
+    applyEnvOverrides(settings.envOverrides);
+    return settings;
+  }
+  const defaults = normalizeSettings(DEFAULT_SETTINGS);
+  await writeKey('settings', defaults);
+  applyEnvOverrides(defaults.envOverrides);
+  return defaults;
 }
 
-async function saveSettings(data){ await writeKey('settings', data); }
+async function saveSettings(data){
+  const current = await readKey('settings', null);
+  const merged = normalizeSettings({ ...(current || {}), ...(data || {}) });
+  await writeKey('settings', merged);
+  applyEnvOverrides(merged.envOverrides);
+  return merged;
+}
 
+try {
+  await loadSettings();
+} catch (err) {
+  logError('SETTINGS_INIT_FAILED', 'Failed to hydrate settings on startup', err);
+}
 
 const require = createRequire(import.meta.url);
 let nodemailer = null;
@@ -156,7 +214,7 @@ async function getAuthUser(req){
   const db = await loadUsersDB();
   if(auth.startsWith("Bearer ")){
     try{
-      const payload = jwt.verify(auth.slice(7), JWT_SECRET);
+      const payload = jwt.verify(auth.slice(7), getJwtSecret());
       const found = db.users.find(u=>u.id===payload.id);
       if(!found) return null;
       return { ...found, permissions: found.permissions || [] };
@@ -350,10 +408,11 @@ app.post("/api/settings", async (req, res) => {
     googleCalendarToken = "",
     googleCalendarId = "",
     stripeApiKey = "",
+    envOverrides = {},
   } = req.body || {};
-  await saveSettings({ hibpApiKey, rssFeedUrl, googleCalendarToken, googleCalendarId, stripeApiKey });
+  const settings = await saveSettings({ hibpApiKey, rssFeedUrl, googleCalendarToken, googleCalendarId, stripeApiKey, envOverrides });
 
-  res.json({ ok: true });
+  res.json({ ok: true, settings });
 });
 
 app.get("/api/calendar/events", async (_req, res) => {

--- a/metro2 (copy 1)/crm/tests/settingsOverrides.test.js
+++ b/metro2 (copy 1)/crm/tests/settingsOverrides.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import request from 'supertest';
+import { readKey, writeKey, deleteKey } from '../kvdb.js';
+
+const originalSettings = await readKey('settings', null);
+const originalNodeEnv = process.env.NODE_ENV;
+const originalEnv = {
+  SCM_API_KEY: process.env.SCM_API_KEY,
+  TWILIO_AUTH_TOKEN: process.env.TWILIO_AUTH_TOKEN,
+};
+
+await writeKey('settings', {
+  hibpApiKey: '',
+  rssFeedUrl: 'https://example.com/rss',
+  googleCalendarToken: '',
+  googleCalendarId: '',
+  stripeApiKey: '',
+  envOverrides: { SCM_API_KEY: 'boot-seeded-key' },
+});
+
+delete process.env.SCM_API_KEY;
+delete process.env.TWILIO_AUTH_TOKEN;
+process.env.NODE_ENV = 'test';
+
+const { default: app } = await import('../server.js');
+
+test('hydrates stored env overrides on startup', () => {
+  assert.equal(process.env.SCM_API_KEY, 'boot-seeded-key');
+});
+
+test('saving env overrides normalizes keys and hydrates process.env', async () => {
+  const res = await request(app)
+    .post('/api/settings')
+    .send({
+      envOverrides: {
+        'scm api key': 'runtime-key',
+        'twilio.auth-token': 'abc123',
+      },
+    });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.ok, true);
+  assert.equal(res.body.settings.envOverrides.SCM_API_KEY, 'runtime-key');
+  assert.equal(res.body.settings.envOverrides.TWILIO_AUTH_TOKEN, 'abc123');
+  assert.equal(process.env.SCM_API_KEY, 'runtime-key');
+  assert.equal(process.env.TWILIO_AUTH_TOKEN, 'abc123');
+});
+
+test.after(async () => {
+  if (originalSettings === null) await deleteKey('settings');
+  else await writeKey('settings', originalSettings);
+
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+
+  if (originalEnv.SCM_API_KEY === undefined) delete process.env.SCM_API_KEY;
+  else process.env.SCM_API_KEY = originalEnv.SCM_API_KEY;
+
+  if (originalEnv.TWILIO_AUTH_TOKEN === undefined) delete process.env.TWILIO_AUTH_TOKEN;
+  else process.env.TWILIO_AUTH_TOKEN = originalEnv.TWILIO_AUTH_TOKEN;
+});


### PR DESCRIPTION
## Summary
- sanitize and normalize environment override keys in the admin settings UI while refreshing fields after a successful save so API credentials stick
- normalize override payloads on the server, cap key length, and hydrate `process.env` during startup so saved secrets survive restarts
- add a regression test that proves env overrides populate `process.env` on boot and after posting updated keys

## Testing
- node --test tests/settingsOverrides.test.js *(passes but process keeps background handles alive; interrupted after assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdeb98fe48323a401924c74f02216