### PR TITLE
Refine tradeline dedupe by account numbers

### DIFF
--- a/metro2 (copy 1)/crm/tests/dedupeTradelines.test.js
+++ b/metro2 (copy 1)/crm/tests/dedupeTradelines.test.js
@@ -24,3 +24,21 @@ test('dedupeTradelines merges entries with matching account numbers across burea
   const deduped = dedupeTradelines(lines);
   assert.equal(deduped.length, 1);
 });
+
+test('dedupeTradelines keeps creditor-only entries separate when no account numbers exist', () => {
+  const lines = [
+    { meta:{ creditor:'No Numbers Creditor' }, per_bureau:{ TransUnion:{ balance:100 }, Experian:{}, Equifax:{} }, violations:[] },
+    { meta:{ creditor:'No Numbers Creditor' }, per_bureau:{ TransUnion:{ balance:200 }, Experian:{}, Equifax:{} }, violations:[] }
+  ];
+  const deduped = dedupeTradelines(lines);
+  assert.equal(deduped.length, 2);
+});
+
+test('dedupeTradelines merges using meta.account_numbers when bureau numbers are missing', () => {
+  const lines = [
+    { meta:{ creditor:'Meta Number Creditor', account_numbers:{ Experian:' abc123 ' } }, per_bureau:{ TransUnion:{ balance:150 }, Experian:{}, Equifax:{} }, violations:[] },
+    { meta:{ creditor:'Meta Number Creditor', account_numbers:{ TransUnion:'ABC123' } }, per_bureau:{ TransUnion:{}, Experian:{ balance:250 }, Equifax:{} }, violations:[] }
+  ];
+  const deduped = dedupeTradelines(lines);
+  assert.equal(deduped.length, 1);
+});


### PR DESCRIPTION
## Summary
- normalize tradeline account numbers from bureau data and meta account_numbers before deduping
- skip dedupe merges when no account numbers exist so creditor-only entries remain unique
- add regression tests covering creditor-only and meta-sourced account number scenarios

## Testing
- node --test tests/dedupeTradelines.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cbe6ece9b48323a9a3520575864173