### PR TITLE
Use auth header for /api/me fetch

### DIFF
--- a/metro2 (copy 1)/crm/public/settings.js
+++ b/metro2 (copy 1)/crm/public/settings.js
@@ -190,7 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function init() {
     try {
-      const resp = await fetch('/api/me');
+      const resp = await fetch('/api/me', { headers: authHeader() });
       if (!resp.ok) {
         return;
       }


### PR DESCRIPTION
## Summary
- ensure the settings panel initialization uses the shared auth header when requesting `/api/me`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbe7d60fb88323b6596fc4ae15fe42