### PR TITLE
Merge tradeline duplicates without data loss

### DIFF
--- a/metro2 (copy 1)/crm/tests/dedupeTradelines.test.js
+++ b/metro2 (copy 1)/crm/tests/dedupeTradelines.test.js
@@ -12,7 +12,12 @@ for (; i < source.length && depth > 0; i++) {
   if (source[i] === '{') depth++;
   else if (source[i] === '}') depth--;
 }
-let fnCode = source.slice(start, i);
+const helpersStart = source.lastIndexOf('function isPlainObject', start);
+let fnCode = '';
+if (helpersStart !== -1) {
+  fnCode += source.slice(helpersStart, start);
+}
+fnCode += source.slice(start, i);
 fnCode = fnCode.replace('export function', 'function');
 const dedupeTradelines = (new Function(`${fnCode}; return dedupeTradelines;`))();
 
@@ -41,4 +46,55 @@ test('dedupeTradelines merges using meta.account_numbers when bureau numbers are
   ];
   const deduped = dedupeTradelines(lines);
   assert.equal(deduped.length, 1);
+});
+
+test('dedupeTradelines merges bureau data, violations, and metadata without losing detail', () => {
+  const lines = [
+    {
+      meta:{
+        creditor:'Merge Creditor',
+        account_numbers:{ TransUnion:'12345TU' },
+        manual_reason:'Detailed bilingual rationale / Razón detallada'
+      },
+      per_bureau:{
+        TransUnion:{ account_number:'12345TU', balance:200, payment_status:'Late' },
+        Experian:{},
+        Equifax:{ account_number:'12345TU', payment_status:'Current' }
+      },
+      violations:[{ title:'TU mismatch', bureaus:['TransUnion'] }]
+    },
+    {
+      meta:{
+        creditor:'Merge Creditor',
+        account_numbers:{ Experian:'12345TU' },
+        manual_reason:' '
+      },
+      per_bureau:{
+        TransUnion:{ account_number:'12345TU', past_due:0 },
+        Experian:{ account_number:'12345TU', past_due:50 },
+        Equifax:{ account_number:'12345TU', payment_status:'' }
+      },
+      violations:[
+        { title:'TU mismatch', bureaus:['TransUnion'] },
+        { title:'Experian notice missing', bureaus:['Experian'] }
+      ]
+    }
+  ];
+
+  const deduped = dedupeTradelines(lines);
+  assert.equal(deduped.length, 1);
+  const merged = deduped[0];
+
+  assert.equal(merged.per_bureau.TransUnion.account_number, '12345TU');
+  assert.equal(merged.per_bureau.TransUnion.balance, 200);
+  assert.equal(merged.per_bureau.Experian.account_number, '12345TU');
+  assert.equal(merged.per_bureau.Experian.past_due, 50);
+  assert.equal(merged.per_bureau.Equifax.payment_status, 'Current');
+
+  assert.equal(merged.violations.length, 2);
+  assert.deepEqual(new Set(merged.violations.map(v => v.title)), new Set(['TU mismatch', 'Experian notice missing']));
+
+  assert.equal(merged.meta.manual_reason, 'Detailed bilingual rationale / Razón detallada');
+  assert.equal(merged.meta.account_numbers.TransUnion, '12345TU');
+  assert.equal(merged.meta.account_numbers.Experian, '12345TU');
 });


### PR DESCRIPTION
## Summary
- add helper merge utilities so dedupeTradelines merges duplicate entries instead of replacing them
- ensure per-bureau data, metadata (including account numbers), and violation lists are combined when deduping
- extend dedupeTradelines tests to cover merged bureau fields, metadata preservation, and violation union behavior

## Testing
- node --test tests/dedupeTradelines.test.js


------
https://chatgpt.com/codex/tasks/task_e_68cbff19e91083238b1f6eebfe1d8c00