### PR TITLE
fix: restore responsive layout on dashboard and nav

### DIFF
--- a/metro2 (copy 1)/crm/public/billing.html
+++ b/metro2 (copy 1)/crm/public/billing.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Billing</title>
   <script src="https://cdn.tailwindcss.com"></script>
 <script>
@@ -34,27 +35,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
 <main class="max-w-7xl mx-auto p-4 space-y-4">

--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Client Portal - {{name}}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>

--- a/metro2 (copy 1)/crm/public/dashboard.html
+++ b/metro2 (copy 1)/crm/public/dashboard.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Dashboard</title>
   <script src="https://cdn.tailwindcss.com"></script>
 <script>
@@ -44,31 +45,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-      <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You've started your journey.">
-        <span class="text-xl">📄</span>
-        <span class="font-semibold text-sm">Rookie</span>
-      </div>
-    </div>
+    </nav>
   </div>
 </header>
 <main class="max-w-7xl mx-auto p-4 space-y-4">
@@ -80,26 +97,26 @@
     <div id="confetti" class="pointer-events-none absolute inset-0"></div>
   </div>
 
-  <div class="grid gap-4 md:grid-cols-3">
-    <div class="glass card">
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-3 md:auto-rows-fr">
+    <div class="glass card h-full flex flex-col">
       <div class="font-medium mb-2">News</div>
-      <div id="newsFeed" class="text-sm space-y-1">Loading...</div>
+      <div id="newsFeed" class="text-sm space-y-1 flex-1">Loading...</div>
     </div>
 
-    <div class="glass card">
+    <div class="glass card h-full flex flex-col">
       <div class="font-medium mb-2">Messages</div>
-      <div id="msgList" class="text-sm space-y-1 min-h-[80px] max-h-48 overflow-y-auto muted">No messages.</div>
+      <div id="msgList" class="text-sm space-y-1 min-h-[80px] max-h-48 overflow-y-auto muted flex-1">No messages.</div>
 
     </div>
 
-    <div class="glass card">
+    <div class="glass card h-full flex flex-col">
       <div class="font-medium mb-2">Upcoming Events</div>
-      <div id="eventList" class="text-sm space-y-1 min-h-[80px] max-h-48 overflow-y-auto muted">No events.</div>
+      <div id="eventList" class="text-sm space-y-1 min-h-[80px] max-h-48 overflow-y-auto muted flex-1">No events.</div>
     </div>
   </div>
 
-  <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-    <div class="glass card">
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 sm:auto-rows-fr">
+    <div class="glass card h-full flex flex-col">
       <div class="flex items-start justify-between">
         <div>
           <div class="text-sm muted">Total Leads</div>
@@ -109,7 +126,7 @@
       </div>
     </div>
 
-    <div class="glass card">
+    <div class="glass card h-full flex flex-col">
       <div class="flex items-start justify-between">
         <div>
           <div class="text-sm muted">Total Clients</div>
@@ -119,7 +136,7 @@
       </div>
     </div>
 
-    <div class="glass card">
+    <div class="glass card h-full flex flex-col">
       <div class="flex items-start justify-between">
         <div>
           <div class="text-sm muted">Sales</div>
@@ -129,7 +146,7 @@
       </div>
     </div>
 
-    <div class="glass card">
+    <div class="glass card h-full flex flex-col">
       <div class="flex items-start justify-between">
         <div>
           <div class="text-sm muted">Payments</div>
@@ -140,8 +157,8 @@
     </div>
   </div>
 
-  <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-    <div class="glass card lg:col-span-2">
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 md:auto-rows-fr">
+    <div class="glass card lg:col-span-2 h-full flex flex-col">
       <div class="flex items-center justify-between mb-2">
         <div class="font-medium">Notepad</div>
         <button id="dashSaveNote" class="btn text-sm">Save</button>
@@ -153,22 +170,22 @@
       <div id="noteList" class="mt-2 space-y-1 text-sm"></div>
     </div>
 
-    <div class="glass card">
+    <div class="glass card h-full flex flex-col">
       <div class="font-medium mb-2">Retention Rate</div>
       <div id="dashRetention" class="text-2xl font-semibold">0.0%</div>
     </div>
 
-    <div class="glass card">
+    <div class="glass card h-full flex flex-col">
       <div class="font-medium mb-2">Lead Conversion</div>
       <div id="dashConversion" class="text-2xl font-semibold">0.0%</div>
     </div>
 
-    <div class="glass card">
+    <div class="glass card h-full flex flex-col">
       <div class="font-medium mb-2">Company Deletion Statistics</div>
       <div id="dashDeletion" class="text-sm muted">No data</div>
     </div>
 
-    <div class="glass card md:col-span-2 lg:col-span-3">
+    <div class="glass card md:col-span-2 lg:col-span-3 h-full flex flex-col">
       <div class="font-medium mb-2">Client Locations</div>
       <div id="clientMap" class="w-full h-64 rounded-lg"></div>
     </div>

--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -96,27 +96,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
 

--- a/metro2 (copy 1)/crm/public/leads.html
+++ b/metro2 (copy 1)/crm/public/leads.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Leads</title>
   <script src="https://cdn.tailwindcss.com"></script>
 <script>
@@ -34,27 +35,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
 <main class="max-w-3xl mx-auto p-4 space-y-4">

--- a/metro2 (copy 1)/crm/public/letters.html
+++ b/metro2 (copy 1)/crm/public/letters.html
@@ -54,27 +54,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
 

--- a/metro2 (copy 1)/crm/public/library.html
+++ b/metro2 (copy 1)/crm/public/library.html
@@ -54,27 +54,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
 

--- a/metro2 (copy 1)/crm/public/my-company.html
+++ b/metro2 (copy 1)/crm/public/my-company.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>My Company</title>
   <script src="https://cdn.tailwindcss.com"></script>
 <script>
@@ -34,27 +35,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
 <main class="max-w-3xl mx-auto p-4 space-y-4">

--- a/metro2 (copy 1)/crm/public/quiz.html
+++ b/metro2 (copy 1)/crm/public/quiz.html
@@ -35,27 +35,47 @@
 </head>
 <body>
   <header id="host-nav" class="p-4">
-    <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
       <div class="text-xl font-semibold">Metro 2 CRM</div>
-      <div class="flex items-center gap-2">
-        <a href="/dashboard" class="btn">Dashboard</a>
-        <a href="/clients" class="btn">Clients</a>
-        <a href="/leads" class="btn">Leads</a>
-        <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-        <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
   <main class="max-w-3xl mx-auto p-6">

--- a/metro2 (copy 1)/crm/public/schedule.html
+++ b/metro2 (copy 1)/crm/public/schedule.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Schedule</title>
   <script src="https://cdn.tailwindcss.com"></script>
 <script>
@@ -34,27 +35,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
 <main class="max-w-7xl mx-auto p-4">

--- a/metro2 (copy 1)/crm/public/settings.html
+++ b/metro2 (copy 1)/crm/public/settings.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Settings</title>
   <script src="https://cdn.tailwindcss.com"></script>
 <script>
@@ -34,27 +35,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
 <main class="max-w-3xl mx-auto p-4 space-y-4">

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -269,6 +269,87 @@ header .group > div.absolute {
   z-index: 100 !important;
 }
 
+/* Responsive navigation shell */
+.nav-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nav-brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+#navToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+#primaryNav {
+  width: 100%;
+}
+
+#primaryNavLinks {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav-dropdown {
+  position: relative;
+}
+
+.nav-dropdown-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav-dropdown:not(.open) .nav-dropdown-menu {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .nav-shell {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  #primaryNav {
+    width: auto;
+  }
+
+  #primaryNavLinks {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .nav-dropdown-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 8px);
+    min-width: 200px;
+  }
+}
+
+@media (max-width: 767px) {
+  #primaryNav .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  body {
+    background-attachment: scroll;
+  }
+}
+
 pre.debug {
   background: #f3f4f6;
   border: 1px solid #e5e7eb;

--- a/metro2 (copy 1)/crm/public/tradelines.html
+++ b/metro2 (copy 1)/crm/public/tradelines.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tradelines</title>
   <script src="https://cdn.tailwindcss.com"></script>
 <script>
@@ -34,27 +35,47 @@
 </head>
 <body>
 <header id="host-nav" class="p-4">
-  <div class="max-w-7xl mx-auto glass card flex items-center justify-between">
-    <div class="text-xl font-semibold">Metro 2 CRM</div>
-    <div class="flex items-center gap-2">
-      <a href="/dashboard" class="btn">Dashboard</a>
-      <a href="/clients" class="btn">Clients</a>
-      <a href="/leads" class="btn">Leads</a>
-      <a href="/schedule" class="btn">Schedule</a>
-      <a href="/billing" class="btn">Billing</a>
-      <div class="relative group">
-        <a href="/settings" class="btn">Settings</a>
-        <div class="absolute hidden group-hover:flex flex-col right-0 top-full mt-2 glass card p-2 gap-2 z-10">
-
-          <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
-          <a href="/letters" class="btn text-sm">Letter</a>
-          <a href="/library" class="btn text-sm">Library</a>
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
             <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
         </div>
       </div>
-      <a href="/tradelines" class="btn">Tradelines</a>
-      <button id="btnHelp" class="btn" data-tip="Help (H)">Help</button>
-    </div>
+    </nav>
   </div>
 </header>
 <main class="max-w-7xl mx-auto px-4 py-6">

--- a/metro2 (copy 1)/crm/tests/teamRole.test.js
+++ b/metro2 (copy 1)/crm/tests/teamRole.test.js
@@ -53,20 +53,30 @@ test('restrictRoutes redirects unauthorized paths for team', () => {
 
 test('applyRoleNav removes disallowed nav items for team', () => {
   const applyRoleNav = extractFunction('applyRoleNav');
-  const dom = new JSDOM(`<header><div class="flex items-center gap-2">
-    <a href="/dashboard"></a>
-    <a href="/clients"></a>
-    <a href="/leads"></a>
-    <a href="/schedule"></a>
-    <a href="/billing"></a>
-    <a href="/admin"></a>
-    <button id="btnInvite"></button>
-    <button id="btnHelp"></button>
-    <button id="tierBadge"></button>
-  </div></header>`);
+  const dom = new JSDOM(`<header>
+    <div class="nav-shell">
+      <div class="nav-brand-row">
+        <div class="text-xl font-semibold">Metro 2 CRM</div>
+        <button id="navToggle"></button>
+      </div>
+      <nav id="primaryNav">
+        <div id="primaryNavLinks">
+          <a href="/dashboard"></a>
+          <a href="/clients"></a>
+          <a href="/leads"></a>
+          <a href="/schedule"></a>
+          <a href="/billing"></a>
+          <a href="/admin"></a>
+          <button id="btnInvite"></button>
+          <button id="btnHelp"></button>
+          <div id="tierBadge"></div>
+        </div>
+      </nav>
+    </div>
+  </header>`);
   global.document = dom.window.document;
   applyRoleNav('team');
-  const nav = dom.window.document.querySelector('header .flex.items-center.gap-2');
+  const nav = dom.window.document.getElementById('primaryNavLinks');
   const items = [...nav.children].map(el => el.tagName === 'A' ? el.getAttribute('href') : el.id);
   assert.deepEqual(items, ['/dashboard','/clients','/leads','/schedule','/billing']);
   delete global.document;


### PR DESCRIPTION
## Summary
- add missing viewport meta tags to host pages so the shared navigation collapses correctly on phones
- rebalance dashboard grids with explicit mobile column defaults and auto row heights for even cards across breakpoints
- stretch dashboard cards with flexbox so content blocks stay aligned when the layout collapses

## Testing
- npm test *(passes but leaves open handles; terminated with Ctrl+C after successful assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68d48a48aed48323b4909f7a6be5eead