### PR TITLE
feat: add marketing placeholder page and nav link

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -151,7 +151,7 @@ window.userRole = _payload.role || null;
 function restrictRoutes(role){
   const allowed = {
     host: null,
-    team: ['/dashboard','/clients','/leads','/schedule','/billing','/','/index.html','/login.html','/team-member-template.html'],
+    team: ['/dashboard','/clients','/leads','/marketing','/schedule','/billing','/','/index.html','/login.html','/team-member-template.html'],
     client: ['/client-portal','/portal','/login.html','/']
   }[role];
   if(!allowed) return;
@@ -166,6 +166,20 @@ restrictRoutes(window.userRole);
 // append a logout button to the nav if present
 const navContainer = document.getElementById('primaryNavLinks');
 if (navContainer) {
+  if (!navContainer.querySelector('a[href="/marketing"]')) {
+    const marketingLink = document.createElement('a');
+    marketingLink.href = '/marketing';
+    marketingLink.className = 'btn nav-btn';
+    marketingLink.textContent = 'Marketing';
+    const scheduleLink = navContainer.querySelector('a[href="/schedule"]');
+    if (scheduleLink?.parentElement === navContainer) {
+      navContainer.insertBefore(marketingLink, scheduleLink);
+    } else {
+      const leadsLink = navContainer.querySelector('a[href="/leads"]');
+      leadsLink?.insertAdjacentElement('afterend', marketingLink);
+      if (!leadsLink) navContainer.appendChild(marketingLink);
+    }
+  }
   const btnLogout = document.createElement('button');
   btnLogout.id = 'btnLogout';
   btnLogout.className = 'btn nav-btn';
@@ -191,7 +205,7 @@ function applyRoleNav(role){
     return;
   }
   if(role === 'team'){
-    const allowed = new Set(['/dashboard','/clients','/leads','/schedule','/billing']);
+    const allowed = new Set(['/dashboard','/clients','/leads','/marketing','/schedule','/billing']);
     navLinks.querySelectorAll('a[href]').forEach(link => {
       const href = link.getAttribute('href');
       if(href && !allowed.has(href)){
@@ -331,7 +345,7 @@ async function limitNavForMembers(){
     if(!role.includes('member')) return;
     const nav = document.getElementById('primaryNavLinks');
     if(!nav) return;
-    const allowed = new Set(['/dashboard','/schedule','/leads','/billing','/clients']);
+    const allowed = new Set(['/dashboard','/schedule','/leads','/marketing','/billing','/clients']);
     [...nav.children].forEach(el=>{
       if(el.tagName === 'A'){
         const href = el.getAttribute('href');

--- a/metro2 (copy 1)/crm/public/marketing.html
+++ b/metro2 (copy 1)/crm/public/marketing.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Marketing</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+(() => {
+  const themes = {
+    purple:{accent:'#AF52DE',hover:'#9333EA',bg:'#AF52DE',
+            glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    blue:{accent:'#007AFF',hover:'#005BB5',bg:'#007AFF',
+          glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'},
+    green:{accent:'#34C759',hover:'#248A3D',bg:'#34C759',
+           glassBg:'rgba(255,255,255,0.4)',glassBrd:'rgba(255,255,255,0.25)'}
+    // …keep the rest of your themes
+  };
+  const name = localStorage.getItem('theme') || 'purple';
+  const t = themes[name] || themes.purple;
+  const r = document.documentElement.style;
+  r.setProperty('--accent', t.accent);
+  r.setProperty('--accent-hover', t.hover);
+  r.setProperty('--accent-bg', t.bg);
+  r.setProperty('--glass-bg', t.glassBg);
+  r.setProperty('--glass-brd', t.glassBrd);
+  r.setProperty('--btn-text', '#fff');
+  document.documentElement.style.visibility = 'hidden';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.style.visibility = '';
+  });
+})();
+  </script>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<header id="host-nav" class="p-4">
+  <div class="max-w-7xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="text-xl font-semibold">Metro 2 CRM</div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <nav id="primaryNav" class="hidden flex-col gap-2 md:flex md:flex-row md:items-center md:gap-2" aria-label="Primary">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a href="/dashboard" class="btn nav-btn">Dashboard</a>
+        <a href="/clients" class="btn nav-btn">Clients</a>
+        <a href="/leads" class="btn nav-btn">Leads</a>
+        <a href="/schedule" class="btn nav-btn">Schedule</a>
+        <a href="/billing" class="btn nav-btn">Billing</a>
+        <div class="nav-dropdown" id="navSettings">
+          <button type="button" id="navSettingsToggle" class="btn nav-btn flex items-center justify-between md:justify-center gap-2" aria-expanded="false" aria-haspopup="true">
+            <span>Settings</span>
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
+            <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
+            <a href="/letters" class="btn text-sm">Letter</a>
+            <a href="/library" class="btn text-sm">Library</a>
+            <a href="/workflows" class="btn text-sm">Workflows</a>
+            <button id="btnInvite" class="btn text-sm" style="background: var(--green-bg);">Add Team Member</button>
+          </div>
+        </div>
+        <a href="/tradelines" class="btn nav-btn">Tradelines</a>
+        <button id="btnHelp" class="btn nav-btn" data-tip="Help (H)">Help</button>
+        <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm" title="You've started your journey.">
+          <span class="text-xl">📄</span>
+          <span class="font-semibold text-sm">Rookie</span>
+        </div>
+      </div>
+    </nav>
+  </div>
+</header>
+<main class="max-w-4xl mx-auto p-4 space-y-4">
+  <h1 class="text-2xl font-bold">Marketing Launchpad</h1>
+  <div class="glass card p-6 text-sm space-y-4">
+    <p class="text-gray-700">Stage your campaigns, track lead magnets, and map premium experiences before you flip the switch. Keep your voice consistent with trust, clarity, and empowerment.</p>
+    <p class="text-gray-500">Espacio reservado para tus campañas bilingües, secuencias de nurturing y activos de conversión. Documenta ideas, audita CTAs y prepárate para probar con seguridad.</p>
+    <div class="border border-dashed border-gray-300 rounded-lg p-6 text-center text-gray-400">
+      Placeholder canvas. Drop funnel diagrams, email cadences, or future marketing automations here cuando estés listo.
+    </div>
+  </div>
+</main>
+<script type="module" src="/common.js"></script>
+</body>
+</html>

--- a/metro2 (copy 1)/crm/server.js
+++ b/metro2 (copy 1)/crm/server.js
@@ -345,6 +345,7 @@ app.get(["/letters", "/letters/:jobId"], optionalAuth, forbidMember, (_req, res)
 );
 app.get("/library", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "library.html")));
 app.get("/workflows", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "workflows.html")));
+app.get("/marketing", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "marketing.html")));
 app.get("/tradelines", optionalAuth, forbidMember, (_req, res) => res.sendFile(path.join(PUBLIC_DIR, "tradelines.html")));
 app.get("/quiz", optionalAuth, forbidMember, (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "quiz.html")));
 app.get("/settings", optionalAuth, forbidMember, (_req,res)=> res.sendFile(path.join(PUBLIC_DIR, "settings.html")));

--- a/metro2 (copy 1)/crm/tests/teamRole.test.js
+++ b/metro2 (copy 1)/crm/tests/teamRole.test.js
@@ -64,6 +64,7 @@ test('applyRoleNav removes disallowed nav items for team', () => {
           <a href="/dashboard"></a>
           <a href="/clients"></a>
           <a href="/leads"></a>
+          <a href="/marketing"></a>
           <a href="/schedule"></a>
           <a href="/billing"></a>
           <a href="/admin"></a>
@@ -78,6 +79,6 @@ test('applyRoleNav removes disallowed nav items for team', () => {
   applyRoleNav('team');
   const nav = dom.window.document.getElementById('primaryNavLinks');
   const items = [...nav.children].map(el => el.tagName === 'A' ? el.getAttribute('href') : el.id);
-  assert.deepEqual(items, ['/dashboard','/clients','/leads','/schedule','/billing']);
+  assert.deepEqual(items, ['/dashboard','/clients','/leads','/marketing','/schedule','/billing']);
   delete global.document;
 });


### PR DESCRIPTION
## Summary
- add a Marketing placeholder page patterned after the existing workflow staging view
- surface a Marketing link in the primary navigation and allow access for team members and members
- expose the new page through the server routes and update nav role tests

## Testing
- `node --test --test-name-pattern "applyRoleNav" tests/teamRole.test.js`
- `npm test` *(hangs after the authorization suite; requires further investigation)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a5c9fdb4832394a066f33224ebe6