### PR TITLE
Make client portal responsive

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -51,29 +51,29 @@
 </head>
 <body>
 <header id="team-nav" class="p-4">
-  <div class="max-w-3xl mx-auto flex items-center justify-between">
-    <div class="flex items-center gap-2">
+  <div class="max-w-6xl mx-auto flex flex-wrap items-center justify-between gap-4">
+    <div class="flex items-center gap-2 flex-1 min-w-[200px]">
       <div id="mascot" class="w-12 h-12"></div>
       <div id="companyName" class="text-xl font-semibold">Client Portal</div>
     </div>
-    <nav class="flex items-center gap-2">
-      <a id="navDashboard" href="#" class="btn">Dashboard</a>
-      <a href="#messages" class="btn">Messages</a>
-      <a href="#educationSection" class="btn">Education</a>
-      <a href="#documentSection" class="btn">Docs</a>
-      <a href="#mailSection" class="btn">Mail</a>
-      <a href="#tradelines" class="btn">Tradelines</a>
-      <a href="#uploads" class="btn">Uploads</a>
-    </nav>
-    <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You’ve planted the seed — secured cards are your first step to building credit.">
+    <div id="tierBadge" class="order-3 sm:order-2 hidden w-full sm:w-auto sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You’ve planted the seed — secured cards are your first step to building credit.">
       <span class="text-xl">🔒</span>
       <span class="font-semibold text-sm">Secured Start</span>
     </div>
+    <nav class="order-2 sm:order-3 flex w-full flex-wrap gap-2 sm:w-auto sm:flex-nowrap sm:items-center sm:justify-end" id="portalNav">
+      <a id="navDashboard" href="#" class="btn flex-1 sm:flex-none">Dashboard</a>
+      <a href="#messages" class="btn flex-1 sm:flex-none">Messages</a>
+      <a href="#educationSection" class="btn flex-1 sm:flex-none">Education</a>
+      <a href="#documentSection" class="btn flex-1 sm:flex-none">Docs</a>
+      <a href="#mailSection" class="btn flex-1 sm:flex-none">Mail</a>
+      <a href="#tradelines" class="btn flex-1 sm:flex-none">Tradelines</a>
+      <a href="#uploads" class="btn flex-1 sm:flex-none">Uploads</a>
+    </nav>
   </div>
 </header>
-<div id="messageBanner" class="max-w-3xl mx-auto p-2 text-center bg-yellow-100 text-yellow-800 hidden"></div>
-<main id="portalMain" class="max-w-3xl mx-auto p-4 space-y-4">
-  <div class="glass card relative overflow-hidden">
+<div id="messageBanner" class="max-w-6xl mx-auto p-2 text-center bg-yellow-100 text-yellow-800 hidden"></div>
+<main id="portalMain" class="max-w-6xl mx-auto grid gap-4 p-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
+  <div class="glass card relative overflow-hidden md:col-span-2 xl:col-span-3">
     <div class="pointer-events-none absolute -top-16 -right-16 h-56 w-56 rounded-full bg-gradient-to-tr from-emerald-400 to-cyan-400 opacity-20 blur-3xl animate-blob"></div>
     <div class="pointer-events-none absolute -bottom-16 -left-16 h-56 w-56 rounded-full bg-gradient-to-tr from-cyan-400 to-emerald-400 opacity-20 blur-3xl animate-blob"></div>
     <h2 class="mb-2 text-2xl font-bold flex items-center gap-2">Welcome, {{name}}</h2>
@@ -84,9 +84,9 @@
 
   </div>
 
-  <div id="creditScoreWidget" class="glass card">
+  <div id="creditScoreWidget" class="glass card md:col-span-2 xl:col-span-1">
     <div class="font-medium mb-2">Credit Score</div>
-    <div class="relative grid grid-cols-3 gap-4 text-center">
+    <div class="relative grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
       <div>
         <div class="text-xs text-gray-500">TransUnion</div>
         <div class="tu text-2xl font-bold">0</div>
@@ -110,7 +110,7 @@
 
   <div class="glass card">
     <div class="font-medium mb-2">Items in Dispute</div>
-    <div id="itemsInDispute" class="text-sm space-y-1 flex flex-col items-center justify-center">
+    <div id="itemsInDispute" class="text-sm space-y-1 flex flex-col items-center justify-center sm:items-start">
       <div id="itemsInDisputeEmpty" class="w-32 h-32"></div>
       <div id="itemsInDisputeText" class="mt-2">No items in dispute.</div>
     </div>
@@ -133,12 +133,12 @@
     <div id="teamList" class="space-y-2 text-sm">Loading...</div>
   </div>
 
-  <div class="glass card">
+  <div class="glass card md:col-span-2 xl:col-span-1">
     <div class="font-medium mb-2">News</div>
     <div id="newsFeed" class="text-sm space-y-1">Loading...</div>
   </div>
 
-  <div class="glass card">
+  <div class="glass card md:col-span-2 xl:col-span-1">
     <div class="font-medium mb-2">Debt Payoff Calculator</div>
     <form id="debtForm" class="space-y-2">
       <input type="number" id="debtAmount" class="input w-full" placeholder="Debt Amount" required />
@@ -150,7 +150,7 @@
   </div>
 
 </main>
-<div id="uploadSection" class="max-w-3xl mx-auto p-4 hidden">
+<div id="uploadSection" class="max-w-6xl mx-auto p-4 hidden">
   <h2 class="text-xl font-bold mb-2">Upload Documents</h2>
   <form id="uploadForm" class="space-y-2">
     <select id="uploadType" class="input w-full">

--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -38,7 +38,7 @@ function renderProductTier(score){
   }
   const tier = getProductTier(deletions, scoreVal);
 
-  el.className = `hidden sm:flex items-center gap-2 rounded-full px-4 py-2 shadow-sm animate-fadeInUp ${tier.class}`;
+  el.className = `order-3 sm:order-2 hidden w-full sm:w-auto sm:flex items-center gap-2 rounded-full px-4 py-2 shadow-sm animate-fadeInUp ${tier.class}`;
   el.innerHTML = `<span class="text-xl">${tier.icon}</span><span class="font-semibold text-sm">${tier.name}</span>`;
   el.title = tier.message;
 }

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -26,6 +26,10 @@ body {
 }
 .card { border-radius:18px; padding:16px }
 .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
   background: var(--accent);
   color: var(--btn-text);
   border: none;
@@ -33,6 +37,7 @@ body {
   padding: 6px 12px;
   box-shadow: 0 1px 2px rgba(0,0,0,.05);
   transition: background .2s;
+  text-decoration: none;
 }
 .btn:hover { background: var(--accent-hover); }
 .input { background: rgba(255,255,255,0.8); border: 1px solid var(--glass-brd); border-radius: 10px; padding: 8px; }
@@ -155,6 +160,42 @@ body.voice-active #voiceNotes{display:block;}
 }
 .news-item:last-child {
   border-bottom: none;
+}
+
+#team-nav nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+#team-nav nav .btn {
+  flex: 1 1 calc(50% - 8px);
+  min-width: 120px;
+}
+
+#tierBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (min-width: 640px) {
+  #team-nav nav {
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+    gap: 8px;
+  }
+  #team-nav nav .btn {
+    flex: 0 0 auto;
+    min-width: auto;
+  }
+  #tierBadge {
+    justify-content: flex-start;
+  }
+}
+
+#portalMain {
+  width: 100%;
 }
 
 .timeline-item {


### PR DESCRIPTION
## Summary
- widen the client portal layout and convert the dashboard cards into a responsive grid that adapts from phones to desktops
- make the header navigation and tier badge flex-wrap so action buttons stack neatly on smaller screens while maintaining premium styling
- adjust shared button styling and tier badge rendering logic so buttons center-align and the badge keeps its new responsive layout

## Testing
- `npm test` *(fails to complete: hangs after initial authorization tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a674021883238899e252171cb8a1