### PR TITLE
Hide client portal nav menu on desktop

### DIFF
--- a/metro2 (copy 1)/crm/public/client-portal-template.html
+++ b/metro2 (copy 1)/crm/public/client-portal-template.html
@@ -51,29 +51,44 @@
 </head>
 <body>
 <header id="team-nav" class="p-4">
-  <div class="max-w-3xl mx-auto flex items-center justify-between">
-    <div class="flex items-center gap-2">
-      <div id="mascot" class="w-12 h-12"></div>
-      <div id="companyName" class="text-xl font-semibold">Client Portal</div>
+  <div class="max-w-6xl mx-auto glass card nav-shell">
+    <div class="nav-brand-row">
+      <div class="flex items-center gap-3">
+        <div id="mascot" class="w-12 h-12"></div>
+        <div class="flex flex-col">
+          <div id="companyName" class="text-xl font-semibold">Client Portal</div>
+          <div class="text-xs text-slate-600/80 hidden sm:block">Track disputes, uploads, and approvals in one place.</div>
+        </div>
+      </div>
+      <button id="navToggle" class="btn md:hidden" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <span>Menu</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
     </div>
-    <nav class="flex items-center gap-2">
-      <a id="navDashboard" href="#" class="btn">Dashboard</a>
-      <a href="#messages" class="btn">Messages</a>
-      <a href="#educationSection" class="btn">Education</a>
-      <a href="#documentSection" class="btn">Docs</a>
-      <a href="#mailSection" class="btn">Mail</a>
-      <a href="#tradelines" class="btn">Tradelines</a>
-      <a href="#uploads" class="btn">Uploads</a>
+    <nav id="primaryNav" class="hidden flex flex-col gap-2 md:flex-row md:items-center md:gap-2" aria-label="Client navigation">
+      <div id="primaryNavLinks" class="flex flex-col md:flex-row md:items-center gap-2 w-full md:w-auto">
+        <a id="navDashboard" href="#" class="btn nav-btn w-full md:w-auto">Dashboard</a>
+        <a href="#messages" class="btn nav-btn w-full md:w-auto">Messages</a>
+        <a href="#educationSection" class="btn nav-btn w-full md:w-auto">Education</a>
+        <a href="#documentSection" class="btn nav-btn w-full md:w-auto">Docs</a>
+        <a href="#mailSection" class="btn nav-btn w-full md:w-auto">Mail</a>
+        <a href="#tradelines" class="btn nav-btn w-full md:w-auto">Tradelines</a>
+        <a href="#uploads" class="btn nav-btn w-full md:w-auto">Uploads</a>
+      </div>
+      <div id="tierBadge" class="order-3 sm:order-2 hidden w-full sm:w-auto sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You’ve planted the seed — secured cards are your first step to building credit.">
+        <span class="text-xl">🔒</span>
+        <span class="font-semibold text-sm">Secured Start</span>
+      </div>
     </nav>
-    <div id="tierBadge" class="hidden sm:flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700 shadow-sm animate-fadeInUp" title="You’ve planted the seed — secured cards are your first step to building credit.">
-      <span class="text-xl">🔒</span>
-      <span class="font-semibold text-sm">Secured Start</span>
-    </div>
   </div>
 </header>
-<div id="messageBanner" class="max-w-3xl mx-auto p-2 text-center bg-yellow-100 text-yellow-800 hidden"></div>
-<main id="portalMain" class="max-w-3xl mx-auto p-4 space-y-4">
-  <div class="glass card relative overflow-hidden">
+<div id="messageBanner" class="max-w-6xl mx-auto p-2 text-center bg-yellow-100 text-yellow-800 hidden"></div>
+<main id="portalMain" class="max-w-6xl mx-auto grid gap-4 p-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
+  <div class="glass card relative overflow-hidden md:col-span-2 xl:col-span-3">
     <div class="pointer-events-none absolute -top-16 -right-16 h-56 w-56 rounded-full bg-gradient-to-tr from-emerald-400 to-cyan-400 opacity-20 blur-3xl animate-blob"></div>
     <div class="pointer-events-none absolute -bottom-16 -left-16 h-56 w-56 rounded-full bg-gradient-to-tr from-cyan-400 to-emerald-400 opacity-20 blur-3xl animate-blob"></div>
     <h2 class="mb-2 text-2xl font-bold flex items-center gap-2">Welcome, {{name}}</h2>
@@ -84,9 +99,9 @@
 
   </div>
 
-  <div id="creditScoreWidget" class="glass card">
+  <div id="creditScoreWidget" class="glass card md:col-span-2 xl:col-span-1">
     <div class="font-medium mb-2">Credit Score</div>
-    <div class="relative grid grid-cols-3 gap-4 text-center">
+    <div class="relative grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
       <div>
         <div class="text-xs text-gray-500">TransUnion</div>
         <div class="tu text-2xl font-bold">0</div>
@@ -110,7 +125,7 @@
 
   <div class="glass card">
     <div class="font-medium mb-2">Items in Dispute</div>
-    <div id="itemsInDispute" class="text-sm space-y-1 flex flex-col items-center justify-center">
+    <div id="itemsInDispute" class="text-sm space-y-1 flex flex-col items-center justify-center sm:items-start">
       <div id="itemsInDisputeEmpty" class="w-32 h-32"></div>
       <div id="itemsInDisputeText" class="mt-2">No items in dispute.</div>
     </div>
@@ -133,12 +148,12 @@
     <div id="teamList" class="space-y-2 text-sm">Loading...</div>
   </div>
 
-  <div class="glass card">
+  <div class="glass card md:col-span-2 xl:col-span-1">
     <div class="font-medium mb-2">News</div>
     <div id="newsFeed" class="text-sm space-y-1">Loading...</div>
   </div>
 
-  <div class="glass card">
+  <div class="glass card md:col-span-2 xl:col-span-1">
     <div class="font-medium mb-2">Debt Payoff Calculator</div>
     <form id="debtForm" class="space-y-2">
       <input type="number" id="debtAmount" class="input w-full" placeholder="Debt Amount" required />
@@ -150,7 +165,7 @@
   </div>
 
 </main>
-<div id="uploadSection" class="max-w-3xl mx-auto p-4 hidden">
+<div id="uploadSection" class="max-w-6xl mx-auto p-4 hidden">
   <h2 class="text-xl font-bold mb-2">Upload Documents</h2>
   <form id="uploadForm" class="space-y-2">
     <select id="uploadType" class="input w-full">

--- a/metro2 (copy 1)/crm/public/client-portal.js
+++ b/metro2 (copy 1)/crm/public/client-portal.js
@@ -38,7 +38,7 @@ function renderProductTier(score){
   }
   const tier = getProductTier(deletions, scoreVal);
 
-  el.className = `hidden sm:flex items-center gap-2 rounded-full px-4 py-2 shadow-sm animate-fadeInUp ${tier.class}`;
+  el.className = `order-3 sm:order-2 hidden w-full sm:w-auto sm:flex items-center gap-2 rounded-full px-4 py-2 shadow-sm animate-fadeInUp ${tier.class}`;
   el.innerHTML = `<span class="text-xl">${tier.icon}</span><span class="font-semibold text-sm">${tier.name}</span>`;
   el.title = tier.message;
 }
@@ -94,10 +94,44 @@ function renderTeamList(){
   }
 }
 
+function initClientPortalNav(){
+  const nav = document.getElementById('primaryNav');
+  const toggle = document.getElementById('navToggle');
+  if (!nav || !toggle) return;
+
+  const updateLayout = () => {
+    if (window.innerWidth >= 768) {
+      nav.classList.add('hidden');
+      toggle.setAttribute('aria-expanded', 'false');
+    } else {
+      const hidden = nav.classList.contains('hidden');
+      toggle.setAttribute('aria-expanded', hidden ? 'false' : 'true');
+    }
+  };
+
+  toggle.addEventListener('click', () => {
+    const nowHidden = nav.classList.toggle('hidden');
+    toggle.setAttribute('aria-expanded', nowHidden ? 'false' : 'true');
+  });
+
+  nav.querySelectorAll('a[href^="#"]').forEach(link => {
+    link.addEventListener('click', () => {
+      if (window.innerWidth < 768) {
+        nav.classList.add('hidden');
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  });
+
+  window.addEventListener('resize', updateLayout);
+  updateLayout();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const idMatch = location.pathname.match(/\/portal\/(.+)$/);
 
   const consumerId = idMatch ? idMatch[1] : null;
+  initClientPortalNav();
   loadScores();
 
   const dash = document.getElementById('navDashboard');

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -26,6 +26,10 @@ body {
 }
 .card { border-radius:18px; padding:16px }
 .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
   background: var(--accent);
   color: var(--btn-text);
   border: none;
@@ -33,6 +37,7 @@ body {
   padding: 6px 12px;
   box-shadow: 0 1px 2px rgba(0,0,0,.05);
   transition: background .2s;
+  text-decoration: none;
 }
 .btn:hover { background: var(--accent-hover); }
 .input { background: rgba(255,255,255,0.8); border: 1px solid var(--glass-brd); border-radius: 10px; padding: 8px; }
@@ -155,6 +160,38 @@ body.voice-active #voiceNotes{display:block;}
 }
 .news-item:last-child {
   border-bottom: none;
+}
+
+#team-nav .nav-brand-row {
+  align-items: center;
+}
+
+#team-nav #primaryNavLinks .btn {
+  justify-content: center;
+}
+
+#tierBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (min-width: 768px) {
+  #team-nav #primaryNavLinks {
+    justify-content: flex-end;
+  }
+
+  #team-nav #primaryNavLinks .btn {
+    justify-content: center;
+  }
+
+  #tierBadge {
+    justify-content: flex-start;
+  }
+}
+
+#portalMain {
+  width: 100%;
 }
 
 .timeline-item {
@@ -294,6 +331,10 @@ header .group > div.absolute {
   width: 100%;
 }
 
+#primaryNav:not(.hidden) {
+  display: flex;
+}
+
 #primaryNavLinks {
   display: flex;
   flex-direction: column;
@@ -315,6 +356,10 @@ header .group > div.absolute {
 }
 
 @media (min-width: 768px) {
+  #primaryNav {
+    display: none !important;
+  }
+
   .nav-shell {
     flex-direction: row;
     align-items: center;


### PR DESCRIPTION
## Summary
- wrap the client portal header in the shared glass nav shell with a menu toggle so it mirrors the host/client dropdown pattern on mobile
- add client portal nav controller logic to open, close, and collapse links consistently across viewport breakpoints
- update portal-specific CSS to lean on the shared nav shell spacing while keeping the tier badge aligned
- hide the client portal navigation menu on desktop so the dropdown treatment only appears on mobile as requested

## Testing
- `npm test` *(hangs after authorization guard suite in this environment; interrupted after repeated idle output)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a674021883238899e252171cb8a1