### PR TITLE
Fix client nav visibility regression on desktop

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -199,9 +199,33 @@ function applyRoleNav(role){
   const navLinks = document.getElementById('primaryNavLinks');
   const toggle = document.getElementById('navToggle');
   if(!nav || !navLinks) return;
+  if(nav.dataset.roleHidden === 'true'){
+    nav.classList.remove('hidden');
+  }
+  nav.style.removeProperty('display');
+  nav.removeAttribute('aria-hidden');
+  delete nav.dataset.roleHidden;
+  if(toggle){
+    if(toggle.dataset.roleHidden === 'true'){
+      toggle.classList.remove('hidden');
+    }
+    toggle.style.removeProperty('display');
+    toggle.removeAttribute('aria-hidden');
+    delete toggle.dataset.roleHidden;
+  }
   if(role === 'client'){
-    nav.style.display = 'none';
-    if(toggle) toggle.style.display = 'none';
+    if(!nav.classList.contains('hidden')){
+      nav.dataset.roleHidden = 'true';
+    }
+    nav.classList.add('hidden');
+    nav.setAttribute('aria-hidden','true');
+    if(toggle){
+      if(!toggle.classList.contains('hidden')){
+        toggle.dataset.roleHidden = 'true';
+      }
+      toggle.classList.add('hidden');
+      toggle.setAttribute('aria-hidden','true');
+    }
     return;
   }
   if(role === 'team'){

--- a/metro2 (copy 1)/crm/public/style.css
+++ b/metro2 (copy 1)/crm/public/style.css
@@ -358,8 +358,8 @@ header .group > div.absolute {
 }
 
 @media (min-width: 768px) {
-  #primaryNav {
-    display: flex !important;
+  #primaryNav:not(.hidden) {
+    display: flex;
   }
 
   .nav-shell {

--- a/metro2 (copy 1)/crm/tests/teamRole.test.js
+++ b/metro2 (copy 1)/crm/tests/teamRole.test.js
@@ -82,3 +82,39 @@ test('applyRoleNav removes disallowed nav items for team', () => {
   assert.deepEqual(items, ['/dashboard','/clients','/leads','/marketing','/schedule','/billing']);
   delete global.document;
 });
+
+test('applyRoleNav hides navigation for client role while preserving responsive state', () => {
+  const applyRoleNav = extractFunction('applyRoleNav');
+  const dom = new JSDOM(`<header>
+    <div class="nav-shell">
+      <div class="nav-brand-row">
+        <div class="text-xl font-semibold">Metro 2 CRM</div>
+        <button id="navToggle" class="btn"></button>
+      </div>
+      <nav id="primaryNav" class="flex">
+        <div id="primaryNavLinks"></div>
+      </nav>
+    </div>
+  </header>`);
+  global.document = dom.window.document;
+  const nav = dom.window.document.getElementById('primaryNav');
+  const toggle = dom.window.document.getElementById('navToggle');
+
+  applyRoleNav('client');
+  assert.equal(nav.classList.contains('hidden'), true);
+  assert.equal(nav.dataset.roleHidden, 'true');
+  assert.equal(nav.getAttribute('aria-hidden'), 'true');
+  assert.equal(toggle.classList.contains('hidden'), true);
+  assert.equal(toggle.dataset.roleHidden, 'true');
+  assert.equal(toggle.getAttribute('aria-hidden'), 'true');
+
+  applyRoleNav('host');
+  assert.equal(nav.classList.contains('hidden'), false);
+  assert.equal(nav.dataset.roleHidden, undefined);
+  assert.equal(nav.getAttribute('aria-hidden'), null);
+  assert.equal(toggle.classList.contains('hidden'), false);
+  assert.equal(toggle.dataset.roleHidden, undefined);
+  assert.equal(toggle.getAttribute('aria-hidden'), null);
+
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- reset role-driven nav state before applying client restrictions so hidden toggles persist alongside responsive logic
- update the desktop media query to only force flex display when the nav is not hidden
- add a regression test to confirm client users cannot see the host navigation

## Testing
- node --test tests/teamRole.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5bad4cd6083239e41560460eae155