### PR TITLE
Prevent role-hidden nav from reappearing on resize

### DIFF
--- a/metro2 (copy 1)/crm/public/common.js
+++ b/metro2 (copy 1)/crm/public/common.js
@@ -41,10 +41,32 @@ function initResponsiveNav() {
   };
 
   const updateLayout = () => {
+    const navRoleHidden = nav.dataset.roleHidden === 'true';
+    const toggleRoleHidden = toggle.dataset.roleHidden === 'true';
+
     if (window.innerWidth >= 768) {
-      nav.classList.remove('hidden');
-      toggle.setAttribute('aria-expanded', 'true');
+      if (!navRoleHidden) {
+        nav.classList.remove('hidden');
+        toggle.setAttribute('aria-expanded', 'true');
+      } else {
+        nav.classList.add('hidden');
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+
+      if (toggleRoleHidden) {
+        toggle.classList.add('hidden');
+      } else {
+        toggle.classList.remove('hidden');
+      }
     } else {
+      if (toggleRoleHidden) {
+        toggle.classList.add('hidden');
+      } else {
+        toggle.classList.remove('hidden');
+      }
+      if (navRoleHidden) {
+        nav.classList.add('hidden');
+      }
       const hidden = nav.classList.contains('hidden');
       toggle.setAttribute('aria-expanded', hidden ? 'false' : 'true');
     }


### PR DESCRIPTION
## Summary
- update the responsive nav resize handler to honor role-driven hidden states on both the nav and toggle
- extend the DOM test utilities to parse functions with spaced braces and cover the resize regression with a new test

## Testing
- `node --test tests/teamRole.test.js --test-name-pattern roleHidden`


------
https://chatgpt.com/codex/tasks/task_e_68e5bd5620248323ac9abb99ad838d38