### PR TITLE
Fix settings dropdown visibility on dashboard

### DIFF
--- a/metro2 (copy 1)/crm/public/index.html
+++ b/metro2 (copy 1)/crm/public/index.html
@@ -123,7 +123,7 @@
               <polyline points="6 9 12 15 18 9"></polyline>
             </svg>
           </button>
-          <div id="navSettings" class="nav-dropdown- glass card p-2">
+          <div id="navSettingsMenu" class="nav-dropdown-menu glass card p-2">
             <a id="navCompany" href="/my-company" class="btn text-sm">My Company</a>
             <a href="/letters" class="btn text-sm">Letter</a>
             <a href="/library" class="btn text-sm">Library</a>


### PR DESCRIPTION
## Summary
- fix the settings dropdown markup on the dashboard so it stays hidden until toggled
- align the dropdown menu id and class with the shared navigation script

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5d36c17f88323a9c863d0f5e4920b