### PR TITLE
Configure Replit workflows/deployment to run CRM backend from correct path

### DIFF
--- a/.replit
+++ b/.replit
@@ -10,28 +10,12 @@ runButton = "Project"
 
 [[workflows.workflow]]
 name = "Project"
-mode = "parallel"
+mode = "sequential"
 author = "agent"
-
-[[workflows.workflow.tasks]]
-task = "workflow.run"
-args = "Client Portal"
 
 [[workflows.workflow.tasks]]
 task = "workflow.run"
 args = "CRM Backend"
-
-[[workflows.workflow]]
-name = "Client Portal"
-author = "agent"
-
-[[workflows.workflow.tasks]]
-task = "shell.exec"
-args = "cd apps/client-portal && npm run dev"
-waitForPort = 5000
-
-[workflows.workflow.metadata]
-outputType = "webview"
 
 [[workflows.workflow]]
 name = "CRM Backend"
@@ -50,10 +34,10 @@ localPort = 3000
 externalPort = 3001
 
 [[ports]]
-localPort = 5000
+localPort = 3000
 externalPort = 80
 
 [deployment]
 deploymentTarget = "autoscale"
-run = ["npm start"]
-build = ["npm install && npm run build"]
+run = ["npm --prefix \"metro2 (copy 1)/crm\" start"]
+build = ["npm --prefix \"metro2 (copy 1)/crm\" install"]


### PR DESCRIPTION
### Motivation
- Replit was configured to run/build from the repository root and an unrelated `apps/client-portal` path that does not exist in this repository, which prevented successful startup and deployment.
- The CRM backend lives in `metro2 (copy 1)/crm` and must be the target for the run/build commands and the Project run button.
- The external port mapping should expose the CRM service on port `80` for web deployment routing on Replit.

### Description
- Simplified the `Project` workflow to run only the existing `CRM Backend` workflow and changed the workflow `mode` to `sequential` so the run button starts the CRM backend directly.
- Removed the stale `Client Portal` workflow and its reference to `apps/client-portal` since that app path is not present in this repo.
- Updated port configuration to map local `3000` to external `80` so the CRM HTTP server is reachable at the expected public port.
- Changed deployment commands to run/install from the CRM package directory using `npm --prefix "metro2 (copy 1)/crm" start` and `npm --prefix "metro2 (copy 1)/crm" install` so Replit installs deps and starts the correct service.

### Testing
- Ran `rg` to verify `.replit` contains the updated `deploymentTarget`, `run`, `build`, `Project` workflow and `externalPort` settings and the query returned the expected entries (success).
- Executed `npm --prefix "metro2 (copy 1)/crm" run` to confirm the CRM package defines the `start`/`dev` scripts and the command completed successfully.
- Inspected the patched `.replit` file contents (`nl -ba .replit`) to confirm the workflow and ports reflect the intended configuration (visual verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0987e9d08323b9a6c584ebcd9384)